### PR TITLE
Return TensorView* from arithmetic operations when possible

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -853,8 +853,8 @@ void testGPU_FusionCodeGen() {
   TensorView* tv0 = makeDummyTensor(3);
 
   new BinaryOp(BinaryOpType::Add, tv0, new Float(0.0), new Float(1.0));
-  TensorView* tv1 = static_cast<TensorView*>(add(tv0, new Float(2.0)));
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(3.0)));
+  TensorView* tv1 = add(tv0, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Float(3.0));
   fusion.addOutput(tv2);
 
   //[I0, I1, I2]
@@ -895,8 +895,8 @@ void testGPU_FusionCodeGen2() {
 
   TensorView* tv0 = makeDummyTensor(3);
   TensorView* tv1 = makeDummyTensor(3);
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -953,8 +953,8 @@ void testGPU_FusionSimplePWise() {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
   fusion.addOutput(tv3);
@@ -1012,8 +1012,8 @@ void testGPU_FusionExecKernel() {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
   fusion.addOutput(tv3);
@@ -1075,13 +1075,13 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv0 = makeDummyTensor(2);
     fusion.addInput(tv0);
 
-    TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
-    TensorView* tv2 = static_cast<TensorView*>(add(tv0, new Float(3.0)));
-    TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.0)));
-    TensorView* tv4 = static_cast<TensorView*>(add(tv2, tv1));
+    TensorView* tv1 = mul(tv0, new Float(-1.0));
+    TensorView* tv2 = add(tv0, new Float(3.0));
+    TensorView* tv3 = mul(tv0, new Float(2.0));
+    TensorView* tv4 = add(tv2, tv1);
 
-    TensorView* tv5 = static_cast<TensorView*>(add(tv4, tv3));
-    TensorView* tv6 = static_cast<TensorView*>(add(tv0, tv3));
+    TensorView* tv5 = add(tv4, tv3);
+    TensorView* tv6 = add(tv0, tv3);
 
     fusion.addOutput(tv5);
     fusion.addOutput(tv6);
@@ -1168,13 +1168,13 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv0 = makeDummyTensor(2);
     fusion.addInput(tv0);
 
-    TensorView* tv1 = static_cast<TensorView*>(mul(tv0, new Float(-1.0)));
-    TensorView* tv2 = static_cast<TensorView*>(add(tv0, new Float(3.0)));
-    TensorView* tv3 = static_cast<TensorView*>(mul(tv0, new Float(2.0)));
-    TensorView* tv4 = static_cast<TensorView*>(add(tv2, tv1));
+    TensorView* tv1 = mul(tv0, new Float(-1.0));
+    TensorView* tv2 = add(tv0, new Float(3.0));
+    TensorView* tv3 = mul(tv0, new Float(2.0));
+    TensorView* tv4 = add(tv2, tv1);
 
-    TensorView* tv5 = static_cast<TensorView*>(add(tv4, tv3));
-    TensorView* tv6 = static_cast<TensorView*>(add(tv5, tv3));
+    TensorView* tv5 = add(tv4, tv3);
+    TensorView* tv6 = add(tv5, tv3);
 
     fusion.addOutput(tv5);
     fusion.addOutput(tv6);
@@ -1252,8 +1252,8 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv1 = makeDummyTensor(4);
     fusion.addInput(tv1);
 
-    TensorView* tv2 = static_cast<TensorView*>(mul(tv1, new Float(.979361)));
-    TensorView* tv3 = static_cast<TensorView*>(mul(tv2, tv0));
+    TensorView* tv2 = mul(tv1, new Float(.979361));
+    TensorView* tv3 = mul(tv2, tv0);
 
     fusion.addOutput(tv3);
 
@@ -1325,9 +1325,9 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv3 = makeDummyTensor(4);
     fusion.addInput(tv3);
 
-    TensorView* tv4 = static_cast<TensorView*>(sub(tv2, tv3));
-    TensorView* tv5 = static_cast<TensorView*>(add(tv1, tv4));
-    TensorView* tv6 = static_cast<TensorView*>(sub(tv5, tv0));
+    TensorView* tv4 = sub(tv2, tv3);
+    TensorView* tv5 = add(tv1, tv4);
+    TensorView* tv6 = sub(tv5, tv0);
 
     fusion.addOutput(tv6);
 
@@ -1406,9 +1406,9 @@ void testGPU_FusionScalarInputs() {
   Val* f4 = mul(f0, f1);
   Val* f5 = sub(f2, f3);
 
-  TensorView* tv2 = static_cast<TensorView*>(sub(tv1, f4));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, f5));
-  TensorView* tv4 = static_cast<TensorView*>(mul(tv3, tv2));
+  TensorView* tv2 = sub(tv1, f4);
+  TensorView* tv3 = add(tv0, f5);
+  TensorView* tv4 = mul(tv3, tv2);
 
   fusion.addOutput(tv4);
 
@@ -1499,8 +1499,8 @@ void testGPU_FusionLoopUnroll() {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv2 = static_cast<TensorView*>(add(tv1, new Float(2.0)));
-  TensorView* tv3 = static_cast<TensorView*>(add(tv0, tv2));
+  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
   fusion.addOutput(tv3);
@@ -1560,7 +1560,7 @@ void testGPU_FusionForLoop() {
 
   auto ID0 = new IterDomain(new Int(0), new Int(8));
 
-  TensorView* TV2 = static_cast<TensorView*>(add(TV0, TV1));
+  TensorView* TV2 = add(TV0, TV1);
   BinaryOp* op = static_cast<BinaryOp*>(TV2->getOrigin());
   fusion.addOutput(TV2);
 
@@ -1917,7 +1917,7 @@ void testGPU_FusionBinaryOps() {
         return at::add(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toScalar());
       },
-      /*JIT  Func   */ add_alpha,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&add_alpha),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -1933,7 +1933,7 @@ void testGPU_FusionBinaryOps() {
         return at::sub(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toScalar());
       },
-      /*JIT  Func   */ sub_alpha,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&sub_alpha),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -1982,7 +1982,7 @@ void testGPU_FusionTernaryOps() {
         return at::where(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toTensor());
       },
-      /*JIT  Func   */ where,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&where),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -2001,7 +2001,7 @@ void testGPU_FusionCompoundOps() {
         return at::lerp(
             vals[0].toTensor(), vals[1].toTensor(), vals[2].toTensor());
       },
