### PR TITLE
Return TensorView* from arithmetic operations when possible

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1732,7 +1732,7 @@ void testGPU_FusionBinaryOps() {
         return at::add(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toScalar());
       },
-      /*JIT  Func   */ add_alpha,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&add_alpha),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1797,7 +1797,10 @@ void testGPU_FusionTernaryOps() {
         return at::where(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toTensor());
       },
-      /*JIT  Func   */ where,
+      /*JIT  Func   */
+      [](Val* c, Val* v1, Val* v2) -> Val* {
+        return where(c, v1, v2);
+      },
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -671,8 +671,8 @@ void testGPU_FusionCodeGen() {
   TensorView* tv0 = makeDummyTensor(3);
 
   new BinaryOp(BinaryOpType::Add, tv0, new Float(0.0), new Float(1.0));
-  TensorView* tv1 = static_cast<TensorView*>(add(tv0, new Float(2.0)));
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(3.0)));
+  TensorView* tv1 = add(tv0, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Float(3.0));
   fusion.addOutput(tv2);
 
   //[I0, I1, I2]
@@ -713,8 +713,8 @@ void testGPU_FusionCodeGen2() {
 
   TensorView* tv0 = makeDummyTensor(3);
   TensorView* tv1 = makeDummyTensor(3);
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -769,10 +769,9 @@ void testGPU_FusionSimplePWise() {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  // Do math with it, it returns a `Val*` but can be static_casted back to
-  // TensorView
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  // Do math with it, it returns a `TensorView*`
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
   fusion.addOutput(tv3);
@@ -828,10 +827,9 @@ void testGPU_FusionExecKernel() {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  // Do math with it, it returns a `Val*` but can be static_casted back to
-  // TensorView
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  // Do math with it, it returns a `TensorView*`
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
   fusion.addOutput(tv3);
@@ -894,12 +892,12 @@ void testGPU_FusionAdvancedComputeAt() {
     fusion.addInput(tv0);
 
     TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
-    TensorView* tv2 = static_cast<TensorView*>(add(tv0, new Float(3.0)));
+    TensorView* tv2 = add(tv0, new Float(3.0));
     TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.0)));
-    TensorView* tv4 = static_cast<TensorView*>(add(tv2, tv1));
+    TensorView* tv4 = add(tv2, tv1);
 
-    TensorView* tv5 = static_cast<TensorView*>(add(tv4, tv3));
-    TensorView* tv6 = static_cast<TensorView*>(add(tv0, tv3));
+    TensorView* tv5 = add(tv4, tv3);
+    TensorView* tv6 = add(tv0, tv3);
 
     fusion.addOutput(tv5);
     fusion.addOutput(tv6);
@@ -987,12 +985,12 @@ void testGPU_FusionAdvancedComputeAt() {
     fusion.addInput(tv0);
 
     TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
-    TensorView* tv2 = static_cast<TensorView*>(add(tv0, new Float(3.0)));
+    TensorView* tv2 = add(tv0, new Float(3.0));
     TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.0)));
-    TensorView* tv4 = static_cast<TensorView*>(add(tv2, tv1));
+    TensorView* tv4 = add(tv2, tv1);
 
-    TensorView* tv5 = static_cast<TensorView*>(add(tv4, tv3));
-    TensorView* tv6 = static_cast<TensorView*>(add(tv5, tv3));
+    TensorView* tv5 = add(tv4, tv3);
+    TensorView* tv6 = add(tv5, tv3);
 
     fusion.addOutput(tv5);
     fusion.addOutput(tv6);
@@ -1144,7 +1142,7 @@ void testGPU_FusionAdvancedComputeAt() {
     fusion.addInput(tv3);
 
     TensorView* tv4 = static_cast<TensorView*>(sub(tv2, tv3));
-    TensorView* tv5 = static_cast<TensorView*>(add(tv1, tv4));
+    TensorView* tv5 = add(tv1, tv4);
     TensorView* tv6 = static_cast<TensorView*>(sub(tv5, tv0));
 
     fusion.addOutput(tv6);
@@ -1225,7 +1223,7 @@ void testGPU_FusionScalarInputs() {
   Val* f5 = sub(f2, f3);
 
   TensorView* tv2 = static_cast<TensorView*>(sub(tv1, f4));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, f5));
+  TensorView* tv3 = add(tv0, f5);
   TensorView* tv4 = static_cast<TensorView*>(mul(tv3, tv2));
 
   fusion.addOutput(tv4);
