### PR TITLE
Minor refactor

### DIFF
--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -3,8 +3,6 @@
 #include <torch/csrc/jit/codegen/cuda/ir_base_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/tensor.h>
 
-#include <sstream>
-
 namespace torch {
 namespace jit {
 namespace fuser {
@@ -27,11 +25,13 @@ TORCH_CUDA_API Val* newValLike(const Val* const val, DataType dtype) {
     default:
       break;
   }
-  std::stringstream err_msg;
-  err_msg << "Could not generate a new value of type "
-          << val->getValType().value() << " with data type "
-          << val->getDataType().value() << std::endl;
-  TORCH_CHECK(false, err_msg.str());
+
+  TORCH_CHECK(
+      false
+    , "Could not generate a new value of type "
+    , val->getValType().value()
+    , " with data type "
+    , val->getDataType().value());
 }
 
 TORCH_CUDA_API Val* newValLike(const Val* const val) {
@@ -62,10 +62,12 @@ TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1) {
     return v1;
 
   if (!is_cast_legal(v1->getDataType().value(), dtype)) {
-    std::stringstream err;
-    err << "Illegal Cast value from  DataType: " << v1->getDataType().value()
-        << " to DataType: " << dtype;
-    TORCH_CHECK(false, err.str());
+    TORCH_CHECK(
+      false
+    , "Illegal Cast value from  DataType: "
+    , v1->getDataType().value()
+    , " to DataType: "
+    , dtype);
   }
 
   Val* out = newValLike(v1, dtype);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -32,7 +32,6 @@ TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1);
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
 
 TORCH_CUDA_API Val* add(Val* v1, Val* v2);
-TORCH_CUDA_API Val* SomeCrazyName(Val* v1, Val* v2);
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2);
 TORCH_CUDA_API Val* mul(Val* v1, Val* v2);
 TORCH_CUDA_API Val* div(Val* v1, Val* v2);

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -124,9 +124,7 @@ bool Fusion::inFusion(const Statement* stmt) const {
 void Fusion::assertInFusion(const Statement* stmt, const std::string& msg) const {
   if (inFusion(stmt))
     return;
-  std::stringstream errmsg;
-  errmsg << msg << " it was not found in the active fusion.";
-  TORCH_CHECK(false, errmsg.str());
+  TORCH_CHECK(false, msg, " it was not found in the active fusion.");
 }
 
 std::vector<Expr*> Fusion::exprs(bool from_outputs_only, bool breadth_first) {
@@ -148,9 +146,7 @@ void Fusion::print() {
 StmtNameType Fusion::registerVal(Val* val) {
   if (val->fusion()) {
     if (val->fusion() != this) {
-      std::stringstream ss;
-      ss << val << " was not found in the active fusion.";
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, val, " was not found in the active fusion.");
     }
     if (inFusion(val)) {
       return val->name();
@@ -163,9 +159,7 @@ StmtNameType Fusion::registerVal(Val* val) {
 StmtNameType Fusion::registerExpr(Expr* expr) {
   if (expr->fusion()) {
     if (expr->fusion() != this) {
-      std::stringstream ss;
-      ss << expr << " was not found in the active fusion.";
-      TORCH_CHECK(false, ss.str());
+      TORCH_CHECK(false, expr, " was not found in the active fusion.");
     }
     if (inFusion(expr)) {
       return expr->name();

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -6,13 +6,7 @@
 #include <torch/csrc/jit/codegen/cuda/ir_base_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/iter_visitor.h>
 
-#include <algorithm>
-#include <deque>
-#include <iostream>
-#include <queue>
 #include <set>
-#include <sstream>
-#include <unordered_map>
 #include <vector>
 
 namespace torch {

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -128,9 +128,9 @@ void compileKernel(Fusion& fusion, CudaKernel& entry) {
     nvrtc().nvrtcGetProgramLogSize(program, &logsize);
     std::vector<char> log(logsize);
     nvrtc().nvrtcGetProgramLog(program, log.data());
-    std::stringstream cu;
-    cu << "NVRTC COMPILE ERROR: " << log.data();
-    throw std::runtime_error(cu.str());
+    TORCH_INTERNAL_ASSERT(false,
+      "NVRTC COMPILE ERROR: ", log.data()
+    );
   }
   const char* lowered_kernel_name;
   nvrtc().nvrtcGetLoweredName(program, func_name.c_str(), &lowered_kernel_name);

--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -73,7 +73,7 @@ public:
     runKernel(cuda_kernel_entry, inputs, outputs);
   }
 
-protected:
+private:
 
   std::mutex mutex_;
 
@@ -89,8 +89,6 @@ protected:
 
   std::unordered_map<std::string, int32_t> graph_cache_;
   std::unordered_map<int64_t, CudaKernel> kernel_cache_;
-
-private:
 
   int32_t next_unique_id_ = 0;
 };

--- a/torch/csrc/jit/codegen/cuda/transform_replay.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.cpp
@@ -2,8 +2,6 @@
 #include <torch/csrc/jit/codegen/cuda/iriostream.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 
-#include <sstream>
-
 namespace torch {
 namespace jit {
 namespace fuser {


### PR DESCRIPTION
CC @jjsjann123 moved members out of protected in the `CudaFusionManager` please double check it's fine. I also got rid of a `std::runtime_error` it's recommended to either use `TORCH_CHECK(false,...)` or `TORCH_INTERNAL_CHECK(false,...)`.

Also cc @kevinstephano in case either of you didn't know (I didn't) you can pass multiple args to the `_CHECK` macro's and they will append the string with `<<` automatically so you don't need to use `stringstream`.