-      /*JIT  Func   */ lerp,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*)>(&lerp),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -2020,7 +2020,7 @@ void testGPU_FusionCompoundOps() {
             vals[2].toTensor(),
             vals[3].toScalar());
       },
-      /*JIT  Func   */ addcmul,
+      /*JIT  Func   */ static_cast<Val* (*)(Val*, Val*, Val*, Val*)>(&addcmul),
       /*Output      */ std::make_pair(ValType::TensorView, DataType::Float),
       /*Inputs Tuple*/
       std::make_tuple(
@@ -2036,8 +2036,8 @@ void testGPU_FusionCastOps() {
 
   TensorView* tv0 = makeDummyTensor(2, DataType::Half);
 
-  Val* intrm1 = castOp(DataType::Float, tv0);
-  TensorView* out = static_cast<TensorView*>(castOp(DataType::Half, intrm1));
+  TensorView* intrm1 = castOp(DataType::Float, tv0);
+  TensorView* out = castOp(DataType::Half, intrm1);
 
   fusion.addInput(tv0);
   fusion.addOutput(out);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2096,7 +2096,7 @@ void testGPU_FusionRFactorReplay() {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv1 = static_cast<TensorView*>(sum(tv0, {1}));
+  TensorView* tv1 = sum(tv0, {1});
   // tv1[I0, R1]
   tv1->split(0, 32);
   // tv1[I0o, I0i{32}, R1]
@@ -2183,8 +2183,7 @@ void testGPU_FusionReduction() {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = static_cast<TensorView*>(
-      reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0));
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -2252,8 +2251,7 @@ void testGPU_FusionReduction2() {
     fusion.addInput(tv0);
 
     // tv1[I0, R1] = tv0[I0, I1]
-    TensorView* tv1 = static_cast<TensorView*>(
-        reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0));
+    TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
 
     fusion.addOutput(tv1);
 
@@ -2331,8 +2329,7 @@ void testGPU_FusionReduction2() {
     fusion.addInput(tv0);
 
     // tv1[I0, R1] = tv0[I0, I1]
-    TensorView* tv1 = static_cast<TensorView*>(
-        reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0));
+    TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
 
     fusion.addOutput(tv1);
 

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -130,6 +130,9 @@ TORCH_CUDA_API TensorView* unaryOp(UnaryOpType type, TensorView* v1) {
 TORCH_CUDA_API Val* neg(Val* v) {
   return unaryOp(UnaryOpType::Neg, v);
 }
+TORCH_CUDA_API TensorView* neg(TensorView* v) {
+  return unaryOp(UnaryOpType::Neg, v);
+}
 
 // BINARY OPERATIONS
 

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -131,19 +131,19 @@ TORCH_CUDA_API Val* neg(Val* v) {
   return unaryOp(UnaryOpType::Neg, v);
 }
 
-#define BINARY_OP_OVERLOADS_FORWARD(name)                       \
-  return static_cast<TensorView*>(                              \
+#define BINARY_OP_OVERLOADS_FORWARD(name) \
+  return static_cast<TensorView*>(        \
       name(static_cast<Val*>(v1), static_cast<Val*>(v2)))
 
-#define DEFINE_BINARY_OP_OVERLOADS(name)                                \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2) {            \
-    BINARY_OP_OVERLOADS_FORWARD(name);                                  \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2) {            \
-    BINARY_OP_OVERLOADS_FORWARD(name);                                  \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2) {     \
-    BINARY_OP_OVERLOADS_FORWARD(name);                                  \
+#define DEFINE_BINARY_OP_OVERLOADS(name)                            \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2) {        \
+    BINARY_OP_OVERLOADS_FORWARD(name);                              \
+  }                                                                 \
+  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2) {        \
+    BINARY_OP_OVERLOADS_FORWARD(name);                              \
+  }                                                                 \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2) { \
+    BINARY_OP_OVERLOADS_FORWARD(name);                              \
   }
 
 // BINARY OPERATIONS
@@ -161,16 +161,26 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   return out;
 }
 
-
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2) {
-  return static_cast<TensorView*>(binaryOp(type, static_cast<TensorView*>(v1), v2));
+TORCH_CUDA_API TensorView* binaryOp(
+    BinaryOpType type,
+    TensorView* v1,
+    Val* v2) {
+  return static_cast<TensorView*>(
+      binaryOp(type, static_cast<TensorView*>(v1), v2));
 }
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2) {
-  return static_cast<TensorView*>(binaryOp(type, v1, static_cast<TensorView*>(v2)));
+TORCH_CUDA_API TensorView* binaryOp(
+    BinaryOpType type,
+    Val* v1,
+    TensorView* v2) {
+  return static_cast<TensorView*>(
+      binaryOp(type, v1, static_cast<TensorView*>(v2)));
 }
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2) {
-  return static_cast<TensorView*>(binaryOp(type, static_cast<TensorView*>(v1),
-                                           static_cast<TensorView*>(v2)));
+TORCH_CUDA_API TensorView* binaryOp(
+    BinaryOpType type,
+    TensorView* v1,
+    TensorView* v2) {
+  return static_cast<TensorView*>(binaryOp(
+      type, static_cast<TensorView*>(v1), static_cast<TensorView*>(v2)));
 }
 
 TORCH_CUDA_API Val* add(Val* v1, Val* v2) {
@@ -298,80 +308,74 @@ TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& axes) {
 
 // COMPOUND OPERATIONS
 
-#define TERNARY_OP_OVERLOADS_FORWARD(name)                      \
-  return static_cast<TensorView*>(                              \
-      name(static_cast<Val*>(v1), static_cast<Val*>(v2),        \
-           static_cast<Val*>(v3)))
-#define QUATERNARY_OP_OVERLOADS_FORWARD(name)                   \
-  return static_cast<TensorView*>(                              \
-      name(static_cast<Val*>(v1), static_cast<Val*>(v2),        \
-           static_cast<Val*>(v3), static_cast<Val*>(v4)))
+#define TERNARY_OP_OVERLOADS_FORWARD(name) \
+  return static_cast<TensorView*>(name(    \
+      static_cast<Val*>(v1), static_cast<Val*>(v2), static_cast<Val*>(v3)))
+#define QUATERNARY_OP_OVERLOADS_FORWARD(name) \
+  return static_cast<TensorView*>(name(       \
+      static_cast<Val*>(v1),                  \
+      static_cast<Val*>(v2),                  \
+      static_cast<Val*>(v3),                  \
+      static_cast<Val*>(v4)))
 
-#define DEFINE_TERNARY_OP_OVERLOADS(name)                               \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3) {   \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3) {   \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, Val* v2, TensorView* v3) {   \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2,       \
-                                  Val* v3) {                            \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2,              \
-                                  TensorView* v3) {                     \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2,              \
-                                  TensorView* v3) {                     \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2,       \
-                                  TensorView* v3) {                     \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
+#define DEFINE_TERNARY_OP_OVERLOADS(name)                                    \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3) {        \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3) {        \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(Val* v1, Val* v2, TensorView* v3) {        \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2, Val* v3) { \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, TensorView* v3) { \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, TensorView* v3) { \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(                                           \
+      TensorView* v1, TensorView* v2, TensorView* v3) {                      \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
   }
-#define DEFINE_TERNARY_OP_OVERLOADS2(name)                              \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3) {   \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3) {   \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2,       \
-                                  Val* v3) {                            \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                 \
+#define DEFINE_TERNARY_OP_OVERLOADS2(name)                                   \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3) {        \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3) {        \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
+  }                                                                          \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2, Val* v3) { \
+    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
   }