@@ -1315,10 +1313,9 @@ void testGPU_FusionLoopUnroll() {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  // Do math with it, it returns a `Val*` but can be static_casted back to
-  // TensorView
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  // Do math with it, it returns a `TensorView*`
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
   fusion.addOutput(tv3);
@@ -1378,7 +1375,7 @@ void testGPU_FusionForLoop() {
 
   auto ID0 = new IterDomain(new Int(0), new Int(8));
 
-  TensorView* TV2 = static_cast<TensorView*>(add(TV0, TV1));
+  TensorView* TV2 = add(TV0, TV1);
   BinaryOp* op = static_cast<BinaryOp*>(TV2->getOrigin());
   fusion.addOutput(TV2);
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -891,9 +891,9 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv0 = makeDummyTensor(2);
     fusion.addInput(tv0);
 
-    TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
+    TensorView* tv1 = mul(tv0, new Float(-1.0));
     TensorView* tv2 = add(tv0, new Float(3.0));
-    TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.0)));
+    TensorView* tv3 = mul(tv0, new Float(2.0));
     TensorView* tv4 = add(tv2, tv1);
 
     TensorView* tv5 = add(tv4, tv3);
@@ -984,9 +984,9 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv0 = makeDummyTensor(2);
     fusion.addInput(tv0);
 
-    TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
+    TensorView* tv1 = mul(tv0, new Float(-1.0));
     TensorView* tv2 = add(tv0, new Float(3.0));
-    TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.0)));
+    TensorView* tv3 = mul(tv0, new Float(2.0));
     TensorView* tv4 = add(tv2, tv1);
 
     TensorView* tv5 = add(tv4, tv3);
@@ -1068,8 +1068,8 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv1 = makeDummyTensor(4);
     fusion.addInput(tv1);
 
-    TensorView* tv2 = static_cast<TensorView*>(mul(tv1, new Float(.979361)));
-    TensorView* tv3 = static_cast<TensorView*>(mul(tv2, tv0));
+    TensorView* tv2 = mul(tv1, new Float(.979361));
+    TensorView* tv3 = mul(tv2, tv0);
 
     fusion.addOutput(tv3);
 
@@ -1141,9 +1141,9 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv3 = makeDummyTensor(4);
     fusion.addInput(tv3);
 
-    TensorView* tv4 = static_cast<TensorView*>(sub(tv2, tv3));
+    TensorView* tv4 = sub(tv2, tv3);
     TensorView* tv5 = add(tv1, tv4);
-    TensorView* tv6 = static_cast<TensorView*>(sub(tv5, tv0));
+    TensorView* tv6 = sub(tv5, tv0);
 
     fusion.addOutput(tv6);
 
@@ -1222,9 +1222,9 @@ void testGPU_FusionScalarInputs() {
   Val* f4 = mul(f0, f1);
   Val* f5 = sub(f2, f3);
 
-  TensorView* tv2 = static_cast<TensorView*>(sub(tv1, f4));
+  TensorView* tv2 = sub(tv1, f4);
   TensorView* tv3 = add(tv0, f5);
-  TensorView* tv4 = static_cast<TensorView*>(mul(tv3, tv2));
+  TensorView* tv4 = mul(tv3, tv2);
 
   fusion.addOutput(tv4);
 
@@ -1748,7 +1748,7 @@ void testGPU_FusionBinaryOps() {
         return at::sub(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toScalar());
       },
-      /*JIT  Func   */ sub_alpha,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&sub_alpha),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -1817,7 +1817,7 @@ void testGPU_FusionCompoundOps() {
         return at::lerp(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toTensor());
       },
-      /*JIT  Func   */ lerp,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&lerp),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -1836,7 +1836,7 @@ void testGPU_FusionCompoundOps() {
             vals[2].toTensor(),
             vals[3].toScalar());
       },
-      /*JIT  Func   */ addcmul,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*, Val*)>(&addcmul),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -1852,8 +1852,8 @@ void testGPU_FusionCastOps() {
 
   TensorView* tv0 = makeDummyTensor(2, DataType::Half);
 
-  Val* intrm1 = castOp(DataType::Float, tv0);
-  TensorView* out = static_cast<TensorView*>(castOp(DataType::Half, intrm1));
+  TensorView* intrm1 = castOp(DataType::Float, tv0);
+  TensorView* out = castOp(DataType::Half, intrm1);
 
   fusion.addInput(tv0);
   fusion.addOutput(out);
@@ -1912,7 +1912,7 @@ void testGPU_FusionRFactorReplay() {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv1 = static_cast<TensorView*>(sum(tv0, {1}));
+  TensorView* tv1 = sum(tv0, {1});
   // tv1[I0, R1]
   tv1->split(0, 32);
   // tv1[I0o, I0i{32}, R1]
@@ -1999,8 +1999,7 @@ void testGPU_FusionReduction() {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = static_cast<TensorView*>(
-      reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0));
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -2068,8 +2067,7 @@ void testGPU_FusionReduction2() {
     fusion.addInput(tv0);
 
     // tv1[I0, R1] = tv0[I0, I1]
-    TensorView* tv1 = static_cast<TensorView*>(
-        reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0));
+    TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
 
     fusion.addOutput(tv1);
 
@@ -2147,8 +2145,7 @@ void testGPU_FusionReduction2() {
     fusion.addInput(tv0);
 
     // tv1[I0, R1] = tv0[I0, I1]
-    TensorView* tv1 = static_cast<TensorView*>(
-        reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0));
+    TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
 
     fusion.addOutput(tv1);
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1798,9 +1798,7 @@ void testGPU_FusionTernaryOps() {
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toTensor());
       },
       /*JIT  Func   */
-      [](Val* c, Val* v1, Val* v2) -> Val* {
-        return where(c, v1, v2);
-      },
+      [](Val* c, Val* v1, Val* v2) -> Val* { return where(c, v1, v2); },
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -111,12 +111,20 @@ TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1) {
   return out;
 }
 
