### PR TITLE
Rename Fusion::uses() to unordered_uses()

### DIFF
--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -193,7 +193,7 @@ void Expr::constDispatch(T handler, const Expr* expr) {
       ptr(handler)->handle(static_cast<const ReductionOp*>(expr));
       return;
     case ExprType::BroadcastOp:
-      ptr(handler)->handle(static_cast<const BroadcastOp* const>(expr));
+      ptr(handler)->handle(static_cast<const BroadcastOp*>(expr));
       return;
     case ExprType::ForLoop:
       ptr(handler)->handle(static_cast<const ForLoop*>(expr));

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -112,7 +112,7 @@ void Fusion::removeVal(Val* val) {
   if (orig != nullptr)
     removeExpr(origin(val));
 
-  for (Expr* use : uses(val))
+  for (Expr* use : unordered_uses(val))
     removeExpr(use);
 
   val_set_.erase(val);
@@ -130,7 +130,7 @@ void Fusion::addInput(Val* const input) {
   assertInFusion(input, "Cannot register input ");
 
   if (input->getValType().value() == ValType::TensorView) {
-    TensorView* tv = static_cast<TensorView* const>(input);
+    auto tv = input->as<TensorView>();
     if (tv->hasReduction())
       TORCH_WARN_ONCE(
           "Registered input ",
@@ -144,7 +144,7 @@ void Fusion::addInput(Val* const input) {
 void Fusion::addOutput(Val* const output) {
   assertInFusion(output, "Cannot register output ");
   if (output->getValType().value() == ValType::TensorView) {
-    TensorView* tv = static_cast<TensorView* const>(output);
+    auto tv = output->as<TensorView>();
     if (TensorDomain::hasBroadcast(tv->getRootDomain()))
       // Go to the root as we can merge bcast and
       // non-bcast dims, making a non-bcast dim.
@@ -311,7 +311,7 @@ const std::unordered_set<Expr*>& Fusion::unordered_exprs() const noexcept {
   return expr_set_;
 }
 
-std::unordered_set<Expr*> Fusion::uses(Val* val) const {
+std::unordered_set<Expr*> Fusion::unordered_uses(Val* val) const {
   assertInFusion(val, "Cannot detect where val was used, ");
   if (uses_.find(val) != uses_.end()) {
     auto ret = uses_.find(val)->second;

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -192,7 +192,7 @@ struct TORCH_CUDA_API Fusion : public IRInputOutput {
   const std::unordered_set<Expr*>& unordered_exprs() const noexcept;
 
   // Return all Exprs that use val
-  std::unordered_set<Expr*> uses(Val* val) const;
+  std::unordered_set<Expr*> unordered_uses(Val* val) const;
 
   // Return the Expr that produces val
   Expr* origin(Val* val) const;

--- a/torch/csrc/jit/codegen/cuda/iter_visitor.cpp
+++ b/torch/csrc/jit/codegen/cuda/iter_visitor.cpp
@@ -250,7 +250,7 @@ std::vector<Statement*> BackwardVisitor::next(Val* val) {
   // Going to sort based on relative topological position
   std::map<size_t, Statement*> exprs;
 
-  for (auto expr : FusionGuard::getCurFusion()->uses(val))
+  for (auto expr : FusionGuard::getCurFusion()->unordered_uses(val))
     // Make sure it's an expr we can traverse
     if (traversal_exprs_.find(expr) != traversal_exprs_.end())
       exprs[traversal_exprs_[expr]] = expr;


### PR DESCRIPTION
Plus cleaning up a few warnings