-#define DEFINE_QUTERNARY_OP_OVERLOADS3(name)                            \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2,              \
-                                  Val* v3, Val* v4) {                   \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2,              \
-                                  Val* v3, Val* v4) {                   \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, Val* v2, TensorView* v3,     \
-                                  Val* v4) {                            \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2,       \
-                                  Val* v3, Val* v4) {                   \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2,              \
-                                  TensorView* v3, Val* v4) {            \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2,              \
-                                  TensorView* v3, Val* v4) {            \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                     \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2,       \
-                                  TensorView* v3, Val* v4) {            \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                              \
+#define DEFINE_QUTERNARY_OP_OVERLOADS3(name)                                   \
+  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3, Val* v4) { \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
+  }                                                                            \
+  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3, Val* v4) { \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
+  }                                                                            \
+  TORCH_CUDA_API TensorView* name(Val* v1, Val* v2, TensorView* v3, Val* v4) { \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
+  }                                                                            \
+  TORCH_CUDA_API TensorView* name(                                             \
+      TensorView* v1, TensorView* v2, Val* v3, Val* v4) {                      \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
+  }                                                                            \
+  TORCH_CUDA_API TensorView* name(                                             \
+      TensorView* v1, Val* v2, TensorView* v3, Val* v4) {                      \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
+  }                                                                            \
+  TORCH_CUDA_API TensorView* name(                                             \
+      Val* v1, TensorView* v2, TensorView* v3, Val* v4) {                      \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
+  }                                                                            \
+  TORCH_CUDA_API TensorView* name(                                             \
+      TensorView* v1, TensorView* v2, TensorView* v3, Val* v4) {               \
+    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
   }
 
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s) {
@@ -452,8 +456,8 @@ TORCH_CUDA_API Val* threshold(Val* in, Val* thresh, Val* value) {
 }
 
 TORCH_CUDA_API TensorView* threshold(TensorView* in, Val* thresh, Val* value) {
-  return static_cast<TensorView*>(threshold(static_cast<Val*>(in),
-                                            thresh, value));
+  return static_cast<TensorView*>(
+      threshold(static_cast<Val*>(in), thresh, value));
 }
 
 TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val) {
@@ -474,8 +478,8 @@ TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val) {
 }
 
 TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val) {
-  return static_cast<TensorView*>(clamp(static_cast<Val*>(in),
-                                        min_val, max_val));
+  return static_cast<TensorView*>(
+      clamp(static_cast<Val*>(in), min_val, max_val));
 }
 
 #undef TERNARY_OP_OVERLOADS_FORWARD

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -112,7 +112,7 @@ TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1) {
 }
 
 TORCH_CUDA_API TensorView* castOp(DataType dtype, TensorView* v1) {
-  return static_cast<TensorView*>(castOp(dtype, static_cast<Val*>(v1)));
+  return castOp(dtype, static_cast<Val*>(v1))->as<TensorView>();
 }
 
 // UNARY OPERATIONS