+TORCH_CUDA_API TensorView* castOp(DataType dtype, TensorView* v1) {
+  return static_cast<TensorView*>(castOp(dtype, static_cast<Val*>(v1)));
+}
+
 // UNARY OPERATIONS
 
 TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1) {
   Val* out = newValLike(v1);
   new UnaryOp(type, out, v1);
   return out;
+}
+
+TORCH_CUDA_API TensorView* unaryOp(UnaryOpType type, TensorView* v1) {
+  return static_cast<TensorView*>(unaryOp(type, static_cast<Val*>(v1)));
 }
 
 // BINARY OPERATIONS
@@ -134,45 +142,9 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   return out;
 }
 
-TORCH_CUDA_API Val* sub(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::Sub, v1, v2);
-}
-
-TORCH_CUDA_API Val* mul(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::Mul, v1, v2);
-}
-
-TORCH_CUDA_API Val* div(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::Div, v1, v2);
-}
-
-TORCH_CUDA_API Val* mod(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::Mod, v1, v2);
-}
-
-TORCH_CUDA_API Val* lt(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::LT, v1, v2);
-}
-
-TORCH_CUDA_API Val* ceilDiv(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::CeilDiv, v1, v2);
-}
-
-TORCH_CUDA_API Val* andOp(Val* v1, Val* v2) {
-  TORCH_CHECK(
-      v1->getDataType().value() == DataType::Bool,
-      "Input1 should be of type bool, not ",
-      v1->getDataType().value());
-  TORCH_CHECK(
-      v2->getDataType().value() == DataType::Bool,
-      "Input2 should be of type bool, not ",
-      v2->getDataType().value());
-  return binaryOp(BinaryOpType::And, v1, v2);
-}
-
 // REDUCTION OPERATIONS
 
-Val* reductionOp(
+TensorView* reductionOp(
     BinaryOpType reduction_op_type,
     const std::vector<int>& axes,
     Val* init,
@@ -208,14 +180,14 @@ Val* reductionOp(
     uint_axes.push_back((unsigned int)axis);
   }
 
-  Val* out = tv->newForReduction(uint_axes);
+  TensorView* out = tv->newForReduction(uint_axes);
   if (init->getDataType().value() != v1->getDataType().value())
     init = castOp(v1->getDataType().value(), init);
   new ReductionOp(reduction_op_type, init, out, v1);
   return out;
 }
 
-TORCH_CUDA_API Val* sum(Val* v1, const std::vector<int>& axes) {
+TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& axes) {
   Val* init;
   switch (v1->getDataType().value()) {
     case (DataType::Float):

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -289,12 +289,12 @@ TORCH_CUDA_API Val* ternaryOp(TernaryOpType type, Val* v1, Val* v2, Val* v3) {
     case TernaryOpType::Clamp:
       TORCH_CHECK(
           v1->getDataType().value() == v2->getDataType().value() &&
-          v1->getDataType().value() == v3->getDataType().value(),
+              v1->getDataType().value() == v3->getDataType().value(),
           "All input DataType values should match the input ",
           v1->getDataType().value());
       TORCH_CHECK(
           v2->getValType().value() == ValType::Scalar &&
-          v3->getValType().value() == ValType::Scalar,
+              v3->getValType().value() == ValType::Scalar,
           "Thresh and Value values should be Scalars");
       out = newValLike(v1);
       break;

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -134,6 +134,19 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   return out;
 }
 
+TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2) {
+  return static_cast<TensorView*>(binaryOp(type, static_cast<Val*>(v1), v2));
+}
+
+TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2) {
+  return static_cast<TensorView*>(binaryOp(type, v1, static_cast<Val*>(v2)));
+}
+
+TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2) {
+  return static_cast<TensorView*>(binaryOp(type, static_cast<TensorView*>(v1),
+                                           static_cast<Val*>(v2)));
+}
+
 TORCH_CUDA_API Val* add(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Add, v1, v2);
 }

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -134,23 +134,6 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   return out;
 }
 
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2) {
-  return static_cast<TensorView*>(binaryOp(type, static_cast<Val*>(v1), v2));
-}
-
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2) {
-  return static_cast<TensorView*>(binaryOp(type, v1, static_cast<Val*>(v2)));
-}
-
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2) {
-  return static_cast<TensorView*>(binaryOp(type, static_cast<TensorView*>(v1),
-                                           static_cast<Val*>(v2)));
-}
-
-TORCH_CUDA_API Val* add(Val* v1, Val* v2) {
-  return binaryOp(BinaryOpType::Add, v1, v2);
-}
-
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Sub, v1, v2);
 }

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -117,11 +117,37 @@ TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* add_alp
 TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s);
 TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
 TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
