### PR TITLE
[Integration code refactor]

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -578,6 +578,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/ir_iostream.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/iter_visitor.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/kernel.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/kernel_cache.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/manager.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/mutator.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/parser.cpp

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -552,7 +552,7 @@ void testGPU_FusionParser() {
   fuser::cuda::parseJitIR(g, fusion);
 
   std::stringstream ref;
-  ref << "__global__ void kernel(Tensor<float> T0, Tensor<float> T1, Tensor<float> T3){\n"
+  ref << "__global__ void kernel(Tensor<float, 3> T0, Tensor<float, 3> T1, Tensor<float, 3> T3){\n"
       << "  float T2[1];\n"
       << "  if( ( ( ( ( ( blockIdx.x * 128 ) + threadIdx.x ) / T1.size[2] ) / T1.size[1] ) < T1.size[0] ) && ( ( ( ( ( blockIdx.x * 128 ) + threadIdx.x ) / T1.size[2] ) % T1.size[1] ) < T1.size[1] ) && ( ( ( ( blockIdx.x * 128 ) + threadIdx.x ) % T1.size[2] ) < T1.size[2] ) ) {\n"
       << "    T2[0]\n"
@@ -675,7 +675,7 @@ void testGPU_FusionCodeGen() {
   tv0->computeAt(tv2, 1);
 
   std::stringstream ref;
-  ref << "__global__ void kernel(Tensor<float> T2){\n"
+  ref << "__global__ void kernel(Tensor<float, 4> T2){\n"
       << "  float T0[( ( ( 1 * ( ceilDiv(T2.size[0], 4) ) ) * T2.size[2] ) * T2.size[3] )];\n"
       << "  for( size_t i27 = 0; i27 < ( 4 * T2.size[1] ); ++i27 ) {\n"
       << "    for( size_t i29 = 0; i29 < ( ceilDiv(T2.size[0], 4) ); ++i29 ) {\n"
@@ -760,7 +760,7 @@ void testGPU_FusionCodeGen2() {
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
 
   std::stringstream ref;
-  ref << "__global__ void kernel(Tensor<float> T0, Tensor<float> T1, Tensor<float> T3){\n"
+  ref << "__global__ void kernel(Tensor<float, 3> T0, Tensor<float, 3> T1, Tensor<float, 3> T3){\n"
       << "  float T2[1];\n"
       << "  for( size_t i15 = 0; i15 < 4; ++i15 ) {\n"
       << "    for( size_t i17 = 0; i17 < T1.size[1]; ++i17 ) {\n"
@@ -805,7 +805,7 @@ void testGPU_FusionCodeGen2() {
   std::vector<at::Tensor> inputs{{input1, input2}};
   std::vector<at::Tensor> outputs{{output}};
 
-  torch::jit::fuser::cuda::compileKernel(fusion, prog);
+  torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(prog, inputs, outputs);
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -874,7 +874,7 @@ void testGPU_FusionSimplePWise() {
   std::vector<at::Tensor> inputs{{input1, input2}};
   std::vector<at::Tensor> outputs{{output}};
 
-  torch::jit::fuser::cuda::compileKernel(fusion, prog);
+  torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(prog, inputs, outputs);
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -926,7 +926,7 @@ void testGPU_FusionExecKernel() {
   std::vector<at::Tensor> inputs{{input1, input2}};
   std::vector<at::Tensor> outputs{{output}};
 
-  torch::jit::fuser::cuda::compileKernel(fusion, prog);
+  torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(prog, inputs, outputs);
 
   at::Tensor check = at::full({1, 128}, 4, options);

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -86,20 +86,57 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "Requires profiling node to run cuda fuser")
     @skipIfRocm
     def test_scalar_input(self):
-        def t(x, y, z):
-            # type: (Tensor, Tensor, float) -> Tensor
+        def t(x : torch.Tensor, y : torch.Tensor, z : float):
             o = x + y
             o = o + z
             return o
         t_jit = torch.jit.script(t)
-        x = torch.randn(4, 8, dtype=torch.float, device="cuda")
-        y = torch.randn(4, 8, dtype=torch.float, device="cuda")
+        x = torch.randn(4, 8, 32, 32, dtype=torch.float, device="cuda")
+        y = torch.randn(4, 8, 1, 32, dtype=torch.float, device="cuda")
+        y = y.expand(4, 8, 32, 32)
         jit_o = t_jit(x, y, 2.0)
         jit_o = t_jit(x, y, 2.0)
         o = t(x, y, 2.0)
         self.assertEqual(o, jit_o)
         self.assertTrue(self._has_cuda_fusion_group(t_jit.graph_for(x, y, 2.0)))
 
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "Requires profiling node to run cuda fuser")
+    @skipIfRocm
+    def test_broadcasting(self):
+        def t(x : torch.Tensor, y : torch.Tensor, z : float):
+            o = x + y
+            o = o + z
+            return o
+        t_jit = torch.jit.script(t)
+        x = torch.randn(4, 8, 32, 32, dtype=torch.float, device="cuda")
+        y = torch.randn(32, 32, dtype=torch.float, device="cuda")
+        jit_o = t_jit(x, y, 2.0)
+        jit_o = t_jit(x, y, 2.0)
+        o = t(x, y, 2.0)
+        self.assertEqual(o, jit_o)
+        self.assertTrue(self._has_cuda_fusion_group(t_jit.graph_for(x, y, 2.0)))
+
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "Requires profiling node to run cuda fuser")
+    @skipIfRocm
+    def test_broadcasting_multiple_output_shape(self):
+        def t(x : torch.Tensor, y : torch.Tensor, z : torch.Tensor):
+            o = x + 12
+            o1 = o + y
+            o2 = o + z
+            oo = o1.sum() + o2.sum()
+            return oo
+        t_jit = torch.jit.script(t)
+        x = torch.randn(32, 32, dtype=torch.float, device="cuda")
+        y = torch.randn(2, 32, 32, dtype=torch.float, device="cuda")
+        z = torch.randn(4, 32, 32, dtype=torch.float, device="cuda")
+        jit_o = t_jit(x, y, z)
+        jit_o = t_jit(x, y, z)
+        o = t(x, y, z)
+        self.assertEqual(o, jit_o)
+        #can't fuse it now
+        self.assertFalse(self._has_cuda_fusion_group(t_jit.graph_for(x, y, z)))
 
 if __name__ == '__main__':
     run_tests()

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -239,6 +239,7 @@ libtorch_cuda_sources = [
     "torch/csrc/jit/codegen/cuda/ir_iostream.cpp",
     "torch/csrc/jit/codegen/cuda/iter_visitor.cpp",
     "torch/csrc/jit/codegen/cuda/kernel.cpp",
+    "torch/csrc/jit/codegen/cuda/kernel_cache.cpp",
     "torch/csrc/jit/codegen/cuda/manager.cpp",
     "torch/csrc/jit/codegen/cuda/mutator.cpp",
     "torch/csrc/jit/codegen/cuda/parser.cpp",

--- a/torch/csrc/jit/codegen/cuda/code_write.cpp
+++ b/torch/csrc/jit/codegen/cuda/code_write.cpp
@@ -427,19 +427,23 @@ void CodeWrite::header() {
   for (Val* val : vals) {
     switch (val->getValType().value()) {
       case (ValType::TensorView):
+        {
         switch (val->getDataType().value()) {
           case (DataType::Float):
-            os << "Tensor<float> T";
+            os << "Tensor<float, ";
             break;
           case (DataType::Int):
-            os << "Tensor<int> T";
+            os << "Tensor<int, ";
             break;
           default:
             TORCH_CHECK(
                 false,
                 "CodeWrite::header() found an input to the fusion of unexpected val type.");
         }
+
+        os << static_cast<const TensorView*>(val)->getRootDomain()->size() << "> T";
         break;
+        }
       case (ValType::Scalar):
         switch (val->getDataType().value()) {
           case (DataType::Float):

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -5,6 +5,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/ArrayRef.h>
 #include <torch/csrc/jit/resource_guard.h>
 
 namespace torch {
@@ -25,58 +26,135 @@ static int ceilDiv(const int a, const int b) {
   return (a + b - 1) / b;
 }
 
+// IO data structure for kernel code;
+static auto typeinfo = R"(
+template<typename T, int N>
+struct Tensor {
+  T& operator[](int ind) {
+    return data[ind];
+  };
+
+  T* data;
+  int size[N];
+  int stride[N];
+};
+)";
+
+// include IO data structure for host code
+struct KernelArgumentHolder {
+  std::vector<void*> arguments;
+  std::vector<char> buffer;
+  void* buffer_ptr;
+
+  KernelArgumentHolder(size_t n_inputs, size_t n_dimension_per_tensor) {
+    arguments.reserve(n_inputs);
+    // We are being generous here on the allocated buffer;
+    buffer.resize(
+        n_inputs * (sizeof(void*) + 2 * sizeof(int) * n_dimension_per_tensor));
+    buffer_ptr = buffer.data();
+  }
+
+  void** args() {
+    return arguments.data();
+  }
+
+  // this should comply to the storage of Tensor object defined in typeinfo;
+  void push_tensor(
+      const at::Tensor& val,
+      c10::optional<at::IntArrayRef> broadcasted_size = c10::nullopt) {
+    arguments.push_back(buffer_ptr);
+
+    // passing address, type doesn't really matter here;
+    auto data_ptr = static_cast<void**>(buffer_ptr);
+    *data_ptr = val.data_ptr();
+    buffer_ptr += sizeof(char*);
+
+    if (broadcasted_size) {
+      auto b_dim = broadcasted_size->size();
+      auto o_dim = val.dim();
+      TORCH_CHECK(b_dim >= o_dim);
+      int* sizes = reinterpret_cast<int*>(buffer_ptr);
+      int* strides = &sizes[b_dim];
+      for (int i = 0; i < b_dim; i++) {
+        sizes[i] = broadcasted_size->at(i);
+        int index = i + o_dim - b_dim;
+        if (index < 0) {
+          strides[i] = 0;
+        } else if (val.sizes()[index] == sizes[i]) {
+          strides[i] = val.strides()[index];
+        } else {
+          TORCH_CHECK(
+              val.sizes()[index] == 1,
+              "Not compatible dimension size for broadcast");
+          strides[i] = 0;
+        }
+      }
+      buffer_ptr = &strides[b_dim];
+    } else {
+      auto o_dim = val.dim();
+      int* sizes = reinterpret_cast<int*>(buffer_ptr);
+      int* strides = &sizes[o_dim];
+      for (decltype(val.dim()) i{0}; i < o_dim; i++) {
+        sizes[i] = val.sizes()[i];
+        strides[i] = val.strides()[i];
+      }
+      buffer_ptr = &strides[o_dim];
+    }
+  }
+
+  template<typename T>
+  void push_scalar(T scalar) {
+    // TODO: we should probably worry about alignment here;
+    T* ptr = reinterpret_cast<T*>(buffer_ptr);
+    *ptr = scalar;
+    arguments.push_back(buffer_ptr);
+    buffer_ptr += sizeof(T);
+  }
+};
+
 std::pair<std::string, std::string> codeGeneration(Fusion& fusion) {
   std::stringstream str_stream;
 
   str_stream << "namespace " << CG_NAMESPACE << " {\n" << typeinfo << "\n";
+
   CodeWrite cw(str_stream, KERNEL_NAME);
   cw.traverse(&fusion);
   str_stream << "\n}";
 
   std::string func_name = std::string(CG_NAMESPACE) + "::" + KERNEL_NAME;
-
   return std::make_pair(func_name, str_stream.str());
 };
 
 void prepare_argument(
-    std::vector<void*>& arguments,
-    std::vector<Tensor<float>>& tensor_args,
-    const at::Tensor& val) {
-  tensor_args.emplace_back();
-  Tensor<float>& t = tensor_args.back();
-  // passing address, type doesn't really matter here;
-  t.data = static_cast<float*>(val.data_ptr());
-
-  for (decltype(val.dim()) i{0}; i < val.dim(); i++) {
-    t.size[i] = val.sizes()[i];
-    t.stride[i] = val.strides()[i];
-  }
-
-  arguments.push_back(&(tensor_args.back()));
-};
-
-void prepare_argument(
-    std::vector<void*>& arguments,
-    std::vector<Tensor<float>>& tensor_args,
-    std::vector<int>& int_args,
-    std::vector<float>& float_args,
-    const IValue& val) {
+    KernelArgumentHolder& argument_holder,
+    const IValue& val,
+    c10::optional<at::IntArrayRef> broadcasted_size = c10::nullopt) {
   if (val.isTensor()) {
-    prepare_argument(arguments, tensor_args, val.toTensor());
+    argument_holder.push_tensor(val.toTensor(), broadcasted_size);
   } else if (val.isDouble()) {
-    float_args.push_back(val.to<float>());
-    arguments.push_back(&(float_args.back()));
+    argument_holder.push_scalar(val.to<float>());
   } else if (val.isInt()) {
-    int_args.push_back(val.to<int>());
-    arguments.push_back(&(int_args.back()));
+    argument_holder.push_scalar(val.to<int>());
   } else {
     TORCH_CHECK(false, "Not supported input IValue encounted.");
   }
-};
+}
 
 } // namespace
 
-void compileKernel(Fusion& fusion, CudaKernel& entry) {
+bool KernelArgsReq::matchKernelSize(const at::IntArrayRef inputs) {
+  if (inputs.size() != low_.size()) {
+    return false;
+  }
+  for (int i = 0; i < inputs.size(); i++) {
+    if (inputs[i] < low_[i] || inputs[i] > hi_[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void compileKernel(Fusion& fusion, CudaKernel* entry) {
   // generating cuda code;
   std::string code;
   std::string func_name;
@@ -95,7 +173,7 @@ void compileKernel(Fusion& fusion, CudaKernel& entry) {
 
   // set device for the operation;
   const auto prior_device = at::cuda::current_device();
-  at::cuda::set_device(entry.device_);
+  at::cuda::set_device(entry->device_);
 
   const auto prop = at::cuda::getCurrentDeviceProperties();
   int nvrtc_major, nvrtc_minor;
@@ -140,55 +218,52 @@ void compileKernel(Fusion& fusion, CudaKernel& entry) {
   ptx.resize(ptx_size);
   AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetPTX(program, ptx.data()));
 
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoadData(&(entry.module_), ptx.data()));
+  AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoadData(&(entry->module_), ptx.data()));
   AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleGetFunction(
-      &(entry.function_), entry.module_, lowered_kernel_name));
+      &(entry->function_), entry->module_, lowered_kernel_name));
   AT_CUDA_DRIVER_CHECK(nvrtc().cuOccupancyMaxActiveBlocksPerMultiprocessor(
-      &entry.max_blocks_, entry.function_, 128, 0));
-  entry.max_blocks_ *= prop->multiProcessorCount;
+      &entry->max_blocks_, entry->function_, 128, 0));
+  entry->max_blocks_ *= prop->multiProcessorCount;
 }
 
 void runKernel(
-    CudaKernel& entry,
+    CudaKernel* entry,
     const at::ArrayRef<IValue>& inputs,
     std::vector<at::Tensor>& outputs) {
   const auto prior_device = at::cuda::current_device();
-  at::cuda::set_device(entry.device_);
+  at::cuda::set_device(entry->device_);
   auto stream = at::cuda::getCurrentCUDAStream();
 
   // TODO: Proper API to establish reasonable launch configurations;
   // Naive launch config;
   size_t numel = outputs[0].numel();
-  const auto nBlocks = std::min(entry.max_blocks_, ceilDiv(numel, 128));
+
+  // TODO: we can't randomly clap down this until we got striding.
+  //const auto nBlocks = std::min(entry->max_blocks_, ceilDiv(numel, 128));
+  const auto nBlocks = ceilDiv(numel, 128);
 
   // TODO: Proper API to tranform JIT I/O Tensor to CodeGen I/O Tensor
-  std::vector<void*> arguments;
-
-  // TODO: There are better ways to do this;
-  // argument holder;
-  // host code, `T` in `Tensor<T>` doesn't really matter, as we only interact
-  // with the address; Just put a float here to simply the argument holder.
   auto max_capacity = inputs.size() + outputs.size();
-  std::vector<Tensor<float>> tensor_args;
-  std::vector<int> int_args;
-  std::vector<float> float_args;
-  tensor_args.reserve(max_capacity);
-  int_args.reserve(max_capacity);
-  float_args.reserve(max_capacity);
+  KernelArgumentHolder kernel_arg_holder(max_capacity, outputs[0].dim());
 
   // Naive I/O setup, I'm ignoring all the potential transformation (i.e. I/O
   // allocated here from the subgraph could be, and very likely are, different
   // from I/O expected by the generated CUDA kernel.
+  printf("prepare input\n");
   for (auto& input : inputs) {
-    prepare_argument(arguments, tensor_args, int_args, float_args, input);
+    printf(" get input\n");
+    prepare_argument(kernel_arg_holder, input, outputs[0].sizes());
   }
+  printf("prepare output\n");
   for (auto& output : outputs) {
-    prepare_argument(arguments, tensor_args, output);
+    printf(" get output\n");
+    prepare_argument(kernel_arg_holder, output);
   }
 
+  printf("launching\n");
   // launch kernel;
   AT_CUDA_DRIVER_CHECK(nvrtc().cuLaunchKernel(
-      entry.function_,
+      entry->function_,
       nBlocks,
       1,
       1,
@@ -197,17 +272,12 @@ void runKernel(
       1,
       0,
       stream,
-      arguments.data(),
+      kernel_arg_holder.args(),
       nullptr));
 
   // Resets device (see at::DeviceGuard notes above)
   at::cuda::set_device(prior_device);
 
-  /*
-    for (auto& output : outputs) {
-      output.fill_(0.24);
-    }
-   */
 }
 
 // WARNING:
@@ -228,21 +298,16 @@ void runTestKernel(
   // host code, `T` in `Tensor<T>` doesn't really matter, as we only interact
   // with the address; Just put a float here to simply the argument holder.
   auto max_capacity = inputs.size() + outputs.size();
-  std::vector<Tensor<float>> tensor_args;
-  std::vector<int> int_args;
-  std::vector<float> float_args;
-  tensor_args.reserve(max_capacity);
-  int_args.reserve(max_capacity);
-  float_args.reserve(max_capacity);
+  KernelArgumentHolder kernel_arg_holder(max_capacity, outputs[0].dim());
 
   // Naive I/O setup, I'm ignoring all the potential transformation (i.e. I/O
   // allocated here from the subgraph could be, and very likely are, different
   // from I/O expected by the generated CUDA kernel.
   for (auto& input : inputs) {
-    prepare_argument(arguments, tensor_args, input);
+    prepare_argument(kernel_arg_holder, input);
   }
   for (auto& output : outputs) {
-    prepare_argument(arguments, tensor_args, output);
+    prepare_argument(kernel_arg_holder, output);
   }
 
   // launch kernel;
@@ -256,7 +321,7 @@ void runTestKernel(
       entry.block_.z,
       0,
       stream,
-      arguments.data(),
+      kernel_arg_holder.args(),
       nullptr));
 
   // Resets device (see at::DeviceGuard notes above)

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -1,0 +1,29 @@
+#include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
+
+/*
+ */
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+at::optional<CudaKernel*> CudaKernelCache::getKernelPtr(c10::IntArrayRef sizes) {
+  for (auto& iter : kernels_) {
+    if (iter.first.matchKernelSize(sizes)) {
+      return &(iter.second);
+    }
+  }
+  return at::nullopt;
+}
+
+CudaKernel* CudaKernelCache::allocateKernelInCache(
+    KernelArgsReq args_req) {
+  kernels_.emplace_back(std::make_pair(std::move(args_req), CudaKernel()));
+  return &(kernels_.back().second);
+}
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <c10/util/ArrayRef.h>
+
+#include <torch/csrc/jit/codegen/cuda/kernel.h>
+
+/*
+ */
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+class CudaKernelCache {
+ public:
+  CudaKernelCache() = default;
+
+  at::optional<CudaKernel*> getKernelPtr(c10::IntArrayRef sizes);
+  CudaKernel* allocateKernelInCache(KernelArgsReq args_req);
+
+ //private:
+  // TODO: In theory we should assume contiguity remain constant across runs
+  //       (job for BailOut node from profiling executor). In reality we might
+  //       want to be safe and cache on that as well.
+  // Assuming constant nDims. Cache of kernels targetting different tensor size;
+  // We should flatten
+  std::vector<std::pair<KernelArgsReq, CudaKernel>> kernels_;
+};
+
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -1,11 +1,11 @@
 #include <torch/csrc/jit/codegen/cuda/manager.h>
-#include <torch/csrc/jit/codegen/cuda/kernel.h>
 #include <torch/csrc/jit/codegen/cuda/parser.h>
-
+#include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/tensor.h>
 #include <torch/csrc/jit/codegen/cuda/utils.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
+#include <torch/csrc/jit/passes/shape_analysis.h>
 
 #include <unordered_map>
 
@@ -15,6 +15,15 @@ namespace fuser {
 namespace cuda {
 
 namespace {
+
+KernelArgsReq expandSizeSupport(const at::IntArrayRef sizes) {
+  KernelArgsReq req;
+  for (auto size : sizes) {
+    req.low_.push_back(size);
+    req.hi_.push_back(size);
+  }
+  return req;
+}
 
 // CudaFusionManager holds compiled `CudaKernel` and handles all interfacing
 // including compilation and execution.
@@ -38,9 +47,12 @@ class CudaFusionManager {
   //       is even more restricting in a good way)
   int32_t registerOrGetCacheId(std::shared_ptr<Graph>& graph) {
     std::lock_guard<std::mutex> guard(mutex_);
+
     // prepare graph for lowering;
+    // TODO: this is needed. Otherwise caching on tensor size would not work, as
+    //       different tensor size would result in unique string representation.
+    EraseShapeInformation(graph);
     Canonicalize(graph, false);
-    // EraseShapeInformation(graph);
     auto repr = graph->toString(false);
 
     // create new graph_cache_ entry;
@@ -49,29 +61,52 @@ class CudaFusionManager {
 
       graph_cache_[repr] = kernel_id;
 
-      Fusion fusion;
-      // lower torch::jit::Graph to torch::jit::fuser::cuda::fusion
-      parseJitIR(graph, fusion);
+      // create entry for cached kernel;
+      kernel_cache_.insert({kernel_id, CudaKernelCache()});
 
-      // default constructor via accessing empty key;
-      compileKernel(fusion, kernel_cache_[kernel_id]);
-
-      return kernel_id;
-    } else {
-      return graph_cache_[repr];
+      // TODO: we should compile here using profiled information:
+      //       size (range) / stride (contiguity)
     }
+
+    return graph_cache_[repr];
   };
 
   void runFusionNode(
       int32_t kernel_id,
+      std::shared_ptr<Graph>& graph,
       const at::ArrayRef<IValue> inputs,
       std::vector<at::Tensor> outputs) {
-    TORCH_CHECK(
-        kernel_cache_.count(kernel_id) != 0, "kernel id not recognized");
+    std::lock_guard<std::mutex> guard(mutex_);
+    TORCH_CHECK(kernel_cache_.count(kernel_id) != 0, "kernel id not recognized");
 
-    CudaKernel& cuda_kernel_entry = kernel_cache_[kernel_id];
+    // TODO: temporary hack
+    auto cuda_kernel = kernel_cache_[kernel_id].getKernelPtr(outputs[0].sizes());
+    if (cuda_kernel) {
+      // TODO: update launch config for specific sizes;
+      //       maybe we should store it in CudaKernel and compute it later
+      runKernel(*cuda_kernel, inputs, outputs);
+    } else {
 
-    runKernel(cuda_kernel_entry, inputs, outputs);
+      // major HACK!
+      auto kernel_arg_req = expandSizeSupport(outputs[0].sizes());
+      cuda_kernel =
+          kernel_cache_[kernel_id].allocateKernelInCache(kernel_arg_req);
+
+      // lower torch::jit::Graph to torch::jit::fuser::cuda::fusion
+      Fusion fusion;
+      // TODO: pass contiguity infor as well as size req, so we can apply proper
+      //       transform to computation
+      // we should propagate more information back:
+      //   1. device;
+      //   2. launch config;
+      parseJitIR(graph, fusion);
+      cuda_kernel.value()->device_ = 0;
+
+      // NVRTC compile kernel
+      compileKernel(fusion, cuda_kernel.value());
+
+      runKernel(*cuda_kernel, inputs, outputs);
+    }
   }
 
  private:
@@ -87,7 +122,7 @@ class CudaFusionManager {
   };
 
   std::unordered_map<std::string, int32_t> graph_cache_;
-  std::unordered_map<int64_t, CudaKernel> kernel_cache_;
+  std::unordered_map<int64_t, CudaKernelCache> kernel_cache_;
 
   int32_t next_unique_id_ = 0;
 };
@@ -119,9 +154,47 @@ void runCudaFusionGroup(const Node* const fusion_node, Stack& stack) {
   int32_t kernel_id = fusion_node->i(attr::cache_id);
 
   // Currently we just construct I/O tensors for static graph;
-  const std::shared_ptr<Graph> graph = fusion_node->g(attr::Subgraph);
+  std::shared_ptr<Graph> graph = fusion_node->g(attr::Subgraph);
+
   const auto nInputs = graph->inputs().size();
   at::ArrayRef<IValue> inputs = last(stack, nInputs);
+
+  // shape inference in graph
+  bool matched_static_inputs = true;
+  for (int i = 0; i < nInputs; i++) {
+    auto& static_input = graph->inputs()[i];
+    auto& dynamic_input = inputs[i]; // this is FILO stack
+    if ((*dynamic_input.type()) != (*static_input->type())) {
+      matched_static_inputs  = false;
+      break;
+    }
+    if (dynamic_input.isTensor()) {
+      at::Tensor inp_tensor = dynamic_input.toTensor();
+      // we need to return use shape inference when static shape is not complete
+      // even though it is compatible with profiling graph.
+      // TODO: we could relax on a bunch of checks here, like strides & gradient
+      if (!static_input->type()->cast<TensorType>()->sizes().isComplete() ||
+          !static_input->type()->cast<TensorType>()
+          ->isCompatibleWithInCurrentExecutionContext(inp_tensor)) {
+        matched_static_inputs  = false;
+        break;
+      }
+    }
+  }
+  
+  // TODO: expose the API to populate shape inference. This allows separate CI
+  // tests
+  // matched_static_inputs = false;
+  if (!matched_static_inputs) {
+    // update shape information per the new inputs;
+    // shape inference done through PyTorch JIT shape propagation;
+    EraseShapeInformation(graph);
+    for (int i = 0; i < nInputs; i++) {
+      graph->inputs()[i]->setType(inputs[i].type());
+    }
+    // shape inference
+    PropagateInputShapes(graph);
+  }
 
   // we need to construct outputs;
   std::vector<at::Tensor> outputs;
@@ -149,7 +222,7 @@ void runCudaFusionGroup(const Node* const fusion_node, Stack& stack) {
     outputs.push_back(tensor);
   }
 
-  CudaFusionManager::getManager().runFusionNode(kernel_id, inputs, outputs);
+  CudaFusionManager::getManager().runFusionNode(kernel_id, graph, inputs, outputs);
 
   drop(stack, inputs.size());
   stack.insert(

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -40,11 +40,18 @@ class IrParser {
     FusionGuard fg(fusion_);
     auto block = graph_->block();
 
+    // in case of broadcast, we don't support explicit broadcast, so we need to
+    // convert/expand all inputs tensors to comply to the broadcasted size.
+    // This supports very limited case, which we try to accomodate in graph
+    // partition, that we only merge nodes with identical output shapes.
+    int broadcast_dim =
+        block->outputs()[0]->type()->cast<TensorType>()->dim().value();
+
     // register all inputs;
     // shape propagation during parsing is effctively done in parsing rules, as
     // we only explicitly register inputs in the graph.
     for (auto val : block->inputs()) {
-      TORCH_CHECK(registerValue(val));
+      TORCH_CHECK(registerValue(val, broadcast_dim));
       fusion_->addInput(value_maps_[val->unique()]);
     }
 
@@ -193,8 +200,8 @@ class IrParser {
     }
   }
 
-  bool registerValue(const JitValue* val) {
-    return registerTensor(val) || registerScalar(val);
+  bool registerValue(const JitValue* val, int broadcast_dim=-1) {
+    return registerTensor(val, broadcast_dim) || registerScalar(val);
   }
 
   bool registerScalar(const JitValue* val) {
@@ -221,12 +228,16 @@ class IrParser {
     return false;
   }
 
-  bool registerTensor(const JitValue* val) {
+  bool registerTensor(const JitValue* val, int broadcast_dim=-1) {
     CgValue* cg_val;
     if (val->isCompleteTensor()) {
+      auto tensor_type = val->type()->cast<TensorType>();
+      if (broadcast_dim >= 0) {
+        tensor_type = tensor_type->withDim(broadcast_dim);
+      }
       // TODO: make this a static function in Tensor class;
       // create tensor;
-      cg_val = new TensorView(val->type()->cast<TensorType>());
+      cg_val = new TensorView(tensor_type);
       value_maps_.emplace(val->unique(), cg_val);
       return true;
     }

--- a/torch/csrc/jit/codegen/cuda/partition.cpp
+++ b/torch/csrc/jit/codegen/cuda/partition.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/codegen/cuda/partition.h>
 #include <torch/csrc/jit/codegen/cuda/parser.h>
+#include <ATen/core/jit_type.h>
 
 namespace torch {
 namespace jit {
@@ -54,6 +55,24 @@ inline bool isFusableNode(const Node* const node) {
   return (isNodeParsible(node) || node->kind() == prim::CudaFusionGroup);
 }
 
+// TODO: how would symbolic shape from profiling executor play with this?
+static bool compatible_broadcast_shape(
+    const c10::VaryingShape& e,
+    const c10::VaryingShape& a) {
+  if (e.isComplete() &&
+      a.isComplete()) {
+    auto e_size = e.concrete_sizes().value();
+    auto a_size = a.concrete_sizes().value();
+    for (size_t i = 0; i < e_size.size(); i++) {
+      if (e_size[i] != a_size[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 } // namespace
 
 bool isFusableCudaFusionGroup(const Node* const node) {
@@ -69,7 +88,29 @@ bool isFusableCudaFusionGroup(
   if (isFusableNode(node)) {
     auto device = getDevice(fusion);
 
-    return (device.has_value() && isFusableDevice(node, device.value()));
+    auto tensor_type = fusion->outputs()[0]->type()->cast<TensorType>();
+    if (tensor_type) {
+      for (auto output : node->outputs()) {
+        // We only check shape of tensor output
+        auto output_type = output->type()->cast<TensorType>();
+        if (output_type) {
+          bool output_tensor = false;
+          for (auto use : output->uses()) {
+            if (use.user != fusion) {
+              output_tensor = true;
+              break;
+            }
+          }
+          // if the output is not used by outside, there's no need to check its
+          // shape
+          if (output_tensor &&
+              !compatible_broadcast_shape(tensor_type->sizes() , output_type->sizes())) {
+            return false;
+          }
+        }
+      }
+      return (device.has_value() && isFusableDevice(node, device.value()));
+    }
   }
   return false;
 }


### PR DESCRIPTION
1. restrict partition to ensure all outputs have identical shape. [WAR for not
supporting explicit broadcast];

2. refactored IO Tensor to make more efficient use of CUDA function arguments;

3. updated kernel cache to store multiple kernels to support different dynamic
input tensor size;