@@ -124,7 +124,7 @@ TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1) {
 }
 
 TORCH_CUDA_API TensorView* unaryOp(UnaryOpType type, TensorView* v1) {
-  return static_cast<TensorView*>(unaryOp(type, static_cast<Val*>(v1)));
+  return unaryOp(type, static_cast<Val*>(v1))->as<TensorView>();
 }
 
 TORCH_CUDA_API Val* neg(Val* v) {
@@ -140,13 +140,13 @@ namespace {
 // Helper function to reduce repetitive code
 template <typename T1, typename T2>
 TensorView* arithOpOverloads(Val* (*func)(Val*, Val*), T1* v1, T2* v2) {
-  return static_cast<TensorView*>(
-      func(static_cast<Val*>(v1), static_cast<Val*>(v2)));
+  return func(v1->template as<Val>(), v2->template as<Val>())
+      ->template as<TensorView>();
 }
 template <typename T1, typename T2>
 TensorView* arithOpOverloads(BinaryOpType type, T1* v1, T2* v2) {
-  return static_cast<TensorView*>(
-      binaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2)));
+  return binaryOp(type, v1->template as<Val>(), v2->template as<Val>())
+      ->template as<TensorView>();
 }
 template <typename T1, typename T2, typename T3>
 TensorView* arithOpOverloads(
@@ -154,8 +154,11 @@ TensorView* arithOpOverloads(
     T1* v1,
     T2* v2,
     T3* v3) {
-  return static_cast<TensorView*>(func(
-      static_cast<Val*>(v1), static_cast<Val*>(v2), static_cast<Val*>(v3)));
+  return func(
+             v1->template as<Val>(),
+             v2->template as<Val>(),
+             v3->template as<Val>())
+      ->template as<TensorView>();
 }
 template <typename T1, typename T2, typename T3, typename T4>
 TensorView* arithOpOverloads(
@@ -164,11 +167,12 @@ TensorView* arithOpOverloads(
     T2* v2,
     T3* v3,
     T4* v4) {
-  return static_cast<TensorView*>(func(
-      static_cast<Val*>(v1),
-      static_cast<Val*>(v2),
-      static_cast<Val*>(v3),
-      static_cast<Val*>(v4)));
+  return func(
+             v1->template as<Val>(),
+             v2->template as<Val>(),
+             v3->template as<Val>(),
+             v4->template as<Val>())
+      ->template as<TensorView>();
 }
 } // namespace
 
@@ -547,8 +551,7 @@ TORCH_CUDA_API Val* threshold(Val* in, Val* thresh, Val* value) {
 }
 
 TORCH_CUDA_API TensorView* threshold(TensorView* in, Val* thresh, Val* value) {
-  return static_cast<TensorView*>(
-      threshold(static_cast<Val*>(in), thresh, value));
+  return threshold(static_cast<Val*>(in), thresh, value)->as<TensorView>();
 }
 
 TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val) {
@@ -569,8 +572,7 @@ TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val) {
 }
 
 TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val) {
-  return static_cast<TensorView*>(
-      clamp(static_cast<Val*>(in), min_val, max_val));
+  return clamp(static_cast<Val*>(in), min_val, max_val)->as<TensorView>();
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -180,7 +180,7 @@ TORCH_CUDA_API Val* andOp(Val* v1, Val* v2) {
 
 // REDUCTION OPERATIONS
 
-Val* reductionOp(
+TensorView* reductionOp(
     BinaryOpType reduction_op_type,
     const std::vector<int>& axes,
     Val* init,
@@ -216,14 +216,14 @@ Val* reductionOp(
     uint_axes.push_back((unsigned int)axis);
   }
 
-  Val* out = tv->newForReduction(uint_axes);
+  TensorView* out = tv->newForReduction(uint_axes);
   if (init->getDataType().value() != v1->getDataType().value())
     init = castOp(v1->getDataType().value(), init);
   new ReductionOp(reduction_op_type, init, out, v1);
   return out;
 }
 
-TORCH_CUDA_API Val* sum(Val* v1, const std::vector<int>& axes) {
+TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& axes) {
   Val* init;
   switch (v1->getDataType().value()) {
     case (DataType::Float):

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -131,22 +131,43 @@ TORCH_CUDA_API Val* neg(Val* v) {
   return unaryOp(UnaryOpType::Neg, v);
 }
 
-#define BINARY_OP_OVERLOADS_FORWARD(name) \
-  return static_cast<TensorView*>(        \
-      name(static_cast<Val*>(v1), static_cast<Val*>(v2)))
-
-#define DEFINE_BINARY_OP_OVERLOADS(name)                            \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2) {        \
-    BINARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                 \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2) {        \
-    BINARY_OP_OVERLOADS_FORWARD(name);                              \
-  }                                                                 \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2) { \
-    BINARY_OP_OVERLOADS_FORWARD(name);                              \
-  }
-
 // BINARY OPERATIONS
+
+namespace {
+// Helper function to reduce repetitive code
+template <typename T1, typename T2>
+TensorView* arithOpOverloads(Val* (*func)(Val*, Val*), T1* v1, T2* v2) {
+  return static_cast<TensorView*>(
+      func(static_cast<Val*>(v1), static_cast<Val*>(v2)));
+}
+template <typename T1, typename T2>
+TensorView* arithOpOverloads(BinaryOpType type, T1* v1, T2* v2) {
+  return static_cast<TensorView*>(
+      binaryOp(type, static_cast<Val*>(v1), static_cast<Val*>(v2)));
+}
+template <typename T1, typename T2, typename T3>
+TensorView* arithOpOverloads(
+    Val* (*func)(Val*, Val*, Val*),
+    T1* v1,
+    T2* v2,
+    T3* v3) {
+  return static_cast<TensorView*>(func(
+      static_cast<Val*>(v1), static_cast<Val*>(v2), static_cast<Val*>(v3)));
+}
+template <typename T1, typename T2, typename T3, typename T4>
+TensorView* arithOpOverloads(
+    Val* (*func)(Val*, Val*, Val*, Val*),
+    T1* v1,
+    T2* v2,
+    T3* v3,
+    T4* v4) {
+  return static_cast<TensorView*>(func(
+      static_cast<Val*>(v1),
+      static_cast<Val*>(v2),
+      static_cast<Val*>(v3),
+      static_cast<Val*>(v4)));
+}
+} // namespace
 
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   Val* out = promoteNew(v1, v2);
@@ -160,71 +181,117 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   new BinaryOp(type, out, v1, v2);
   return out;
 }
-
 TORCH_CUDA_API TensorView* binaryOp(
     BinaryOpType type,
     TensorView* v1,
     Val* v2) {
-  return static_cast<TensorView*>(
-      binaryOp(type, static_cast<TensorView*>(v1), v2));
+  return arithOpOverloads(type, v1, v2);
 }
 TORCH_CUDA_API TensorView* binaryOp(
     BinaryOpType type,
     Val* v1,
     TensorView* v2) {
-  return static_cast<TensorView*>(
-      binaryOp(type, v1, static_cast<TensorView*>(v2)));
+  return arithOpOverloads(type, v1, v2);
 }
 TORCH_CUDA_API TensorView* binaryOp(
     BinaryOpType type,
     TensorView* v1,
     TensorView* v2) {
-  return static_cast<TensorView*>(binaryOp(
-      type, static_cast<TensorView*>(v1), static_cast<TensorView*>(v2)));
+  return arithOpOverloads(type, v1, v2);
 }
 
+// add
 TORCH_CUDA_API Val* add(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Add, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(add)
-
+TORCH_CUDA_API TensorView* add(TensorView* v1, Val* v2) {
+  return arithOpOverloads(add, v1, v2);
+}
+TORCH_CUDA_API TensorView* add(Val* v1, TensorView* v2) {
+  return arithOpOverloads(add, v1, v2);
+}
+TORCH_CUDA_API TensorView* add(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(add, v1, v2);
+}
+// sub
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Sub, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(sub)
-
+TORCH_CUDA_API TensorView* sub(TensorView* v1, Val* v2) {
+  return arithOpOverloads(sub, v1, v2);
+}
+TORCH_CUDA_API TensorView* sub(Val* v1, TensorView* v2) {
+  return arithOpOverloads(sub, v1, v2);
+}
+TORCH_CUDA_API TensorView* sub(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(sub, v1, v2);
+}
+// mul
 TORCH_CUDA_API Val* mul(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Mul, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(mul)
-
+TORCH_CUDA_API TensorView* mul(TensorView* v1, Val* v2) {
+  return arithOpOverloads(mul, v1, v2);
+}
+TORCH_CUDA_API TensorView* mul(Val* v1, TensorView* v2) {
+  return arithOpOverloads(mul, v1, v2);
+}
+TORCH_CUDA_API TensorView* mul(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(mul, v1, v2);
+}
+// div
 TORCH_CUDA_API Val* div(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Div, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(div)
-
+TORCH_CUDA_API TensorView* div(TensorView* v1, Val* v2) {
+  return arithOpOverloads(div, v1, v2);
+}
+TORCH_CUDA_API TensorView* div(Val* v1, TensorView* v2) {
+  return arithOpOverloads(div, v1, v2);
+}
+TORCH_CUDA_API TensorView* div(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(div, v1, v2);
+}
+// mod
 TORCH_CUDA_API Val* mod(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Mod, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(mod)
-
+TORCH_CUDA_API TensorView* mod(TensorView* v1, Val* v2) {
+  return arithOpOverloads(mod, v1, v2);
+}
+TORCH_CUDA_API TensorView* mod(Val* v1, TensorView* v2) {
+  return arithOpOverloads(mod, v1, v2);
+}
+TORCH_CUDA_API TensorView* mod(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(mod, v1, v2);
+}
+// lt
 TORCH_CUDA_API Val* lt(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::LT, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(lt)
-
+TORCH_CUDA_API TensorView* lt(TensorView* v1, Val* v2) {
+  return arithOpOverloads(lt, v1, v2);
+}
+TORCH_CUDA_API TensorView* lt(Val* v1, TensorView* v2) {
+  return arithOpOverloads(lt, v1, v2);
+}
+TORCH_CUDA_API TensorView* lt(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(lt, v1, v2);
+}
+// ceilDiv
 TORCH_CUDA_API Val* ceilDiv(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::CeilDiv, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(ceilDiv)
-
+TORCH_CUDA_API TensorView* ceilDiv(TensorView* v1, Val* v2) {
+  return arithOpOverloads(ceilDiv, v1, v2);
+}
+TORCH_CUDA_API TensorView* ceilDiv(Val* v1, TensorView* v2) {
+  return arithOpOverloads(ceilDiv, v1, v2);
+}
+TORCH_CUDA_API TensorView* ceilDiv(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(ceilDiv, v1, v2);
+}
+// andOp
 TORCH_CUDA_API Val* andOp(Val* v1, Val* v2) {
   TORCH_CHECK(
       v1->getDataType().value() == DataType::Bool,
@@ -236,11 +303,15 @@ TORCH_CUDA_API Val* andOp(Val* v1, Val* v2) {
       v2->getDataType().value());
   return binaryOp(BinaryOpType::And, v1, v2);
 }
-
-DEFINE_BINARY_OP_OVERLOADS(andOp)
-
-#undef BINARY_OP_OVERLOADS_FORWARD
-#undef DEFINE_BINARY_OP_OVERLOADS
+TORCH_CUDA_API TensorView* andOp(TensorView* v1, Val* v2) {
+  return arithOpOverloads(andOp, v1, v2);
+}
+TORCH_CUDA_API TensorView* andOp(Val* v1, TensorView* v2) {
+  return arithOpOverloads(andOp, v1, v2);
+}
+TORCH_CUDA_API TensorView* andOp(TensorView* v1, TensorView* v2) {
+  return arithOpOverloads(andOp, v1, v2);
+}
 
 // REDUCTION OPERATIONS
 
@@ -308,76 +379,7 @@ TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& axes) {
 
 // COMPOUND OPERATIONS
 
-#define TERNARY_OP_OVERLOADS_FORWARD(name) \
-  return static_cast<TensorView*>(name(    \
-      static_cast<Val*>(v1), static_cast<Val*>(v2), static_cast<Val*>(v3)))
-#define QUATERNARY_OP_OVERLOADS_FORWARD(name) \
-  return static_cast<TensorView*>(name(       \
-      static_cast<Val*>(v1),                  \
-      static_cast<Val*>(v2),                  \
-      static_cast<Val*>(v3),                  \
-      static_cast<Val*>(v4)))
-
-#define DEFINE_TERNARY_OP_OVERLOADS(name)                                    \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3) {        \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3) {        \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(Val* v1, Val* v2, TensorView* v3) {        \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2, Val* v3) { \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, TensorView* v3) { \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, TensorView* v3) { \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(                                           \
-      TensorView* v1, TensorView* v2, TensorView* v3) {                      \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }
-#define DEFINE_TERNARY_OP_OVERLOADS2(name)                                   \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3) {        \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3) {        \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }                                                                          \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, TensorView* v2, Val* v3) { \
-    TERNARY_OP_OVERLOADS_FORWARD(name);                                      \
-  }
-#define DEFINE_QUTERNARY_OP_OVERLOADS3(name)                                   \
-  TORCH_CUDA_API TensorView* name(TensorView* v1, Val* v2, Val* v3, Val* v4) { \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }                                                                            \
-  TORCH_CUDA_API TensorView* name(Val* v1, TensorView* v2, Val* v3, Val* v4) { \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }                                                                            \
-  TORCH_CUDA_API TensorView* name(Val* v1, Val* v2, TensorView* v3, Val* v4) { \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }                                                                            \
-  TORCH_CUDA_API TensorView* name(                                             \
-      TensorView* v1, TensorView* v2, Val* v3, Val* v4) {                      \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }                                                                            \
-  TORCH_CUDA_API TensorView* name(                                             \
-      TensorView* v1, Val* v2, TensorView* v3, Val* v4) {                      \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }                                                                            \
-  TORCH_CUDA_API TensorView* name(                                             \
-      Val* v1, TensorView* v2, TensorView* v3, Val* v4) {                      \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }                                                                            \
-  TORCH_CUDA_API TensorView* name(                                             \
-      TensorView* v1, TensorView* v2, TensorView* v3, Val* v4) {               \
-    QUATERNARY_OP_OVERLOADS_FORWARD(name);                                     \
-  }
-
+// add_alpha
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s) {
   TORCH_CHECK(
       s->getValType().value() == ValType::Scalar,
@@ -387,9 +389,16 @@ TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s) {
   Val* intrm = binaryOp(BinaryOpType::Mul, v2, s);
   return binaryOp(BinaryOpType::Add, v1, intrm);
 }
-
-DEFINE_TERNARY_OP_OVERLOADS2(add_alpha)
-
+TORCH_CUDA_API TensorView* add_alpha(TensorView* v1, Val* v2, Val* v3) {
+  return arithOpOverloads(add_alpha, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* add_alpha(Val* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(add_alpha, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* add_alpha(TensorView* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(add_alpha, v1, v2, v3);
+}
+// sub_alpha
 TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s) {
   TORCH_CHECK(
       s->getValType().value() == ValType::Scalar,
@@ -399,17 +408,46 @@ TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s) {
   Val* intrm = binaryOp(BinaryOpType::Mul, v2, s);
   return binaryOp(BinaryOpType::Sub, v1, intrm);
 }
-
-DEFINE_TERNARY_OP_OVERLOADS2(sub_alpha)
-
+TORCH_CUDA_API TensorView* sub_alpha(TensorView* v1, Val* v2, Val* v3) {
+  return arithOpOverloads(sub_alpha, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* sub_alpha(Val* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(sub_alpha, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* sub_alpha(TensorView* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(sub_alpha, v1, v2, v3);
+}
+// lerp
 TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight) {
   Val* intrm1 = binaryOp(BinaryOpType::Sub, end, start);
   Val* intrm2 = binaryOp(BinaryOpType::Mul, weight, intrm1);
   return binaryOp(BinaryOpType::Add, start, intrm2);
 }
-
-DEFINE_TERNARY_OP_OVERLOADS(lerp)
-
+TORCH_CUDA_API TensorView* lerp(TensorView* v1, Val* v2, Val* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* lerp(Val* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* lerp(Val* v1, Val* v2, TensorView* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* lerp(TensorView* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* lerp(TensorView* v1, Val* v2, TensorView* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* lerp(Val* v1, TensorView* v2, TensorView* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* lerp(
+    TensorView* v1,
+    TensorView* v2,
+    TensorView* v3) {
+  return arithOpOverloads(lerp, v1, v2, v3);
+}
+// addcmul
 TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s) {
   TORCH_CHECK(
       s->getValType().value() == ValType::Scalar,
@@ -420,11 +458,46 @@ TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s) {
   Val* intrm2 = binaryOp(BinaryOpType::Mul, v2, intrm1);
   return binaryOp(BinaryOpType::Add, v1, intrm2);
 }
-
-DEFINE_QUTERNARY_OP_OVERLOADS3(addcmul)
+TORCH_CUDA_API TensorView* addcmul(TensorView* v1, Val* v2, Val* v3, Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
+TORCH_CUDA_API TensorView* addcmul(Val* v1, TensorView* v2, Val* v3, Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
+TORCH_CUDA_API TensorView* addcmul(Val* v1, Val* v2, TensorView* v3, Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
+TORCH_CUDA_API TensorView* addcmul(
+    TensorView* v1,
+    TensorView* v2,
+    Val* v3,
+    Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
+TORCH_CUDA_API TensorView* addcmul(
+    TensorView* v1,
+    Val* v2,
+    TensorView* v3,
+    Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
+TORCH_CUDA_API TensorView* addcmul(
+    Val* v1,
+    TensorView* v2,
+    TensorView* v3,
+    Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
+TORCH_CUDA_API TensorView* addcmul(
+    TensorView* v1,
+    TensorView* v2,
+    TensorView* v3,
+    Val* v4) {
+  return arithOpOverloads(addcmul, v1, v2, v3, v4);
+}
 
 // TERNARY OPERATIONS
-
+// where
 TORCH_CUDA_API Val* where(Val* c, Val* v1, Val* v2) {
   TORCH_CHECK(
       c->getDataType().value() == DataType::Bool,
@@ -435,8 +508,30 @@ TORCH_CUDA_API Val* where(Val* c, Val* v1, Val* v2) {
   new TernaryOp(TernaryOpType::Where, out, c, v1, v2);
   return out;
 }
-
-DEFINE_TERNARY_OP_OVERLOADS(where)
+TORCH_CUDA_API TensorView* where(TensorView* v1, Val* v2, Val* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* where(Val* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* where(Val* v1, Val* v2, TensorView* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* where(TensorView* v1, TensorView* v2, Val* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* where(TensorView* v1, Val* v2, TensorView* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* where(Val* v1, TensorView* v2, TensorView* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
+TORCH_CUDA_API TensorView* where(
+    TensorView* v1,
+    TensorView* v2,
+    TensorView* v3) {
+  return arithOpOverloads(where, v1, v2, v3);
+}
 
 TORCH_CUDA_API Val* threshold(Val* in, Val* thresh, Val* value) {
   TORCH_CHECK(
@@ -481,11 +576,6 @@ TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val) {
   return static_cast<TensorView*>(
       clamp(static_cast<Val*>(in), min_val, max_val));
 }
-
-#undef TERNARY_OP_OVERLOADS_FORWARD
-#undef DEFINE_TERNARY_OP_OVERLOADS
-#undef DEFINE_TERNARY_OP_OVERLOADS2
-#undef DEFINE_QUTERNARY_OP_OVERLOADS3
 
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -112,7 +112,7 @@ TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1) {
 }
 
 TORCH_CUDA_API TensorView* castOp(DataType dtype, TensorView* v1) {
-  return static_cast<TensorView*>(castOp(dtype, static_cast<TensorView*>(v1)));
+  return static_cast<TensorView*>(castOp(dtype, static_cast<Val*>(v1)));
 }
 
 // UNARY OPERATIONS
@@ -124,7 +124,7 @@ TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1) {
 }
 
 TORCH_CUDA_API TensorView* unaryOp(UnaryOpType type, TensorView* v1) {
-  return static_cast<TensorView*>(unaryOp(type, static_cast<TensorView*>(v1)));
+  return static_cast<TensorView*>(unaryOp(type, static_cast<Val*>(v1)));
 }
 
 TORCH_CUDA_API Val* neg(Val* v) {

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -50,6 +50,7 @@ TORCH_CUDA_API TensorView* reductionOp(
 
 // UNARY OPERATIONS
 TORCH_CUDA_API Val* neg(Val* v);
+TORCH_CUDA_API TensorView* neg(TensorView* v);
 
 // BINARY OPERATIONS
 // add

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -34,7 +34,7 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
 
 // Perform a reduction operation on v1, initial value for reduction is init,
 // reduces across axes, and reduction operation defined by BinaryOp.
-TORCH_CUDA_API Val* reductionOp(
+TORCH_CUDA_API TensorView* reductionOp(
     BinaryOpType reduction_op_type,
     const std::vector<int>& axes,
     Val* init,
@@ -54,7 +54,7 @@ TORCH_CUDA_API Val* ceilDiv(Val* v1, Val* v2);
 TORCH_CUDA_API Val* andOp(Val* v1, Val* v2);
 
 // REDUCTION OPERATIONS
-TORCH_CUDA_API Val* sum(Val* v1, const std::vector<int>& reduction_axes);
+TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& reduction_axes);
 
 // COMPOUND OPERATIONS
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -46,7 +46,7 @@ TORCH_CUDA_API TensorView* reductionOp(
     BinaryOpType reduction_op_type,
     const std::vector<int>& axes,
     Val* init,
-    Val* v1);
+    TensorView* v1);
 
 // UNARY OPERATIONS
 TORCH_CUDA_API Val* neg(Val* v);
@@ -94,7 +94,9 @@ TORCH_CUDA_API TensorView* andOp(Val* v1, TensorView* v2);
 TORCH_CUDA_API TensorView* andOp(TensorView* v1, TensorView* v2);
 
 // REDUCTION OPERATIONS
-TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& reduction_axes);
+TORCH_CUDA_API TensorView* sum(
+    TensorView* v1,
+    const std::vector<int>& reduction_axes);
 
 // COMPOUND OPERATIONS
 // add_alpha

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -35,7 +35,10 @@ TORCH_CUDA_API TensorView* unaryOp(UnaryOpType type, TensorView* v1);
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
 TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2);
 TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2);
-TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* binaryOp(
+    BinaryOpType type,
+    TensorView* v1,
+    TensorView* v2);
 
 // Perform a reduction operation on v1, initial value for reduction is init,
 // reduces across axes, and reduction operation defined by BinaryOp.
@@ -109,19 +112,47 @@ TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
 TORCH_CUDA_API TensorView* lerp(TensorView* start, Val* end, Val* weight);
 TORCH_CUDA_API TensorView* lerp(Val* start, TensorView* end, Val* weight);
 TORCH_CUDA_API TensorView* lerp(Val* start, Val* end, TensorView* weight);
-TORCH_CUDA_API TensorView* lerp(TensorView* start, TensorView* end, Val* weight);
-TORCH_CUDA_API TensorView* lerp(TensorView* start, Val* end, TensorView* weight);
-TORCH_CUDA_API TensorView* lerp(Val* start, TensorView* end, TensorView* weight);
-TORCH_CUDA_API TensorView* lerp(TensorView* start, TensorView* end, TensorView* weight);
+TORCH_CUDA_API TensorView* lerp(
+    TensorView* start,
+    TensorView* end,
+    Val* weight);
+TORCH_CUDA_API TensorView* lerp(
+    TensorView* start,
+    Val* end,
+    TensorView* weight);
+TORCH_CUDA_API TensorView* lerp(
+    Val* start,
+    TensorView* end,
+    TensorView* weight);
+TORCH_CUDA_API TensorView* lerp(
+    TensorView* start,
+    TensorView* end,
+    TensorView* weight);
 // addcmul
 TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
 TORCH_CUDA_API TensorView* addcmul(TensorView* v1, Val* v2, Val* v3, Val* s);
 TORCH_CUDA_API TensorView* addcmul(Val* v1, TensorView* v2, Val* v3, Val* s);
 TORCH_CUDA_API TensorView* addcmul(Val* v1, Val* v2, TensorView* v3, Val* s);
-TORCH_CUDA_API TensorView* addcmul(TensorView* v1, TensorView* v2, Val* v3, Val* s);
-TORCH_CUDA_API TensorView* addcmul(TensorView* v1, Val* v2, TensorView* v3, Val* s);
-TORCH_CUDA_API TensorView* addcmul(Val* v1, TensorView* v2, TensorView* v3, Val* s);
-TORCH_CUDA_API TensorView* addcmul(TensorView* v1, TensorView* v2, TensorView* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(
+    TensorView* v1,
+    TensorView* v2,
+    Val* v3,
+    Val* s);
+TORCH_CUDA_API TensorView* addcmul(
+    TensorView* v1,
+    Val* v2,
+    TensorView* v3,
+    Val* s);
+TORCH_CUDA_API TensorView* addcmul(
+    Val* v1,
+    TensorView* v2,
+    TensorView* v3,
+    Val* s);
+TORCH_CUDA_API TensorView* addcmul(
+    TensorView* v1,
+    TensorView* v2,
+    TensorView* v3,
+    Val* s);
 
 // TERNARY OPERATIONS
 // where

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -24,13 +24,18 @@ TORCH_CUDA_API Val* promoteNew(Val* v1, Val* v2);
 
 // Insertion of casting op to dtype, returns new resulting val
 TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1);
+TORCH_CUDA_API TensorView* castOp(DataType dtype, TensorView* v1);
 
 // Perform unary op type and return the output
 TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1);
+TORCH_CUDA_API TensorView* unaryOp(UnaryOpType type, TensorView* v1);
 
 // Perform binary op type on v1 and v2 and return a type promoted output.
 // Mod, CeilDiv, and LT are considered Int only output operations for now.
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2);
 
 // Perform a reduction operation on v1, initial value for reduction is init,
 // reduces across axes, and reduction operation defined by BinaryOp.
@@ -44,28 +49,96 @@ TORCH_CUDA_API TensorView* reductionOp(
 TORCH_CUDA_API Val* neg(Val* v);
 
 // BINARY OPERATIONS
+// add
 TORCH_CUDA_API Val* add(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* add(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* add(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* add(TensorView* v1, TensorView* v2);
+// sub
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* sub(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* sub(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* sub(TensorView* v1, TensorView* v2);
+// mul
 TORCH_CUDA_API Val* mul(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* mul(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* mul(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* mul(TensorView* v1, TensorView* v2);
+// div
 TORCH_CUDA_API Val* div(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* div(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* div(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* div(TensorView* v1, TensorView* v2);
+// mod
 TORCH_CUDA_API Val* mod(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* mod(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* mod(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* mod(TensorView* v1, TensorView* v2);
+// lt
 TORCH_CUDA_API Val* lt(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* lt(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* lt(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* lt(TensorView* v1, TensorView* v2);
+// ceilDiv
 TORCH_CUDA_API Val* ceilDiv(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* ceilDiv(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* ceilDiv(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* ceilDiv(TensorView* v1, TensorView* v2);
+// andOp
 TORCH_CUDA_API Val* andOp(Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* andOp(TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* andOp(Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* andOp(TensorView* v1, TensorView* v2);
 
 // REDUCTION OPERATIONS
 TORCH_CUDA_API TensorView* sum(Val* v1, const std::vector<int>& reduction_axes);
 
 // COMPOUND OPERATIONS
+// add_alpha
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s);
+TORCH_CUDA_API TensorView* add_alpha(TensorView* v1, Val* v2, Val* s);
+TORCH_CUDA_API TensorView* add_alpha(Val* v1, TensorView* v2, Val* s);
+TORCH_CUDA_API TensorView* add_alpha(TensorView* v1, TensorView* v2, Val* s);
+// sub_alpha
 TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s);
+TORCH_CUDA_API TensorView* sub_alpha(TensorView* v1, Val* v2, Val* s);
+TORCH_CUDA_API TensorView* sub_alpha(Val* v1, TensorView* v2, Val* s);
+TORCH_CUDA_API TensorView* sub_alpha(TensorView* v1, TensorView* v2, Val* s);
+// lerp
 TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
+TORCH_CUDA_API TensorView* lerp(TensorView* start, Val* end, Val* weight);
+TORCH_CUDA_API TensorView* lerp(Val* start, TensorView* end, Val* weight);
+TORCH_CUDA_API TensorView* lerp(Val* start, Val* end, TensorView* weight);
+TORCH_CUDA_API TensorView* lerp(TensorView* start, TensorView* end, Val* weight);
+TORCH_CUDA_API TensorView* lerp(TensorView* start, Val* end, TensorView* weight);
+TORCH_CUDA_API TensorView* lerp(Val* start, TensorView* end, TensorView* weight);
+TORCH_CUDA_API TensorView* lerp(TensorView* start, TensorView* end, TensorView* weight);
+// addcmul
 TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
-TORCH_CUDA_API Val* where(Val* c, Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* addcmul(TensorView* v1, Val* v2, Val* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(Val* v1, TensorView* v2, Val* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(Val* v1, Val* v2, TensorView* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(TensorView* v1, TensorView* v2, Val* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(TensorView* v1, Val* v2, TensorView* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(Val* v1, TensorView* v2, TensorView* v3, Val* s);
+TORCH_CUDA_API TensorView* addcmul(TensorView* v1, TensorView* v2, TensorView* v3, Val* s);
 
 // TERNARY OPERATIONS
+// where
+TORCH_CUDA_API Val* where(Val* c, Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* where(TensorView* c, Val* v1, Val* v2);
+TORCH_CUDA_API TensorView* where(Val* c, TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* where(Val* c, Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* where(TensorView* c, TensorView* v1, Val* v2);
+TORCH_CUDA_API TensorView* where(TensorView* c, Val* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* where(Val* c, TensorView* v1, TensorView* v2);
+TORCH_CUDA_API TensorView* where(TensorView* c, TensorView* v1, TensorView* v2);
+// threshold
 TORCH_CUDA_API Val* threshold(Val* in, Val* thresh, Val* value);
+TORCH_CUDA_API TensorView* threshold(TensorView* in, Val* thresh, Val* value);
+// clamp
 TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val);
+TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -193,13 +193,19 @@ class IrParser {
           ptr_op,
           [](const Node* const node,
              std::unordered_map<size_t, CgValue>& value_map) -> void {
+            using BinaryOpWithAlphaType = Val* (*)(Val*, Val*, Val*);
             static std::unordered_map<
                 Symbol,
-                std::pair<BinaryOpType, decltype(&add_alpha)>>
+              std::pair<BinaryOpType, BinaryOpWithAlphaType>>
                 op_mapping({
-                    {aten::add, std::make_pair(BinaryOpType::Add, &add_alpha)},
-                    {aten::sub, std::make_pair(BinaryOpType::Sub, &sub_alpha)},
-                });
+                    {aten::add,
+                     std::make_pair(
+                         BinaryOpType::Add,
+                         static_cast<BinaryOpWithAlphaType>(&add_alpha))},
+                    {aten::sub,
+                     std::make_pair(
+                         BinaryOpType::Sub,
+                         static_cast<BinaryOpWithAlphaType>(&sub_alpha))}});
             // TODO: handle scaling factor when it's not constant 1;
             auto lhs = value_map[node->inputs()[0]->unique()];
             auto rhs = value_map[node->inputs()[1]->unique()];

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -196,16 +196,16 @@ class IrParser {
             using BinaryOpWithAlphaType = Val* (*)(Val*, Val*, Val*);
             static std::unordered_map<
                 Symbol,
-              std::pair<BinaryOpType, BinaryOpWithAlphaType>>
-                op_mapping({
-                    {aten::add,
-                     std::make_pair(
-                         BinaryOpType::Add,
-                         static_cast<BinaryOpWithAlphaType>(&add_alpha))},
-                    {aten::sub,
-                     std::make_pair(
-                         BinaryOpType::Sub,
-                         static_cast<BinaryOpWithAlphaType>(&sub_alpha))}});
+                std::pair<BinaryOpType, BinaryOpWithAlphaType>>
+                op_mapping(
+                    {{aten::add,
+                      std::make_pair(
+                          BinaryOpType::Add,
+                          static_cast<BinaryOpWithAlphaType>(&add_alpha))},
+                     {aten::sub,
+                      std::make_pair(
+                          BinaryOpType::Sub,
+                          static_cast<BinaryOpWithAlphaType>(&sub_alpha))}});
             // TODO: handle scaling factor when it's not constant 1;
             auto lhs = value_map[node->inputs()[0]->unique()];
             auto rhs = value_map[node->inputs()[1]->unique()];


### PR DESCRIPTION
This is a second attempt to close #36 . See #40 for another PR.

Unlike #40, no template expansion is used in arith.h. There are a few in arith.cpp that are just used internally in arith.cpp to reduce code repetition. 

Where there are a lot of repetitiveness, the actual implementations basically just do forwarding to the `Val*`-only versions. The forwarding itself is unified in helper functions, so hopefully future changes in these functions won't be terribly burdensome. 

I also initially used macros to further reduce repetitiveness, but that was discouraged by clang-tidy, so went without the macros.