-TORCH_CUDA_API Val* where(Val* c, Val* v1, Val* v2);
 
 // TERNARY OPERATIONS
-TORCH_CUDA_API Val* threshold(Val* in, Val* thresh, Val* value);
-TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val);
+TORCH_CUDA_API Val* ternaryOp(TernaryOpType type, Val* v1, Val* v2, Val* v3);
+template <typename OpType1, typename OpType2, typename OpType3,
+          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
+ternaryOp(TernaryOpType type, OpType1* v1, OpType2* v2, OpType3* v3) {
+  return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
+      ternaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2), static_cast<Val*>(v3)));
+}
+
+template <typename OpType1, typename OpType2, typename OpType3,
+          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* where(
+    OpType1* v1, OpType2* v2, OpType3* v3) {
+  return ternaryOp(TernaryOpType::Where, v1, v2, v3);
+}
+
+template <typename OpType1, typename OpType2, typename OpType3,
+          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* threshold(
+    OpType1* in, OpType2* thresh, OpType3* value) {
+  return ternaryOp(TernaryOpType::Threshold, in, thresh, value);
+}
+
+template <typename OpType1, typename OpType2, typename OpType3,
+          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* clamp(
+    OpType1* in, OpType2* min_val, OpType3* max_val) {
+  return ternaryOp(TernaryOpType::Clamp, in, min_val, max_val);
+}
 
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -20,6 +20,40 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
+namespace {
+
+template <typename Head, typename... Tail>
+struct IsValidArithOpType {
+  static constexpr bool value = !std::is_base_of<Val, Head>::value ?
+      false : IsValidArithOpType<Tail...>::value;
+};
+
+template <typename Type>
+struct IsValidArithOpType<Type> {
+  static constexpr bool value = std::is_base_of<Val, Type>::value;
+};
+
+template <typename Head, typename... Tail>
+struct HasTensorView {
+  static constexpr bool value = std::is_base_of<TensorView, Head>::value ?
+      true : HasTensorView<Tail...>::value;
+};
+
+template <typename Type>
+struct HasTensorView<Type> {
+  static constexpr bool value = std::is_base_of<TensorView, Type>::value;
+};
+
+// Define return type of arithmetic operations. Currently, TensorView
+// when any of operands is TensorView, and Val otherwise.
+template <typename... OpTypes>
+struct ArithOpRetType {
+  using Type = typename std::conditional<HasTensorView<OpTypes...>::value,
+                                         TensorView, Val>::type;
+};
+
+} // namespace
+
 // Promotion logic between two values, returns a new val from resulting type
 // promotion.
 TORCH_CUDA_API Val* promoteNew(Val* v1, Val* v2);
@@ -33,36 +67,16 @@ TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1);
 // Perform binary op type on v1 and v2 and return a type promoted output.
 // Mod, CeilDiv, and LT are considered Int only output operations for now.
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2);
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2);
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2);
 
+// Overload for the case when operands are not Val*. Template matching
+// fails when their classes are not valid types as determined by IsValidArithOpType
 template <typename OpType1, typename OpType2,
-          bool OpType1IsVal = std::is_base_of<Val, OpType1>::value,
-          bool OpType2IsVal = std::is_base_of<Val, OpType2>::value,
-          bool OpType1IsTensorView = std::is_base_of<TensorView, OpType1>::value,
-          bool OpType2IsTensorView = std::is_base_of<TensorView, OpType2>::value>
-struct BinaryOpRetType;
-
-template <typename OpType1, typename OpType2>
-struct BinaryOpRetType<OpType1, OpType2, true, true, false, false> {
-  using Type = Val;
-};
-
-template <typename OpType1, typename OpType2>
-struct BinaryOpRetType<OpType1, OpType2, true, true, true, false> {
-  using Type = TensorView;
-};
-
-template <typename OpType1, typename OpType2>
-struct BinaryOpRetType<OpType1, OpType2, true, true, false, true> {
-  using Type = TensorView;
-};
-
-template <typename OpType1, typename OpType2>
-struct BinaryOpRetType<OpType1, OpType2, true, true, true, true> {
-  using Type = TensorView;
-};
+          std::enable_if_t<IsValidArithOpType<OpType1, OpType2>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type*
+binaryOp(BinaryOpType type, OpType1* v1, OpType2* v2) {
+  return static_cast<typename ArithOpRetType<OpType1, OpType2>::Type*>(
+      binaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2)));
+}
 
 // Perform a reduction operation on v1, initial value for reduction is init,
 // reduces across axes, and reduction operation defined by BinaryOp.
