### PR TITLE
IrGraphGenerator: export fuser IR to graphviz

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -411,6 +411,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/graph_fuser.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/index_compute.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/ir_graphviz.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/ir_nodes.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/ir_iostream.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/iter_visitor.cpp

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_graphviz.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 #include <torch/csrc/jit/codegen/cuda/kernel.h>
 #include <torch/csrc/jit/codegen/cuda/lower2device.h>
@@ -34,6 +35,69 @@ TensorView* makeDummyTensor(int nDims, DataType dtype = DataType::Float) {
 
 // 1. Test cases are void() functions.
 // 2. They start with the prefix `test`
+
+// A few smoke tests for IrGraphGenerator
+// (These tests exercise IrGraphGenerator through a non-trivial IR,
+//  to make sure that it runs w/o crashing. The actual output is not
+//  validated)
+void testGPU_IrGraphGenerator() {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Make sure we can handle empty IRs
+  {
+    IrGraphGenerator ir_graph(&fusion, IrGraphGenerator::DetailLevel::Basic);
+    TORCH_CHECK(!ir_graph.generate().empty());
+  }
+
+  // Construct an interesting IR
+  TensorView* tv0 = makeDummyTensor(2);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
+  TensorView* tv2 = static_cast<TensorView*>(add(tv0, new Float(3.0)));
+  TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.5)));
+  TensorView* tv4 = static_cast<TensorView*>(add(tv2, tv1));
+  TensorView* tv5 = static_cast<TensorView*>(add(tv4, tv3));
+  TensorView* tv6 = static_cast<TensorView*>(add(tv0, tv3));
+
+  // Another checkpoint before adding outputs
+  {
+    IrGraphGenerator ir_graph(&fusion, IrGraphGenerator::DetailLevel::Explicit);
+    TORCH_CHECK(!ir_graph.generate().empty());
+  }
+
+  fusion.addOutput(tv5);
+  fusion.addOutput(tv6);
+
+  tv6->merge(0);
+  tv6->split(0, 4);
+  tv6->axis(0)->parallelize(ParallelType::BIDx);
+  tv5->reorder({{-1, 0}});
+  tv0->computeAt(tv3, 1);
+  tv0->computeAt(tv6, 1);
+
+  // Another checkpoint with more node types
+  {
+    IrGraphGenerator ir_graph(
+        &fusion, IrGraphGenerator::DetailLevel::ComputeOnly);
+    TORCH_CHECK(!ir_graph.generate().empty());
+  }
+
+  for (Val* val : fusion.vals()) {
+    if (!fusion.hasInput(val) &&
+        val->getValType().value() == ValType::TensorView) {
+      TensorView* tv = static_cast<TensorView*>(val);
+      tv->axis(-1)->parallelize(ParallelType::TIDx);
+    }
+  }
+
+  // Final IR graph
+  {
+    IrGraphGenerator ir_graph(&fusion, IrGraphGenerator::DetailLevel::Verbose);
+    TORCH_CHECK(!ir_graph.generate().empty());
+  }
+}
 
 void testGPU_FusionDispatch() {
   Fusion fusion;

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -45,10 +45,9 @@ void testGPU_IrGraphGenerator() {
   FusionGuard fg(&fusion);
 
   // Make sure we can handle empty IRs
-  {
-    IrGraphGenerator ir_graph(&fusion, IrGraphGenerator::DetailLevel::Basic);
-    TORCH_CHECK(!ir_graph.generate().empty());
-  }
+  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
+                   &fusion, IrGraphGenerator::DetailLevel::Basic)
+                   .empty());
 
   // Construct an interesting IR
   TensorView* tv0 = makeDummyTensor(2);
@@ -62,10 +61,9 @@ void testGPU_IrGraphGenerator() {
   TensorView* tv6 = static_cast<TensorView*>(add(tv0, tv3));
 
   // Another checkpoint before adding outputs
-  {
-    IrGraphGenerator ir_graph(&fusion, IrGraphGenerator::DetailLevel::Explicit);
-    TORCH_CHECK(!ir_graph.generate().empty());
-  }
+  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
+                   &fusion, IrGraphGenerator::DetailLevel::Explicit)
+                   .empty());
 
   fusion.addOutput(tv5);
   fusion.addOutput(tv6);
