### PR TITLE
Grid reduction

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2927,6 +2927,71 @@ void testGPU_FusionGridReduction5() {
   TORCH_CHECK(aten_output.allclose(cg_output));
 }
 
+// Similar to FusionGridReduction1 but with 3D tensors
+void testGPU_FusionGridReduction6() {
+  torch::jit::fuser::cuda::CudaKernel prog;
+  Fusion& fusion = *prog.fusion_;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeDummyTensor(3);
+  fusion.addInput(tv0);
+
+  // tv1[I0, R1, R2] = tv0[I0, I1, I2]
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1, 2}, new Float(0), tv0);
+  fusion.addOutput(tv1);
+
+  TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
+
+  // Splitting for TID
+  tv1->split(2, 128);
+  // tv1[I0, R1, R2o, R2i{128}] = tv0[I0, I1, I2]
+
+  // Splitting for BID
+  tv1->split(1, 128);
+
+  // tv1[I0, R1o, R1i{128}, R2o, R2i{128}] = tv0[I0, I1, I2]
+
+  TensorView* tv2 = tv1->rFactor({3});
+  // tv2[I0, I1o, I1i{128}, R2o, I2i{128}]
+  // tv1[I0, R1o, R1i{128},      R2i{128}]
+
+  TensorView* tv3 = tv1->rFactor({1});
+  // tv2[I0, I1o, I1i{128}, R2o, I2i{128}]
+  // tv3[I0, R1o, I1i{128},      I2i{128}]
+  // tv1[I0,      R1i{128},      R2i{128}]
+
+  tv3->computeAt(tv1, 1);
+  tv2->computeAt(tv3, 3);
+
+  tv1->axis(0)->parallelize(ParallelType::BIDy);
+
+  tv1->axis(-1)->parallelize(ParallelType::TIDx);
+  tv2->axis(-1)->parallelize(ParallelType::TIDx);
+  tv3->axis(-1)->parallelize(ParallelType::TIDx);
+
+  tv1->axis(-2)->parallelize(ParallelType::BIDx);
+  tv2->axis(-3)->parallelize(ParallelType::BIDx);
+  tv3->axis(-2)->parallelize(ParallelType::BIDx);
+
+  int numel_x = 6500;
+  int numel_y = 200;
+  int numel_z = numel_y;
+
+  prog.device_ = 0;
+  prog.grid(128, numel_x);
+  prog.block(128);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::rand({numel_x, numel_y, numel_z}, options);
+  at::Tensor cg_output = at::empty({numel_x}, options);
+
+  torch::jit::fuser::cuda::compileKernel(&prog);
+  torch::jit::fuser::cuda::runTestKernel(&prog, {input}, {cg_output});
+
+  auto aten_output = input.sum({1, 2});
+  TORCH_CHECK(aten_output.allclose(cg_output));
+}
 } // namespace jit
 } // namespace torch
 // #endif // #if defined(USE_CUDA)

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -138,7 +138,12 @@ namespace jit {
   _(GPU_FusionReduction2)        \
   _(GPU_FusionReduction3)        \
   _(GPU_FusionReduction4)        \
-  _(GPU_FusionSimpleBCast)
+  _(GPU_FusionSimpleBCast)       \
+  _(GPU_FusionGridReduction1)    \
+  _(GPU_FusionGridReduction2)    \
+  _(GPU_FusionGridReduction3)    \
+  _(GPU_FusionGridReduction4)    \
+  _(GPU_FusionGridReduction5)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -143,7 +143,8 @@ namespace jit {
   _(GPU_FusionGridReduction2)    \
   _(GPU_FusionGridReduction3)    \
   _(GPU_FusionGridReduction4)    \
-  _(GPU_FusionGridReduction5)
+  _(GPU_FusionGridReduction5)    \
+  _(GPU_FusionGridReduction6)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -368,6 +368,26 @@ bool Fusion::hasReduction() {
   return false;
 }
 
+bool Fusion::hasBlockReduction() {
+  for (auto expr : exprs(true))
+    for (auto out : expr->outputs())
+      if (out->getValType() == ValType::TensorView)
+        if (static_cast<TensorView*>(out)->hasBlockReduction())
+          return true;
+
+  return false;
+}
+
+bool Fusion::hasGridReduction() {
+  for (auto expr : exprs(true))
+    for (auto out : expr->outputs())
+      if (out->getValType() == ValType::TensorView)
+        if (static_cast<TensorView*>(out)->hasGridReduction())
+          return true;
+
+  return false;
+}
+
 } // namespace fuser
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -203,8 +203,10 @@ struct TORCH_CUDA_API Fusion : public IRInputOutput {
   // Indicate to kernel to set itself up to generate random numbers
   bool hasRNG();
 
-  // Indicate to kernel to set itself up to generate random numbers
   bool hasReduction();
+  bool hasBlockReduction();
+  bool hasGridReduction();
+  size_t gridReductionTempBufferSize();
 
  private:
   // Sets of all Vals/Exprs registered with this fusion

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -199,6 +199,8 @@ struct TORCH_CUDA_API TensorView : public Val {
   }
 
   bool hasReduction() const;
+  bool hasBlockReduction() const;
+  bool hasGridReduction() const;
   bool hasBroadcast() const;
 
   // Is there an active computeAt TensorView/Axis

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -159,6 +159,11 @@ struct TORCH_CUDA_API ReductionOp : public Expr {
 
   bool sameAs(const ReductionOp* const other) const;
 
+  std::vector<IterDomain*> getReductionDomains() const;
+
+  std::unordered_map<ParallelType, IterDomain*> getParallelReductionDomains()
+      const;
+
  private:
   const BinaryOpType reduction_op_type_;
   Val* const init_;
@@ -280,10 +285,6 @@ struct TORCH_CUDA_API IterDomain : public Val {
 
   void parallelize(ParallelType t) {
     parallel_method_ = t;
-    if (isBlockDim())
-      TORCH_CHECK(
-          !isReduction(),
-          "Cannot parallelize reductions across a block dimension.");
 
     // Currently a limitation as we allocate shared memory as static (not based
     // off a dynamic size.)
@@ -381,6 +382,8 @@ struct TORCH_CUDA_API TensorDomain : public Val {
   }
 
   bool hasReduction() const;
+  bool hasBlockReduction() const;
+  bool hasGridReduction() const;
   bool hasBroadcast() const;
   bool hasRFactor() const;
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -207,6 +207,33 @@ bool ReductionOp::sameAs(const ReductionOp* other) const {
       this->init()->sameAs(other->init()));
 }
 
+std::vector<IterDomain*> ReductionOp::getReductionDomains() const {
+  const Val* out_val = out();
+  // out is a TensorIndex after lowering
+  if (out_val->getValType() == ValType::TensorIndex) {
+    out_val = static_cast<const TensorIndex*>(out_val)->view();
+  }
+  auto vec_domain = out_val->as<TensorView>()->domain()->domain();
+  vec_domain.erase(
+      std::remove_if(
+          vec_domain.begin(),
+          vec_domain.end(),
+          [](IterDomain* id) { return !id->isReduction(); }),
+      vec_domain.end());
+  return vec_domain;
+}
+
+std::unordered_map<ParallelType, IterDomain*> ReductionOp::
+    getParallelReductionDomains() const {
+  std::unordered_map<ParallelType, IterDomain*> parallel_domains;
+  for (auto d : getReductionDomains()) {
+    if (d->isThread()) {
+      parallel_domains.insert(std::make_pair(d->parallel_method(), d));
+    }
+  }
+  return parallel_domains;
+}
+
 IterDomain::IterDomain(
     Val* _start,
     Val* _extent,
@@ -432,6 +459,18 @@ bool TensorDomain::sameAs(
 
 bool TensorDomain::hasReduction() const {
   return no_reduction_domain_.size() != domain_.size();
+}
+
+bool TensorDomain::hasBlockReduction() const {
+  return std::any_of(domain_.begin(), domain_.end(), [](IterDomain* id) {
+    return id->isReduction() && id->isThreadDim();
+  });
+}
+
+bool TensorDomain::hasGridReduction() const {
+  return std::any_of(domain_.begin(), domain_.end(), [](IterDomain* id) {
+    return id->isReduction() && id->isBlockDim();
+  });
 }
 
 bool TensorDomain::hasBroadcast() const {

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -656,8 +656,8 @@ void runTestKernel(
     at::Tensor reduction_work_buffer = at::empty(
         {(long)(temp_buf_sizes[0] / c10::elementSize(temp_buf_type))}, options);
     kernel_args.push(reduction_work_buffer);
-    at::Tensor sync_flags =
-        at::zeros({(long)(temp_buf_sizes[1] / elementSize(temp_buf_type))}, options);
+    at::Tensor sync_flags = at::zeros(
+        {(long)(temp_buf_sizes[1] / elementSize(temp_buf_type))}, options);
     kernel_args.push(sync_flags);
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -654,10 +654,10 @@ void runTestKernel(
     auto options =
         at::TensorOptions().dtype(temp_buf_type).device(at::kCUDA, 0);
     at::Tensor reduction_work_buffer = at::empty(
-        {temp_buf_sizes[0] / c10::elementSize(temp_buf_type)}, options);
+        {(long)(temp_buf_sizes[0] / c10::elementSize(temp_buf_type))}, options);
     kernel_args.push(reduction_work_buffer);
     at::Tensor sync_flags =
-        at::zeros({temp_buf_sizes[1] / elementSize(temp_buf_type)}, options);
+        at::zeros((long)({temp_buf_sizes[1] / elementSize(temp_buf_type))}, options);
     kernel_args.push(sync_flags);
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -657,7 +657,7 @@ void runTestKernel(
         {(long)(temp_buf_sizes[0] / c10::elementSize(temp_buf_type))}, options);
     kernel_args.push(reduction_work_buffer);
     at::Tensor sync_flags =
-        at::zeros((long)({temp_buf_sizes[1] / elementSize(temp_buf_type))}, options);
+        at::zeros({(long)(temp_buf_sizes[1] / elementSize(temp_buf_type))}, options);
     kernel_args.push(sync_flags);
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -152,7 +152,8 @@ std::pair<std::string, std::string> codeGeneration(Fusion* fusion) {
              << code_fp16_support << "\n"
              << code_random_number_gen << "\n"
              << code_helper_funcs << "\n"
-             << code_template_block_reduction << "\n";
+             << code_template_block_reduction << "\n"
+             << code_template_grid_reduction << "\n";
   std::stringstream cdg;
   GPULower gpulw(fusion);
   gpulw.printKernel(str_stream, KERNEL_NAME);
@@ -300,6 +301,73 @@ void validateKernelArgs(
         msg.str());
   }
 }
+
+size_t size(const dim3& d) {
+  return (size_t)d.x * (size_t)d.y * (size_t)d.z;
+}
+
+dim3 dimensionOfReductionBlock(
+    const dim3& block_dim,
+    bool x_thread,
+    bool y_thread,
+    bool z_thread) {
+  return dim3{x_thread ? block_dim.x : 1,
+              y_thread ? block_dim.y : 1,
+              z_thread ? block_dim.z : 1};
+}
+
+int sizeOfReductionBlock(
+    const dim3& block_dim,
+    bool x_thread,
+    bool y_thread,
+    bool z_thread) {
+  return size(
+      dimensionOfReductionBlock(block_dim, x_thread, y_thread, z_thread));
+}
+
+// Returns the total number of reduction segments.
+size_t numberOfReductionSegments(
+    const dim3& grid_dim,
+    bool x_block,
+    bool y_block,
+    bool z_block) {
+  return (x_block ? 1 : grid_dim.x) * (y_block ? 1 : grid_dim.y) *
+      (z_block ? 1 : grid_dim.z);
+}
+
+std::array<size_t, 2> gridReductionTempBufferSizes(CudaKernel* entry) {
+  size_t buffer_size = 0;
+  size_t sync_flag_size = 0;
+  for (auto expr : entry->fusion_->exprs(true)) {
+    if (expr->getExprType() != ExprType::ReductionOp)
+      continue;
+    ReductionOp* rop = static_cast<ReductionOp*>(expr);
+    auto domains = rop->getParallelReductionDomains();
+    bool x_block = domains.find(ParallelType::BIDx) != domains.end();
+    bool y_block = domains.find(ParallelType::BIDy) != domains.end();
+    bool z_block = domains.find(ParallelType::BIDz) != domains.end();
+    // No buffer needed unless it's a grid reduction
+    if (!x_block && !y_block && !z_block)
+      continue;
+    // Assumption here is that reduction along the block-parallel
+    // domains is done prior to this grid reduction, so those domains
+    // do not need to participate in the grid reductions
+    bool x_thread = domains.find(ParallelType::TIDx) == domains.end();
+    bool y_thread = domains.find(ParallelType::TIDy) == domains.end();
+    bool z_thread = domains.find(ParallelType::TIDz) == domains.end();
+    auto rb_size =
+        sizeOfReductionBlock(entry->block_, x_thread, y_thread, z_thread);
+    auto num_blocks = size(entry->grid_);
+    auto element_size = dataTypeSize(*(rop->out()->getDataType()));
+    auto required_temp_buffer_size = num_blocks * rb_size * element_size;
+    buffer_size = std::max(buffer_size, required_temp_buffer_size);
+    auto flag_size = sizeof(unsigned) *
+        numberOfReductionSegments(entry->grid_, x_block, y_block, z_block);
+    sync_flag_size = std::max(sync_flag_size, flag_size);
+  }
+  return {{buffer_size, sync_flag_size}};
+}
+
 } // namespace
 
 bool NaivePWKernelArgsReq::matchKernelSize(const at::ArrayRef<IValue> inputs) {
@@ -575,6 +643,22 @@ void runTestKernel(
     }
     kernel_args.push(philox_engine_inputs.first);
     kernel_args.push(philox_engine_inputs.second);
+  }
+
+  // When the kernel has global reductions, the kernel needs two
+  // additional temporary buffers, one for intermediate results and
+  // another for synchronization among thread blocks.
+  if (entry->fusion_->hasGridReduction()) {
+    auto temp_buf_type = at::kFloat;
+    auto temp_buf_sizes = gridReductionTempBufferSizes(entry);
+    auto options =
+        at::TensorOptions().dtype(temp_buf_type).device(at::kCUDA, 0);
+    at::Tensor reduction_work_buffer = at::empty(
+        {temp_buf_sizes[0] / c10::elementSize(temp_buf_type)}, options);
+    kernel_args.push(reduction_work_buffer);
+    at::Tensor sync_flags =
+        at::zeros({temp_buf_sizes[1] / elementSize(temp_buf_type)}, options);
+    kernel_args.push(sync_flags);
   }
 
   // launch kernel;

--- a/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
@@ -184,25 +184,22 @@ static auto code_template_block_reduction = R"(
 // may actually be slower.
 template<bool X_REDUCE, bool Y_REDUCE, bool Z_REDUCE, typename T, typename Func>
 __inline__ __device__
-void blockReduce(T& out, const T inp_val, Func reduction_op) {
-
-  // Use worst case for memory.
-  __shared__ T shared_mem[1024];
+void blockReduce(T& out, const T inp_val, Func reduction_op, const dim3& thread_idx, const dim3& block_dim, T* shared_mem) {
 
   unsigned int reduction_size 
-    = (X_REDUCE ? blockDim.x : 1) 
-    * (Y_REDUCE ? blockDim.y : 1)
-    * (Z_REDUCE ? blockDim.z : 1);
+    = (X_REDUCE ? block_dim.x : 1)
+    * (Y_REDUCE ? block_dim.y : 1)
+    * (Z_REDUCE ? block_dim.z : 1);
 
   // If this thread will output a final result
   bool should_write = true;
 
   if (X_REDUCE)
-    should_write = should_write && threadIdx.x == 0;
+    should_write = should_write && thread_idx.x == 0;
   if (Y_REDUCE)
-    should_write = should_write && threadIdx.y == 0;
+    should_write = should_write && thread_idx.y == 0;
   if (Z_REDUCE)
-    should_write = should_write && threadIdx.z == 0;
+    should_write = should_write && thread_idx.z == 0;
 
   unsigned int reduction_stride;
   unsigned int reduction_tid;
@@ -211,24 +208,24 @@ void blockReduce(T& out, const T inp_val, Func reduction_op) {
   if(X_REDUCE && !Y_REDUCE && Z_REDUCE){
     // Transpose Z and Y in the shared memory so Z and X dims are contiguous in smem
     reduction_stride = 1;
-    linear_tid = threadIdx.y * blockDim.z * blockDim.x + threadIdx.z * blockDim.x + threadIdx.x;
+    linear_tid = thread_idx.y * block_dim.z * block_dim.x + thread_idx.z * block_dim.x + thread_idx.x;
     reduction_tid
-    = threadIdx.y * blockDim.z * blockDim.x
-    + threadIdx.z              * blockDim.x
-    + threadIdx.x;
+    = thread_idx.y * block_dim.z * block_dim.x
+    + thread_idx.z              * block_dim.x
+    + thread_idx.x;
   } else {
     // Normal reduction in order
     reduction_stride 
     = (X_REDUCE ? 1 
-    : (Y_REDUCE ? blockDim.x
-    : (Z_REDUCE ? blockDim.x * blockDim.y : 0)));
+    : (Y_REDUCE ? block_dim.x
+    : (Z_REDUCE ? block_dim.x * block_dim.y : 0)));
 
-    linear_tid = threadIdx.z * blockDim.y * blockDim.x + threadIdx.y * blockDim.x + threadIdx.x;
+    linear_tid = thread_idx.z * block_dim.y * block_dim.x + thread_idx.y * block_dim.x + thread_idx.x;
 
     reduction_tid
-    = ( Z_REDUCE ? threadIdx.z : 0 ) * ( Y_REDUCE ? blockDim.y : 1 ) * ( X_REDUCE ? blockDim.x : 1 )
-    + ( Y_REDUCE ? threadIdx.y : 0 )                                 * ( X_REDUCE ? blockDim.x : 1 )
-    + ( X_REDUCE ? threadIdx.x : 0 );
+    = ( Z_REDUCE ? thread_idx.z : 0 ) * ( Y_REDUCE ? block_dim.y : 1 ) * ( X_REDUCE ? block_dim.x : 1 )
+    + ( Y_REDUCE ? thread_idx.y : 0 )                                 * ( X_REDUCE ? block_dim.x : 1 )
+    + ( X_REDUCE ? thread_idx.x : 0 );
   }
 
   assert( reduction_stride != 0 );
@@ -255,6 +252,314 @@ void blockReduce(T& out, const T inp_val, Func reduction_op) {
     out = shared_mem[linear_tid];
   
 }
+)";
+
+/**
+  Inter-block reduction.
+
+  Function gridReduce performs point-wise reductions of scalars across thread
+  blocks. Thread blocks are disjointly partitioned into groups of thread blocks,
+  "reduction segments," that are collectively defined by boolean template
+  parameters, X_BLOCK, Y_BLOCK and Z_BLOCK. Each of X/Y/Z_BLOCK determines
+  whether thread blocks along the dimension should be grouped into the same
+  reduction segment. Cross-block reducitons are independently done within each
+  segment and generates distinctive results per segment. For instance, if all of
+  X/Y/Z_BLOCK are true, reductions will be done across all thread blocks since
+  there will be just a single segment consisting of all thread blocks. If none
+  of them are true, each thread block will become a segment by itself, so no
+  reduction will be performed.
+
+  The input scalars to reduce within each segment are a certain subset of
+  thread-private scalars provided as part of the gridReduce function parameters.
+  Boolean template parameters, X_THREAD, Y_THREAD and Z_THREAD, determine which
+  subset of the scalars should be used for inter-block reductions. Specifically,
+  all the input scalars of threads along each dimension will be used when
+  X/Y/Z_THREAD are true. Otherwise, only the value held at offset 0 of each
+  dimension will be used. Thus, for example, if all of X/Y/Z_THREAD are true,
+  the scalars of all threads in each block will participate in inter-block
+  reductions. If all of them are false, only one scalar of the thread at
+  threadIdx.x == threadIdx.y == threadIdx.z == 0 will be used. In the code
+  below, we call the subset of threads a "reduction block."
+
+  Inter-block reductions perform point-wise reductions of scalars of reduction
+  blocks within each reduction segment. More specifically, let rb be a reduction
+  block and rs be a reduction segment. Let IN(thread_idx, block_idx) denote the
+  input scalar of thread at thread_idx and block_idx. The result of each
+  reduction segment, OUT(thread_idx, block_idx_out), is defined only for each
+  thread_idx in thread block block_idx_out in the segment as follows:
+
+    OUT(thread_idx, block_idx_out) = Reduction of IN(thread_idx, block_idx) for
+  all block_idx in a reduction segment
+
+  OUT is not given for all threads that are not in block_idx_out and the
+  reduction block.
+
+  See also the function comment of gridReduce.
+*/
+static auto code_template_grid_reduction = R"(
+namespace reduction {
+
+// Utility functions
+__host__ __device__ __forceinline__ size_t size(const dim3& d) {
+  return (size_t)d.x * (size_t)d.y * (size_t)d.z;
+}
+
+__host__ __device__ __forceinline__ int isize(const dim3& d) {
+  return d.x * d.y * d.z;
+}
+
+__host__ __device__ __forceinline__ size_t offset(const dim3& pos, const dim3& dim) {
+  return (size_t)pos.x + (size_t)pos.y * (size_t)dim.x +
+      (size_t)pos.z * (size_t)dim.x * (size_t)dim.y;
+}
+
+__host__ __device__ __forceinline__ size_t ioffset(const dim3& pos, const dim3& dim) {
+  return pos.x + pos.y * dim.x + pos.z * dim.x * dim.y;
+}
+
+// Returns dim3 of each reduction segment.
+template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK>
+__host__ __device__ dim3 dimension_of_reduction_segment(const dim3& grid_dim) {
+  return dim3{X_BLOCK ? grid_dim.x : 1,
+        Y_BLOCK ? grid_dim.y : 1,
+        Z_BLOCK ? grid_dim.z : 1};
+}
+
+// Returns the number of blocks in each reduction segment.
+template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK>
+__host__ __device__ size_t size_of_reduction_segment(const dim3& grid_dim) {
+  return size(dimension_of_reduction_segment<X_BLOCK, Y_BLOCK, Z_BLOCK>(grid_dim));
+}
+
+// Returns the total number of reduction segments.
+template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK>
+__host__ __device__ size_t number_of_reduction_segments(const dim3& grid_dim) {
+  return (X_BLOCK ? 1: grid_dim.x) *
+      (Y_BLOCK ? 1 : grid_dim.y) *
+      (Z_BLOCK ? 1 : grid_dim.z);
+}
+
+// Returns the 1-D index of the segment of thread block of block_idx.
+template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK>
+__host__ __device__ size_t index_of_reduction_segment(const dim3& block_idx,
+                                                      const dim3& grid_dim) {
+  size_t seg_idx = 0;
+  if (!Z_BLOCK)
+    seg_idx += block_idx.z;
+  if (!Y_BLOCK)
+    seg_idx = seg_idx * grid_dim.y + block_idx.y;
+  if (!X_BLOCK)
+    seg_idx = seg_idx * grid_dim.x + block_idx.x;
+  return seg_idx;
+}
+
+// Returns the offset of thread block in its reduction segment.
+template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK>
+__host__ __device__ size_t offset_in_reduction_segment(const dim3& block_idx,
+                                                       const dim3& grid_dim) {
+  size_t offset = 0;
+  if (Z_BLOCK)
+    offset = offset * grid_dim.z + block_idx.z;
+  if (Y_BLOCK)
+    offset = offset * grid_dim.y + block_idx.y;
+  if (X_BLOCK)
+    offset = offset * grid_dim.x + block_idx.x;
+  return offset;
+}
+
+// Returns dim3 of each reduction block.
+template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD>
+__host__ __device__ dim3 dimension_of_reduction_block(const dim3& block_dim) {
+  return dim3{X_THREAD ? block_dim.x : 1,
+        Y_THREAD ? block_dim.y : 1,
+        Z_THREAD ? block_dim.z : 1};
+}
+
+// Returns the number of threads of each reduction block.
+template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD>
+__host__ __device__ int size_of_reduction_block(const dim3& block_dim) {
+  return isize(dimension_of_reduction_block<X_THREAD, Y_THREAD, Z_THREAD>(block_dim));
+}
+
+// Returns the linear offset of a thread in a reduction block.
+template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD>
+__host__ __device__ int offset_in_reduction_block(const dim3& thread_idx,
+                                                  const dim3& block_dim) {
+  int offset = 0;
+  if (Z_THREAD)
+    offset += thread_idx.z;
+  if (Y_THREAD)
+    offset = offset * block_dim.y + thread_idx.y;
+  if (X_THREAD)
+    offset = offset * block_dim.x + thread_idx.x;
+  return offset;
+}
+
+/** Reduces all the reduction blocks in each reduction segment.
+
+  This is only used by one thread block per reduction segment. The input
+  reduction blocks of the segment are stored in an intermediate buffer pointed
+  by parameter in. Template parameters X/Y/Z_THREAD denote how the reduction
+  block is formed.
+
+  The size of a reduction block is by definition smaller or equal to the size of
+  a thread block. We use the remaining threads to parallelize reductions across
+  reduction blocks. For example, when X/Y/Z_THREAD = {true, false, false}, we
+  use blockDim.y*blockDim.z threads for each output value. This is done first by
+  loading the input values in parallel and then by reducing across threads of
+  dimensions whose XYZ_THREAD are false.
+
+  Note that what is done here after the loading from global memory is similar to
+  what the existing blockReduce function does. The main difference is that the
+  logical block to reduce is a 2D domain where the leading dimension is the size
+  of a reduction block and the second dimension is the remaining factor in each
+  thread block. For example, when X/Y/Z_THREAD = {false, true, false}, the
+  threads are arranged as (blockDim.y, blockDim.x*blockDim.z). We do not reduce
+  along the first dimension but only the second dimension. So, it is possible to
+  reuse the existing blockReduce with dim3{blockDim.y, blockDim.x*blockDim.z}
+  instead of blockDim and with X_THREAD and Y_THREAD being false and true,
+  respectively. Also, it still need to shuffle the final output values to their
+  actual corresponding threads. In the case of when X/Y/Z_THREAD = {false, true,
+  false}, after the intra-block reduction, the final results will still be held
+  by the first blockDim.y threads, which need to be transferred to threads at
+  threadIdx.x == 0 and threadIdx.z == 0.
+*/
+template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD,
+          typename T, typename Func>
+__device__ void gridReduceLastBlock(T& out, const T *in, const size_t in_size,
+                                    Func reduction_op, T* shared_buf) {
+  const int tid = ioffset(threadIdx, blockDim);
+  const int block_size = isize(blockDim);
+  const int rblock_size = size_of_reduction_block<X_THREAD, Y_THREAD, Z_THREAD>(blockDim);
+
+  T inp = 0;
+  if (tid < in_size) {
+    inp = in[tid];
+  }
+  for (size_t i = tid + block_size; i < in_size; i += block_size) {
+    reduction_op(inp, in[i]);
+  }
+
+  const auto should_write = (X_THREAD || threadIdx.x == 0) &&
+      (Y_THREAD || threadIdx.y == 0) &&
+      (Z_THREAD || threadIdx.z == 0);
+
+  auto rem_size = block_size / rblock_size;
+
+  if (rem_size > 1) {
+    const int rblock_offset = tid % rblock_size;
+    const int rblock_idx = tid / rblock_size;
+    blockReduce<false, true, false>(
+        inp, inp, reduction_op,
+        dim3{(unsigned)rblock_offset, (unsigned)rblock_idx, 0},
+        dim3{(unsigned)rblock_size, (unsigned)rem_size},
+        shared_buf);
+    __syncthreads();
+    if (tid < rblock_size) {
+      shared_buf[tid] = inp;
+    }
+    __syncthreads();
+    if (should_write) {
+      inp = shared_buf[offset_in_reduction_block<X_THREAD, Y_THREAD, Z_THREAD>(
+          threadIdx, blockDim)];
+    }
+  }
+
+  if (should_write) {
+    out = inp;
+  }
+}
+
+__device__ unsigned atomic_inc(unsigned* sync_flag, unsigned max_val) {
+  return atomicInc(sync_flag, max_val - 1);
+}
+
+/** Reduces per-thread values across thread blocks.
+
+Function parameters:
+- out: Per-thread output location
+- inp_val: Per-thread input value
+- reduction_op: Scalar reduction function
+- work_buf: Temporary buffer for cross-block reductions
+- sync_flags: A vector of integers for synchronizations
+- shared_buf: Shared memory buffer for intra-block reduction
+
+Template parameters:
+- X/Y/Z_BLOCK: When true, reduces across thread blocks along the X/Y/Z
+  dimensions
+- X/Y/Z_THREAD: When true, all threads along the X/Y/Z dimensions participate in
+  the cross-block reduction. Otherwise, only threads at offset 0 do.
+- T: Scalar data type of input/output data
+- Func: Type of scalara reduction function
+
+Template parameters X/Y/Z_BLOCK define a group of thread blocks that are reduced together. We call
+it a reduction segment. Some examples are:
+
+Case 1: X/Y/Z_BLOCK == true/true/true -> There is only one segment, which includes all
+  thread blocks. It is effecively the same as the grid.
+Case 2: X/Y/Z_BLOCK == false/false/false -> Each thread block comprises an individual
+  segment by itself.
+Case 3: X/Y/Z_BLOCK == true/false/false -> Each segment contains thread blocks that have
+  the same blockDim.x. There will be blockDim.y*blockDim.z such segments.
+
+X/Y/Z_THREAD defines a sub region of a thread block that should be reduced with
+the sub regions of other thread blocks. We call it a reduction block. E.g.,
+
+Case 1: X/Y/Z_THREAD == false/false/false -> Only thread 0 participates in the
+  cross-block reductions. The reduction block is 1x1x1 with thread 0.
+Case 2: X/Y/Z_THREAD == true/true/true-> All threads in a thread block participate in
+  the cross-block reductions. The reduction block in this case is equivalent to
+  the thread block.
+
+After the function completes, only one thread block per reduction segment gets
+valid reduction results. There is no guarantee which particular block gets the
+final results.
+*/
+template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK,
+          bool X_THREAD, bool Y_THREAD, bool Z_THREAD,
+          typename T, typename Func>
+__device__ void gridReduce(T& out, T inp_val, Func reduction_op,
+                           volatile T* work_buf,
+                           unsigned* sync_flags,
+                           T* shared_buf) {
+  const auto seg_size =
+      size_of_reduction_segment<X_BLOCK, Y_BLOCK, Z_BLOCK>(gridDim);
+  const auto seg_idx =
+      index_of_reduction_segment<X_BLOCK, Y_BLOCK, Z_BLOCK>(blockIdx, gridDim);
+  const auto rblock_size =
+      size_of_reduction_block<X_THREAD, Y_THREAD, Z_THREAD>(blockDim);
+
+  // advance to the offset for this segment
+  work_buf += seg_idx * seg_size * rblock_size;
+
+  if ((X_THREAD || threadIdx.x == 0) &&
+      (Y_THREAD || threadIdx.y == 0) &&
+      (Z_THREAD || threadIdx.z == 0)) {
+    auto rblock_offset =
+        offset_in_reduction_segment<X_BLOCK, Y_BLOCK, Z_BLOCK>(blockIdx, gridDim);
+    auto thread_offset =
+        offset_in_reduction_block<X_THREAD, Y_THREAD, Z_THREAD>(threadIdx, blockDim);
+    auto work_buf_offset = rblock_size * rblock_offset + thread_offset;
+    work_buf[work_buf_offset] = inp_val;
+  }
+  __syncthreads();
+
+  __shared__ bool last_block;
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    __threadfence();
+    auto old = atomic_inc(&sync_flags[seg_idx], seg_size);
+    last_block = old == seg_size - 1;
+  }
+  __syncthreads();
+
+  if (last_block) {
+    // final reduction
+    gridReduceLastBlock<X_THREAD, Y_THREAD, Z_THREAD>(
+        out, (T*)work_buf, seg_size * rblock_size,
+        reduction_op, shared_buf);
+  }
+}
+} // namespace reduction
 )";
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -42,6 +42,14 @@ bool TensorView::hasReduction() const {
   return domain()->hasReduction();
 }
 
+bool TensorView::hasBlockReduction() const {
+  return domain()->hasBlockReduction();
+}
+
+bool TensorView::hasGridReduction() const {
+  return domain()->hasGridReduction();
+}
+
 bool TensorView::hasBroadcast() const {
   return domain()->hasBroadcast();
 }

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -319,6 +319,22 @@ TORCH_CUDA_API c10::optional<std::string> cast_func_str(
   }
 }
 
+size_t dataTypeSize(DataType type) {
+  switch (type) {
+    // TODO: Is Bool actually supported? If so, is it one byte?
+    case DataType::Bool:
+      return 1;
+    case DataType::Float:
+      return 4;
+    case DataType::Half:
+      return 2;
+    case DataType::Int:
+      return 4;
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Size undefined for data type, ", type);
+  }
+}
+
 } // namespace fuser
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -143,6 +143,8 @@ TORCH_CUDA_API c10::optional<std::string> inline_op_str(const BinaryOpType);
 TORCH_CUDA_API c10::optional<std::string> cast_func_str(
     const std::pair<DataType, DataType>&);
 
+size_t dataTypeSize(DataType type);
+
 } // namespace fuser
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This PR adds support of grid reductions that reduce blockIdx dimensions.

The main logic of grid reduction is `gridReduce`, which is defined as a code string template in kernel_resources_string.h. It uses two temporary buffers whose required sizes depend on blockDim and gridDim. They are currently set up before calling the kernel using `at::zeros` and `at::empty`. 

For now, only `runTestKernel` is modified. I believe `runKernel` can be modified similarly, but I don't know why we have two very similar functions.

A new test, `testGPU_FusionGridReduction` is added. It's based on `testGPU_FusionReduction` but modified to used `BIDx` to parallelize the dimension next to the one parallelized by `TIDx`. 

TODO:
- [ ] General review of the approach taken
- [x] More complex tests