@@ -74,9 +88,8 @@ TORCH_CUDA_API Val* reductionOp(
 
 // BINARY OPAERATIONS
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename BinaryOpRetType<OpType1, OpType2>::Type* add(
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* add(
     OpType1* v1, OpType2* v2) {
-  //return binaryOp2<OpType1, OpType2>(BinaryOpType::Add, v1, v2);
   return binaryOp(BinaryOpType::Add, v1, v2);
 }
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -20,8 +20,6 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-namespace {
-
 template <typename Head, typename... Tail>
 struct IsValidArithOpType {
   static constexpr bool value = !std::is_base_of<Val, Head>::value
@@ -53,8 +51,6 @@ struct ArithOpRetType {
   using Type = typename std::
       conditional<HasTensorView<OpTypes...>::value, TensorView, Val>::type;
 };
-
-} // namespace
 
 // Promotion logic between two values, returns a new val from resulting type
 // promotion.

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -24,8 +24,9 @@ namespace {
 
 template <typename Head, typename... Tail>
 struct IsValidArithOpType {
-  static constexpr bool value = !std::is_base_of<Val, Head>::value ?
-      false : IsValidArithOpType<Tail...>::value;
+  static constexpr bool value = !std::is_base_of<Val, Head>::value
+      ? false
+      : IsValidArithOpType<Tail...>::value;
 };
 
 template <typename Type>
@@ -35,8 +36,9 @@ struct IsValidArithOpType<Type> {
 
 template <typename Head, typename... Tail>
 struct HasTensorView {
-  static constexpr bool value = std::is_base_of<TensorView, Head>::value ?
-      true : HasTensorView<Tail...>::value;
+  static constexpr bool value = std::is_base_of<TensorView, Head>::value
+      ? true
+      : HasTensorView<Tail...>::value;
 };
 
 template <typename Type>
@@ -48,8 +50,8 @@ struct HasTensorView<Type> {
 // when any of operands is TensorView, and Val otherwise.
 template <typename... OpTypes>
 struct ArithOpRetType {
-  using Type = typename std::conditional<HasTensorView<OpTypes...>::value,
-                                         TensorView, Val>::type;
+  using Type = typename std::
+      conditional<HasTensorView<OpTypes...>::value, TensorView, Val>::type;
 };
 
 } // namespace
@@ -69,11 +71,16 @@ TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1);
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
 
 // Overload for the case when operands are not Val*. Template matching
-// fails when their classes are not valid types as determined by IsValidArithOpType
-template <typename OpType1, typename OpType2,
-          std::enable_if_t<IsValidArithOpType<OpType1, OpType2>::value>* = nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type*
-binaryOp(BinaryOpType type, OpType1* v1, OpType2* v2) {
+// fails when their classes are not valid types as determined by
+// IsValidArithOpType
+template <
+    typename OpType1,
+    typename OpType2,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* binaryOp(
+    BinaryOpType type,
+    OpType1* v1,
+    OpType2* v2) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2>::Type*>(
       binaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2)));
 }
@@ -89,7 +96,8 @@ TORCH_CUDA_API Val* reductionOp(
 // BINARY OPAERATIONS
 template <typename OpType1, typename OpType2>
 TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* add(
-    OpType1* v1, OpType2* v2) {
+    OpType1* v1,
+    OpType2* v2) {
   return binaryOp(BinaryOpType::Add, v1, v2);
 }
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2);
@@ -106,10 +114,14 @@ TORCH_CUDA_API Val* sum(Val* v1, const std::vector<int>& reduction_axes);
 // COMPOUND OPERATIONS
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s);
 
-template <typename OpType1, typename OpType2, typename OpType3,
-          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* add_alpha(
-    OpType1* v1, OpType2* v2, OpType3* s) {
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
+add_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
       add_alpha(v1, v2, s));
 }
@@ -120,32 +132,56 @@ TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
 
 // TERNARY OPERATIONS
 TORCH_CUDA_API Val* ternaryOp(TernaryOpType type, Val* v1, Val* v2, Val* v3);