@@ -78,11 +76,9 @@ void testGPU_IrGraphGenerator() {
   tv0->computeAt(tv6, 1);
 
   // Another checkpoint with more node types
-  {
-    IrGraphGenerator ir_graph(
-        &fusion, IrGraphGenerator::DetailLevel::ComputeOnly);
-    TORCH_CHECK(!ir_graph.generate().empty());
-  }
+  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
+                   &fusion, IrGraphGenerator::DetailLevel::ComputeOnly)
+                   .empty());
 
   for (Val* val : fusion.vals()) {
     if (!fusion.hasInput(val) &&
@@ -93,10 +89,9 @@ void testGPU_IrGraphGenerator() {
   }
 
   // Final IR graph
-  {
-    IrGraphGenerator ir_graph(&fusion, IrGraphGenerator::DetailLevel::Verbose);
-    TORCH_CHECK(!ir_graph.generate().empty());
-  }
+  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
+                   &fusion, IrGraphGenerator::DetailLevel::Verbose)
+                   .empty());
 }
 
 void testGPU_FusionDispatch() {

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -100,6 +100,7 @@ namespace jit {
   _(GraphExecutor)               \
   _(ModuleConversion)            \
   _(Interp)                      \
+  _(GPU_IrGraphGenerator)        \
   _(GPU_FusionDispatch)          \
   _(GPU_FusionSimpleArith)       \
   _(GPU_FusionSimpleTypePromote) \

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -297,6 +297,7 @@ libtorch_cuda_sources = [
     "torch/csrc/jit/codegen/cuda/graph_fuser.cpp",
     "torch/csrc/jit/codegen/cuda/index_compute.cpp",
     "torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp",
+    "torch/csrc/jit/codegen/cuda/ir_graphviz.cpp",
     "torch/csrc/jit/codegen/cuda/ir_nodes.cpp",
     "torch/csrc/jit/codegen/cuda/ir_iostream.cpp",
     "torch/csrc/jit/codegen/cuda/iter_visitor.cpp",

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -1,7 +1,7 @@
 
+#include <torch/csrc/jit/codegen/cuda/ir_graphviz.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
-#include <torch/csrc/jit/codegen/cuda/ir_graphviz.h>
 #include <torch/csrc/jit/codegen/cuda/type.h>
 
 #include <fstream>

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -1,0 +1,446 @@
+
+#include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_graphviz.h>
+#include <torch/csrc/jit/codegen/cuda/type.h>
+
+#include <fstream>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+
+namespace {
+
+// Private helper, generating node labels for IrGraphGenerator
+class IrNodeLabel : private OptInConstDispatch {
+  using DetailLevel = IrGraphGenerator::DetailLevel;
+
+ public:
+  static std::string gen(
+      const Statement* node,
+      DetailLevel detail_level = DetailLevel::Basic) {
+    IrNodeLabel generator(detail_level);
+    generator.OptInConstDispatch::handle(node);
+    return generator.label_.str();
+  }
+
+ private:
+  explicit IrNodeLabel(DetailLevel detail_level)
+      : detail_level_(detail_level) {}
+
+  ~IrNodeLabel() override = default;
+
+  void handle(const Float* f) override {
+    if (f->isSymbolic()) {
+      label_ << "f" << f->name();
+    } else {
+      if (detail_level_ > DetailLevel::Basic) {
+        label_ << "f" << f->name() << "=";
+      }
+      label_ << std::fixed << std::setprecision(2) << *f->value();
+    }
+  }
+
+  void handle(const Int* i) override {
+    if (i->isSymbolic()) {
+      label_ << "i" << i->name();
+    } else {
+      if (detail_level_ > DetailLevel::Basic) {
+        label_ << "i" << i->name() << "=";
+      }
+      label_ << *i->value();
+    }
+  }
+
+  void handle(const NamedScalar* ns) override {
+    label_ << ns->name();
+  }
+
+  void handle(const IterDomain* id) override {
+    if (id->isReduction()) {
+      label_ << "r";
+    } else {
+      label_ << "i";
+    }
+
+    switch (id->parallel_method()) {
+      case (ParallelType::Vectorize):
+        label_ << "V";
+        break;
+      case (ParallelType::Unroll):
+        label_ << "U";
+        break;
+      case (ParallelType::Serial):
+        label_ << "S";
+        break;
+      default:
+        label_ << id->parallel_method();
+    }
+
+    label_ << "(";
+    if (!id->start()->isZeroInt()) {
+      label_ << IrNodeLabel::gen(id->start()) << " : ";
+    }
+    label_ << IrNodeLabel::gen(id->extent());
+    if (id->rawExtent() != id->extent()) {
+      label_ << "\\<" << IrNodeLabel::gen(id->rawExtent()) << "\\>";
+    }
+    label_ << ")";
+  }
+
+  void handle(const Split* split) override {
+    label_ << "Split(axis=" << split->axis()
+           << ", factor=" << IrNodeLabel::gen(split->factor()) << ")";
+  }
+
+  void handle(const Merge* merge) override {
+    label_ << "Merge(axis=" << merge->axis() << ")";
+  }
+
+  void handle(const Reorder* reorder) override {
+    label_ << "Reorder( ";
+    for (const int old_pos : reorder->new2old()) {
+      label_ << old_pos << " ";
+    }
+    label_ << ")";
+  }
+
+ private:
+  std::stringstream label_;
+  const DetailLevel detail_level_;
+};
+
+} // anonymous namespace
+
+void IrGraphGenerator::print(
+    const Fusion* fusion,
+    const char* filename,
+    DetailLevel detail_level) {
+  // output file
+  std::ofstream dot_file(filename);
+  TORCH_CHECK(dot_file.good(), "Failed to open the IR graph file");
+
+  // generate the dot graph definition
+  IrGraphGenerator ir_graph(fusion, detail_level);
+  dot_file << ir_graph.generate();
+}
+
+IrGraphGenerator::IrGraphGenerator(
+    const Fusion* fusion,
+    DetailLevel detail_level)
+    : detail_level_(detail_level), fusion_(fusion) {
+  // setup inputs & outputs
+  // (indexes used to quickly check if a value is fusion input or output)
+  for (const auto* input : fusion->inputs()) {
+    TORCH_CHECK(inputs_.count(input) == 0);
+    inputs_.insert(input);
+  }
+  for (const auto* output : fusion->outputs()) {
+    TORCH_CHECK(outputs_.count(output) == 0);
+    outputs_.insert(output);
+  }
+}
+
+std::string IrGraphGenerator::getid(const Statement* stm) {
+  const auto it = id_map_.find(stm);
+  if (it == id_map_.end()) {
+    // First reference, generate a new id
+    std::stringstream new_id;
+    new_id << "stm_" << next_id_++;
+    id_map_.insert({stm, new_id.str()});
+    return new_id.str();
+  } else {
+    return it->second;
+  }
+}
+
+void IrGraphGenerator::addArc(
+    const Statement* src,
+    const Statement* dst,
+    const std::string& style) {
+  // We automatically visit (handle) the arc's source and destination
+  handle(src);
+  handle(dst);
+
+  // generate and queue the arc definition
+  std::stringstream arc_def;
+  arc_def << getid(src) << " -> " << getid(dst) << " " << style;
+  arcs_.push_back(arc_def.str());
+}
+
+void IrGraphGenerator::printExpr(const Expr* expr, const std::string& label) {
+  graph_def_ << "    " << getid(expr) << " "
+             << "[label=\"" << label << "\", shape=oval, color=blue, "
+             << "style=filled, fillcolor=azure];\n";
+}
+
+void IrGraphGenerator::printValue(const Val* val, const std::string& label) {
+  graph_def_ << "    " << getid(val) << " [label=\"" << label
+             << "\", shape=rect, color=green, fontsize=10];\n";
+}
+
+std::string IrGraphGenerator::generate() {
+  // IrGraphGenerator instances are not reusable
+  TORCH_CHECK(graph_def_.str().empty());
+  TORCH_CHECK(visited_.empty());
+
+  // record detail level
+  graph_def_ << "// detail level: ";
+  switch (detail_level_) {
+    case DetailLevel::ComputeOnly:
+      graph_def_ << "compute only\n";
+      break;
+    case DetailLevel::Basic:
+      graph_def_ << "minimal\n";
+      break;
+    case DetailLevel::Explicit:
+      graph_def_ << "explicit\n";
+      break;
+    case DetailLevel::Verbose:
+      graph_def_ << "verbose\n";
+      break;
+    default:
+      TORCH_CHECK(!"Unexpected detail level");
+  }
+
+  graph_def_ << "digraph fusion_ir {\n"
+             << "  node [shape=circle, color=gray];\n"
+             << "  edge [color=black];\n";
+
+  // Compute graph
+  generateComputeGraph();
+
+  // Schedule graph
+  if (detail_level_ > DetailLevel::ComputeOnly) {
+    generateScheduleGraph();
+  }
+
+  // All expressions & values
+  // (These are otherwise unreacheable (dead) nodes)
+  if (detail_level_ >= DetailLevel::Verbose) {
+    for (const auto* expr : fusion_->unordered_exprs()) {
+      handle(expr);
+    }
+    for (const auto* val : fusion_->vals()) {
+      handle(val);
+    }
+  }
+
+  // Finally, print all arc definitions
+  for (const auto& arc : arcs_) {
+    graph_def_ << "  " << arc << ";\n";
+  }
+
+  graph_def_ << "}\n";
+
+  // Make sure that all referenced nodes have been visited
+  for (const auto& kv : id_map_) {
+    TORCH_CHECK(visited(kv.first));
+  }
+
+  return graph_def_.str();
+}
+
+void IrGraphGenerator::generateComputeGraph() {
+  graph_def_ << "  subgraph cluster_compute {\n"
+             << "    label=\"compute\";\n"
+             << "    style=dashed;\n";
+
+  // Inputs
+  for (const auto* input : fusion_->inputs()) {
+    handle(input);
+  }
+
+  // Outputs
+  for (const auto* output : fusion_->outputs()) {
+    handle(output);
+  }
+
+  graph_def_ << "  }\n";
+}
+
+void IrGraphGenerator::generateScheduleGraph() {
+  graph_def_ << "  subgraph cluster_schedule {\n"
+             << "    label=\"schedule\";\n"
+             << "    style=dashed;\n";
+
+  // Connect TensorView with their TensorDomain
+  // (this will trigger the traversal of the schedule graph)
+  for (auto tv : tensor_views_) {
+    addArc(tv->domain(), tv, "[style=dashed]");
+  }
+
+  graph_def_ << "  }\n";
+}
+
+void IrGraphGenerator::handle(const Statement* s) {
+  OptInConstDispatch::handle(s);
+};
+
+void IrGraphGenerator::handle(const Val* v) {
+  if (!visited(v)) {
+    visited_.insert(v);
+    if (const auto* def = fusion_->origin(v)) {
+      handle(def);
+    }
+    OptInConstDispatch::handle(v);
+  }
+};
+
+void IrGraphGenerator::handle(const Expr* e) {
+  if (!visited(e)) {
+    visited_.insert(e);
+    OptInConstDispatch::handle(e);
+  }
+};
+
+void IrGraphGenerator::handle(const TensorDomain* td) {
+  graph_def_ << "    " << getid(td) << " [label=\"TensorDomain\", "
+             << "shape=note, color=gray, "
+             << "style=filled, fillcolor=gray90, fontsize=10];\n";
+  for (auto iter_domain : td->domain()) {
+    addArc(iter_domain, td, "[color=gray]");
+  }
+}
+
+void IrGraphGenerator::handle(const IterDomain* id) {
+  graph_def_ << "    " << getid(id) << " [label=\"" << IrNodeLabel::gen(id)
+             << "\", shape=cds, color=gray, fontsize=10];\n";
+
+  if (!id->start()->isZeroInt()) {
+    addArc(id->start(), id, "[color=gray]");
+  }
+
+  addArc(id->rawExtent(), id, "[color=gray]");
+
+  if (detail_level_ > DetailLevel::Basic && id->rawExtent() != id->extent()) {
+    addArc(id->extent(), id, "[color=gray, style=dashed]");
+  }
+}
+
+void IrGraphGenerator::handle(const TensorIndex* ti) {
+  graph_def_ << "    " << getid(ti) << " [label=\"TensorIndex\", "
+             << "shape=rarrow, color=gray, fontsize=10];\n";
+
+  addArc(ti, ti->view());
+
+  for (const auto index : ti->indices()) {
+    addArc(index, ti);
+  }
+}
+
+void IrGraphGenerator::handle(const Float* f) {
+  printValue(f, IrNodeLabel::gen(f, detail_level_));
+}
+
+void IrGraphGenerator::handle(const Int* i) {
+  printValue(i, IrNodeLabel::gen(i, detail_level_));
+}
+
+void IrGraphGenerator::handle(const NamedScalar* i) {
+  printValue(i, IrNodeLabel::gen(i, detail_level_));
+}
+
+void IrGraphGenerator::handle(const TensorView* tv) {
+  std::stringstream label;
+  label << "{T" << tv->name() << "|";
+  label << "{";
+  bool first_axis = true;
+  for (auto iter_domain : tv->domain()->domain()) {
+    if (first_axis) {
+      first_axis = false;
+    } else {
+      label << "|";
+    }
+    label << IrNodeLabel::gen(iter_domain);
+  }
+  label << "}}";
+
+  const bool is_input = inputs_.find(tv) != inputs_.end();
+  const bool is_output = outputs_.find(tv) != outputs_.end();
+
+  const char* style = is_input ? "style=filled, fillcolor=palegreen"
+                               : is_output ? "style=filled, fillcolor=lightblue"
+                                           : "style=filled, fillcolor=beige";
+
+  graph_def_ << "    " << getid(tv) << " [label=\"" << label.str()
+             << "\", shape=Mrecord, color=brown, " << style << "];\n";
+
+  if (const auto* compute_at_view = tv->getComputeAtView()) {
+    std::stringstream arc_style;
+    arc_style << "[color=red, style=dashed, label=\""
+              << "ComputeAt(" << tv->getComputeAtAxis() << ")\"]";
+    addArc(tv, compute_at_view, arc_style.str());
+  }
+
+  tensor_views_.push_back(tv);
+}
+
+void IrGraphGenerator::handle(const UnaryOp* uop) {
+  // node
+  std::stringstream label;
+  label << uop->getUnaryOpType();
+  printExpr(uop, label.str());
+
+  // UnaryOp inputs & outputs
+  addArc(uop->in(), uop);
+  addArc(uop, uop->out());
+}
+
+void IrGraphGenerator::handle(const BinaryOp* bop) {
+  // node
+  std::stringstream label;
+  label << bop->getBinaryOpType();
+  printExpr(bop, label.str());
+
+  // BinaryOp inputs & outputs
+  addArc(bop->lhs(), bop);
+  addArc(bop->rhs(), bop, "[color=blue]");
+  addArc(bop, bop->out());
+}
+
+void IrGraphGenerator::handle(const ForLoop* for_loop) {
+  printExpr(for_loop, "ForLoop");
+  addArc(for_loop->index(), for_loop);
+  addArc(for_loop->iter_domain(), for_loop);
+  if (for_loop->parentScope()) {
+    addArc(for_loop, for_loop->parentScope());
+  }
+}
+
+void IrGraphGenerator::handle(const IfThenElse* if_then_else) {
+  printExpr(if_then_else, "IfThenElse");
+  addArc(if_then_else->cond(), if_then_else);
+  if (if_then_else->parentScope()) {
+    addArc(if_then_else, if_then_else->parentScope());
+  }
+}
+
+void IrGraphGenerator::handle(const Allocate* allocate) {
+  printExpr(allocate, "Allocate");
+  addArc(allocate->extent(), allocate);
+  addArc(allocate->buffer(), allocate);
+}
+
+void IrGraphGenerator::handle(const Split* split) {
+  printExpr(split, IrNodeLabel::gen(split));
+  addArc(split->in(), split);
+  addArc(split, split->out());
+}
+
+void IrGraphGenerator::handle(const Merge* merge) {
+  printExpr(merge, IrNodeLabel::gen(merge));
+  addArc(merge->in(), merge);
+  addArc(merge, merge->out());
+}
+
+void IrGraphGenerator::handle(const Reorder* reorder) {
+  printExpr(reorder, IrNodeLabel::gen(reorder));
+  addArc(reorder->in(), reorder);
+  addArc(reorder, reorder->out());
+}
+
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -35,7 +35,7 @@ class IrNodeLabel : private OptInConstDispatch {
     if (f->isSymbolic()) {
       label_ << "f" << f->name();
     } else {
-      if (detail_level_ > DetailLevel::Basic) {
+      if (detail_level_ >= DetailLevel::Explicit) {
         label_ << "f" << f->name() << "=";
       }
       label_ << std::fixed << std::setprecision(2) << *f->value();
@@ -46,7 +46,7 @@ class IrNodeLabel : private OptInConstDispatch {
     if (i->isSymbolic()) {
       label_ << "i" << i->name();
     } else {
-      if (detail_level_ > DetailLevel::Basic) {
+      if (detail_level_ >= DetailLevel::Explicit) {
         label_ << "i" << i->name() << "=";
       }
       label_ << *i->value();
@@ -268,7 +268,11 @@ void IrGraphGenerator::generateScheduleGraph() {
   // Connect TensorView with their TensorDomain
   // (this will trigger the traversal of the schedule graph)
   for (auto tv : tensor_views_) {
-    addArc(tv->domain(), tv, "[style=dashed]");
+    addArc(tv->domain(), tv, "[style=dashed, arrowhead=none]");
+    if (detail_level_ >= DetailLevel::Explicit) {
+      const auto root_domain = tv->getRootDomain();
+      addArc(tv, root_domain, "[style=dashed, color=green, arrowhead=none]");
+    }
   }
 
   graph_def_ << "  }\n";
@@ -314,7 +318,8 @@ void IrGraphGenerator::handle(const IterDomain* id) {
 
   addArc(id->rawExtent(), id, "[color=gray]");
 
-  if (detail_level_ > DetailLevel::Basic && id->rawExtent() != id->extent()) {
+  if (detail_level_ >= DetailLevel::Explicit &&
+      id->rawExtent() != id->extent()) {
     addArc(id->extent(), id, "[color=gray, style=dashed]");
   }
 }

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -117,13 +117,16 @@ void IrGraphGenerator::print(
     const Fusion* fusion,
     const char* filename,
     DetailLevel detail_level) {
-  // output file
   std::ofstream dot_file(filename);
   TORCH_CHECK(dot_file.good(), "Failed to open the IR graph file");
+  dot_file << toGraphviz(fusion, detail_level);
+}
 
-  // generate the dot graph definition
+std::string IrGraphGenerator::toGraphviz(
+    const Fusion* fusion,
+    DetailLevel detail_level) {
   IrGraphGenerator ir_graph(fusion, detail_level);
-  dot_file << ir_graph.generate();
+  return ir_graph.generate();
 }
 
 IrGraphGenerator::IrGraphGenerator(

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -12,10 +12,6 @@
 
 namespace torch {
 namespace jit {
-
-// Corresponding unit test
-void testGPU_IrGraphGenerator();
-
 namespace fuser {
 
 // Generates a DOT (https://www.graphviz.org) graph
@@ -38,8 +34,6 @@ namespace fuser {
 //    must be used instead)
 //
 class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
-  friend void torch::jit::testGPU_IrGraphGenerator();
-
  public:
   enum class DetailLevel {
     ComputeOnly, // Only dataflow (compute) nodes
@@ -49,11 +43,12 @@ class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
   };
 
  public:
-  // This is the public interface to IrGraphGenerator
   static void print(
       const Fusion* fusion,
       const char* filename,
       DetailLevel detail_level = DetailLevel::Basic);
+
+  static std::string toGraphviz(const Fusion* fusion, DetailLevel detail_level);
 
  private:
   IrGraphGenerator(const Fusion* fusion, DetailLevel detail_level);

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -19,7 +19,24 @@ void testGPU_IrGraphGenerator();
 namespace fuser {
 
 // Generates a DOT (https://www.graphviz.org) graph
-// representation of the Fusion IR
+// representation of a fuser IR
+//
+// Usage:
+// 1) Add calls to IrGraphGenerator::print(), for example:
+//  `IrGraphGenerator::print(&fusion, "ir.dot")`
+//
+// 2) Call IrGraphGenerator::print() from a debugger. Using gdb for example:
+//  `call IrGraphGenerator::print(&fusion, "ir.dot",
+//      IrGraphGenerator::DetailLevel::Explicit)`
+//
+// Notes:
+//  - When called from the debugger, the detail_level must be
+//    explicitly passed in (most debuggers don't support default arguments)
+//
+//  - The output dot file path can't include shell specific notations,
+//    for example you can't use "~/temp/ir.dot" ("/home/user/temp/ir.dot"
+//    must be used instead)
+//
 class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
   friend void torch::jit::testGPU_IrGraphGenerator();
 

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -1,0 +1,104 @@
+
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/jit/codegen/cuda/dispatch.h>
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace torch {
+namespace jit {
+
+// Corresponding unit test
+void testGPU_IrGraphGenerator();
+
+namespace fuser {
+
+// Generates a DOT (https://www.graphviz.org) graph
+// representation of the Fusion IR
+class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
+  friend void torch::jit::testGPU_IrGraphGenerator();
+
+ public:
+  enum class DetailLevel {
+    ComputeOnly, // Only dataflow (compute) nodes
+    Basic, // Compute + schedule, with minimal details (default)
+    Explicit, // Additional details (ex. symbolic names for scalar constants)
+    Verbose, // Includes all values and dead definitions
+  };
+
+ public:
+  // This is the public interface to IrGraphGenerator
+  static void print(
+      const Fusion* fusion,
+      const char* filename,
+      DetailLevel detail_level = DetailLevel::Basic);
+
+ private:
+  IrGraphGenerator(const Fusion* fusion, DetailLevel detail_level);
+  ~IrGraphGenerator() override = default;
+
+  std::string generate();
+
+  void generateComputeGraph();
+  void generateScheduleGraph();
+
+  void handle(const Statement*) override;
+  void handle(const Val*) override;
+  void handle(const Expr*) override;
+
+  void handle(const TensorDomain*) override;
+  void handle(const TensorView*) override;
+  void handle(const IterDomain*) override;
+  void handle(const TensorIndex*) override;
+
+  void handle(const Float*) override;
+  void handle(const Int*) override;
+  void handle(const NamedScalar*) override;
+
+  void handle(const UnaryOp*) override;
+  void handle(const BinaryOp*) override;
+
+  void handle(const ForLoop*) override;
+  void handle(const IfThenElse*) override;
+  void handle(const Allocate*) override;
+
+  void handle(const Split*) override;
+  void handle(const Merge*) override;
+  void handle(const Reorder*) override;
+
+  // lookup the graph id, creating one if not found
+  std::string getid(const Statement* stm);
+
+  bool visited(const Statement* s) const {
+    return visited_.find(s) != visited_.end();
+  }
+
+  void addArc(
+      const Statement* src,
+      const Statement* dst,
+      const std::string& style = "");
+
+  void printExpr(const Expr* expr, const std::string& label);
+  void printValue(const Val* val, const std::string& label);
+
+ private:
+  const DetailLevel detail_level_;
+  const Fusion* const fusion_;
+  std::stringstream graph_def_;
+  std::unordered_map<const Statement*, std::string> id_map_;
+  std::unordered_set<const Statement*> visited_;
+  std::unordered_set<const Val*> inputs_;
+  std::unordered_set<const Val*> outputs_;
+  std::vector<const TensorView*> tensor_views_;
+  std::vector<std::string> arcs_;
+  int next_id_ = 1;
+};
+
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -277,7 +277,9 @@ struct TORCH_CUDA_API IterDomain : public Val {
     return start_;
   }
   Val* extent() const;
-  Val* rawExtent() const { return extent_; }
+  Val* rawExtent() const {
+    return extent_;
+  }
 
   IterDomain(const IterDomain& other) = delete;
   IterDomain& operator=(const IterDomain& other) = delete;

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -277,6 +277,7 @@ struct TORCH_CUDA_API IterDomain : public Val {
     return start_;
   }
   Val* extent() const;
+  Val* rawExtent() const { return extent_; }
 
   IterDomain(const IterDomain& other) = delete;
   IterDomain& operator=(const IterDomain& other) = delete;


### PR DESCRIPTION
Generate graphviz graphs representing fuser IRs. See IrGraphGenerator comments for basic usage and tips.

The generated graphs are saved as local files (the convention is to use .dot extension), which can be used with any graphviz tool:
- xdot 
- http://viz-js.com
- http://graphviz.it

For VS Code users, the tintinweb.graphviz-interactive-preview is highly recommended.