-template <typename OpType1, typename OpType2, typename OpType3,
-          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
 TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
 ternaryOp(TernaryOpType type, OpType1* v1, OpType2* v2, OpType3* v3) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
-      ternaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2), static_cast<Val*>(v3)));
+      ternaryOp(
+          type,
+          static_cast<Val*>(v1),
+          static_cast<Val*>(v2),
+          static_cast<Val*>(v3)));
 }
 
-template <typename OpType1, typename OpType2, typename OpType3,
-          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
 TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* where(
-    OpType1* v1, OpType2* v2, OpType3* v3) {
+    OpType1* v1,
+    OpType2* v2,
+    OpType3* v3) {
   return ternaryOp(TernaryOpType::Where, v1, v2, v3);
 }
 
-template <typename OpType1, typename OpType2, typename OpType3,
-          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* threshold(
-    OpType1* in, OpType2* thresh, OpType3* value) {
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
+threshold(OpType1* in, OpType2* thresh, OpType3* value) {
   return ternaryOp(TernaryOpType::Threshold, in, thresh, value);
 }
 
-template <typename OpType1, typename OpType2, typename OpType3,
-          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
 TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* clamp(
-    OpType1* in, OpType2* min_val, OpType3* max_val) {
+    OpType1* in,
+    OpType2* min_val,
+    OpType3* max_val) {
   return ternaryOp(TernaryOpType::Clamp, in, min_val, max_val);
 }
 

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -75,61 +75,42 @@ template <
     typename OpType1,
     typename OpType2,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2>::value>* = nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* binaryOp(
-    BinaryOpType type,
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto binaryOp(BinaryOpType type, OpType1* v1, OpType2* v2) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2>::Type*>(
       binaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2)));
 }
 
 // BINARY OPAERATIONS
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* add(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto add(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::Add, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* sub(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto sub(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::Sub, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* mul(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto mul(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::Mul, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* div(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto div(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::Div, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* mod(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto mod(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::Mod, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* lt(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto lt(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::LT, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* ceilDiv(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto ceilDiv(OpType1* v1, OpType2* v2) {
   return binaryOp(BinaryOpType::CeilDiv, v1, v2);
 }
 template <typename OpType1, typename OpType2>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* andOp(
-    OpType1* v1,
-    OpType2* v2) {
+TORCH_CUDA_API auto andOp(OpType1* v1, OpType2* v2) {
   TORCH_CHECK(
       v1->getDataType().value() == DataType::Bool,
       "Input1 should be of type bool, not ",
@@ -165,8 +146,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
-add_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
+TORCH_CUDA_API auto add_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
       add_alpha(v1, v2, s));
 }
@@ -177,8 +157,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
-sub_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
+TORCH_CUDA_API auto sub_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
       sub_alpha(v1, v2, s));
 }
@@ -189,10 +168,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* lerp(
-    OpType1* v1,
-    OpType2* v2,
-    OpType3* s) {
+TORCH_CUDA_API auto lerp(OpType1* v1, OpType2* v2, OpType3* s) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
       lerp(v1, v2, s));
 }
@@ -203,10 +179,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* addcmul(
-    OpType1* v1,
-    OpType2* v2,
-    OpType3* s) {
+TORCH_CUDA_API auto addcmul(OpType1* v1, OpType2* v2, OpType3* s) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
       lerp(v1, v2, s));
 }
@@ -219,8 +192,11 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
-ternaryOp(TernaryOpType type, OpType1* v1, OpType2* v2, OpType3* v3) {
+TORCH_CUDA_API auto ternaryOp(
+    TernaryOpType type,
+    OpType1* v1,
+    OpType2* v2,
+    OpType3* v3) {
   return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
       ternaryOp(
           type,
@@ -235,10 +211,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* where(
-    OpType1* v1,
-    OpType2* v2,
-    OpType3* v3) {
+TORCH_CUDA_API auto where(OpType1* v1, OpType2* v2, OpType3* v3) {
   return ternaryOp(TernaryOpType::Where, v1, v2, v3);
 }
 
@@ -248,8 +221,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
-threshold(OpType1* in, OpType2* thresh, OpType3* value) {
+TORCH_CUDA_API auto threshold(OpType1* in, OpType2* thresh, OpType3* value) {
   return ternaryOp(TernaryOpType::Threshold, in, thresh, value);
 }
 
@@ -259,10 +231,7 @@ template <
     typename OpType3,
     std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
         nullptr>
-TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* clamp(
-    OpType1* in,
-    OpType2* min_val,
-    OpType3* max_val) {
+TORCH_CUDA_API auto clamp(OpType1* in, OpType2* min_val, OpType3* max_val) {
   return ternaryOp(TernaryOpType::Clamp, in, min_val, max_val);
 }
 

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -58,9 +58,11 @@ TORCH_CUDA_API Val* promoteNew(Val* v1, Val* v2);
 
 // Insertion of casting op to dtype, returns new resulting val
 TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1);
+TORCH_CUDA_API TensorView* castOp(DataType dtype, TensorView* v1);
 
 // Perform unary op type and return the output
 TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1);
+TORCH_CUDA_API TensorView* unaryOp(DataType dtype, TensorView* v1);
 
 // Perform binary op type on v1 and v2 and return a type promoted output.
 // Mod, CeilDiv, and LT are considered Int only output operations for now.
@@ -81,14 +83,6 @@ TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* binaryOp(
       binaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2)));
 }
 
-// Perform a reduction operation on v1, initial value for reduction is init,
-// reduces across axes, and reduction operation defined by BinaryOp.
-TORCH_CUDA_API Val* reductionOp(
-    BinaryOpType reduction_op_type,
-    const std::vector<int>& axes,
-    Val* init,
-    Val* v1);
-
 // BINARY OPAERATIONS
 template <typename OpType1, typename OpType2>
 TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* add(
@@ -96,19 +90,74 @@ TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* add(
     OpType2* v2) {
   return binaryOp(BinaryOpType::Add, v1, v2);
 }
-TORCH_CUDA_API Val* sub(Val* v1, Val* v2);
-TORCH_CUDA_API Val* mul(Val* v1, Val* v2);
-TORCH_CUDA_API Val* div(Val* v1, Val* v2);
-TORCH_CUDA_API Val* mod(Val* v1, Val* v2);
-TORCH_CUDA_API Val* lt(Val* v1, Val* v2);
-TORCH_CUDA_API Val* ceilDiv(Val* v1, Val* v2);
-TORCH_CUDA_API Val* andOp(Val* v1, Val* v2);
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* sub(
+    OpType1* v1,
+    OpType2* v2) {
+  return binaryOp(BinaryOpType::Sub, v1, v2);
+}
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* mul(
+    OpType1* v1,
+    OpType2* v2) {
+  return binaryOp(BinaryOpType::Mul, v1, v2);
+}
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* div(
+    OpType1* v1,
+    OpType2* v2) {
+  return binaryOp(BinaryOpType::Div, v1, v2);
+}
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* mod(
+    OpType1* v1,
+    OpType2* v2) {
+  return binaryOp(BinaryOpType::Mod, v1, v2);
+}
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* lt(
+    OpType1* v1,
+    OpType2* v2) {
+  return binaryOp(BinaryOpType::LT, v1, v2);
+}
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* ceilDiv(
+    OpType1* v1,
+    OpType2* v2) {
+  return binaryOp(BinaryOpType::CeilDiv, v1, v2);
+}
+template <typename OpType1, typename OpType2>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2>::Type* andOp(
+    OpType1* v1,
+    OpType2* v2) {
+  TORCH_CHECK(
+      v1->getDataType().value() == DataType::Bool,
+      "Input1 should be of type bool, not ",
+      v1->getDataType().value());
+  TORCH_CHECK(
+      v2->getDataType().value() == DataType::Bool,
+      "Input2 should be of type bool, not ",
+      v2->getDataType().value());
+  return binaryOp(BinaryOpType::And, v1, v2);
+}
 
 // REDUCTION OPERATIONS
-TORCH_CUDA_API Val* sum(Val* v1, const std::vector<int>& reduction_axes);
+
+// Perform a reduction operation on v1, initial value for reduction is init,
+// reduces across axes, and reduction operation defined by BinaryOp.
+TORCH_CUDA_API TensorView* reductionOp(
+    BinaryOpType reduction_op_type,
+    const std::vector<int>& axes,
+    Val* init,
+    Val* v1);
+
+TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& reduction_axes);
 
 // COMPOUND OPERATIONS
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s);
+TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s);
+TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
+TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
 
 template <
     typename OpType1,
@@ -122,9 +171,45 @@ add_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
       add_alpha(v1, v2, s));
 }
 
-TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s);
-TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
-TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*
+sub_alpha(OpType1* v1, OpType2* v2, OpType3* s) {
+  return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
+      sub_alpha(v1, v2, s));
+}
+
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* lerp(
+    OpType1* v1,
+    OpType2* v2,
+    OpType3* s) {
+  return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
+      lerp(v1, v2, s));
+}
+
+template <
+    typename OpType1,
+    typename OpType2,
+    typename OpType3,
+    std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* =
+        nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* addcmul(
+    OpType1* v1,
+    OpType2* v2,
+    OpType3* s) {
+  return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
+      lerp(v1, v2, s));
+}
 
 // TERNARY OPERATIONS
 TORCH_CUDA_API Val* ternaryOp(TernaryOpType type, Val* v1, Val* v2, Val* v3);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -105,6 +105,15 @@ TORCH_CUDA_API Val* sum(Val* v1, const std::vector<int>& reduction_axes);
 
 // COMPOUND OPERATIONS
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s);
+
+template <typename OpType1, typename OpType2, typename OpType3,
+          std::enable_if_t<IsValidArithOpType<OpType1, OpType2, OpType3>::value>* = nullptr>
+TORCH_CUDA_API typename ArithOpRetType<OpType1, OpType2, OpType3>::Type* add_alpha(
+    OpType1* v1, OpType2* v2, OpType3* s) {
+  return static_cast<typename ArithOpRetType<OpType1, OpType2, OpType3>::Type*>(
+      add_alpha(v1, v2, s));
+}
+
 TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s);
 TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
 TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -201,8 +201,11 @@ class IrParser {
                      std::make_pair(
                          BinaryOpType::Add,
                          static_cast<BinaryOpWithAlphaType>(&add_alpha))},
-                    {aten::sub, std::make_pair(BinaryOpType::Sub, &sub_alpha)},
-                });
+                    {aten::sub,
+                     std::make_pair(
+                         BinaryOpType::Sub,
+                         static_cast<BinaryOpWithAlphaType>(&sub_alpha))}
+                  });
             // TODO: handle scaling factor when it's not constant 1;
             auto lhs = value_map[node->inputs()[0]->unique()];
             auto rhs = value_map[node->inputs()[1]->unique()];

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -192,11 +192,12 @@ class IrParser {
           ptr_op,
           [](const Node* const node,
              std::unordered_map<size_t, CgValue>& value_map) -> void {
+            using BinaryOpWithAlphaType = Val* (*)(Val*, Val*, Val*);
             static std::unordered_map<
-                Symbol,
-                std::pair<BinaryOpType, decltype(&add_alpha)>>
+              Symbol, std::pair<BinaryOpType, BinaryOpWithAlphaType>>
                 op_mapping({
-                    {aten::add, std::make_pair(BinaryOpType::Add, &add_alpha)},
+                    {aten::add, std::make_pair(
+                        BinaryOpType::Add, static_cast<BinaryOpWithAlphaType>(&add_alpha))},
                     {aten::sub, std::make_pair(BinaryOpType::Sub, &sub_alpha)},
                 });
             // TODO: handle scaling factor when it's not constant 1;

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -196,16 +196,15 @@ class IrParser {
             static std::unordered_map<
                 Symbol,
                 std::pair<BinaryOpType, BinaryOpWithAlphaType>>
-                op_mapping({
-                    {aten::add,
-                     std::make_pair(
-                         BinaryOpType::Add,
-                         static_cast<BinaryOpWithAlphaType>(&add_alpha))},
-                    {aten::sub,
-                     std::make_pair(
-                         BinaryOpType::Sub,
-                         static_cast<BinaryOpWithAlphaType>(&sub_alpha))}
-                  });
+                op_mapping(
+                    {{aten::add,
+                      std::make_pair(
+                          BinaryOpType::Add,
+                          static_cast<BinaryOpWithAlphaType>(&add_alpha))},
+                     {aten::sub,
+                      std::make_pair(
+                          BinaryOpType::Sub,
+                          static_cast<BinaryOpWithAlphaType>(&sub_alpha))}});
             // TODO: handle scaling factor when it's not constant 1;
             auto lhs = value_map[node->inputs()[0]->unique()];
             auto rhs = value_map[node->inputs()[1]->unique()];

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -194,10 +194,13 @@ class IrParser {
              std::unordered_map<size_t, CgValue>& value_map) -> void {
             using BinaryOpWithAlphaType = Val* (*)(Val*, Val*, Val*);
             static std::unordered_map<
-              Symbol, std::pair<BinaryOpType, BinaryOpWithAlphaType>>
+                Symbol,
+                std::pair<BinaryOpType, BinaryOpWithAlphaType>>
                 op_mapping({
-                    {aten::add, std::make_pair(
-                        BinaryOpType::Add, static_cast<BinaryOpWithAlphaType>(&add_alpha))},
+                    {aten::add,
+                     std::make_pair(
+                         BinaryOpType::Add,
+                         static_cast<BinaryOpWithAlphaType>(&add_alpha))},
                     {aten::sub, std::make_pair(BinaryOpType::Sub, &sub_alpha)},
                 });
             // TODO: handle scaling factor when it's not constant 1;


### PR DESCRIPTION
~~Only `add` is modified for now.~~

Return type is determined based on operand types. `binaryOp` does so by overloading, which means we have 4 versions of `binaryOp`. 

Actual ops like `add` uses a template to avoid defining multiple versions of each op. A downside is a compiler error message when an invalid type is used can be cryptic.

If this looks good, I'll update the other binary ops as well.