### PR TITLE
Compute at refactor

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_CUDA)
+// #if defined(USE_CUDA)
 #include <test/cpp/jit/test_base.h>
 
 #include <torch/csrc/jit/codegen/cuda/arith.h>
@@ -1018,32 +1018,32 @@ void testGPU_FusionParser() {
 __global__ void CUDAGeneratedKernel(Tensor<float, 1> T0, Tensor<float, 1> T1, Tensor<float, 1> T3){
   float T2[4];
   if ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < T3.size[0] ) ) { 
-    for(size_t i40 = 0; i40 < 4; ++i40 ) {
-      T2[ i40 ]
-         = T0[ ( ( ( ( ( blockIdx.x * 4 ) + i40 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ]
-         * T1[ ( ( ( ( ( blockIdx.x * 4 ) + i40 ) * 128 ) + threadIdx.x ) * T1.stride[0] ) ];
+    for(size_t i24 = 0; i24 < 4; ++i24 ) {
+      T2[ i24 ]
+         = T0[ ( ( ( ( ( blockIdx.x * 4 ) + i24 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ]
+         * T1[ ( ( ( ( ( blockIdx.x * 4 ) + i24 ) * 128 ) + threadIdx.x ) * T1.stride[0] ) ];
     }
   } else { 
-    for(size_t i40 = 0; i40 < 4; ++i40 ) {
-      if ( ( ( ( ( ( blockIdx.x * 4 ) + i40 ) * 128 ) + threadIdx.x ) < T3.size[0] ) ) { 
-        T2[ i40 ]
-           = T0[ ( ( ( ( ( blockIdx.x * 4 ) + i40 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ]
-           * T1[ ( ( ( ( ( blockIdx.x * 4 ) + i40 ) * 128 ) + threadIdx.x ) * T1.stride[0] ) ];
+    for(size_t i24 = 0; i24 < 4; ++i24 ) {
+      if ( ( ( ( ( ( blockIdx.x * 4 ) + i24 ) * 128 ) + threadIdx.x ) < T3.size[0] ) ) { 
+        T2[ i24 ]
+           = T0[ ( ( ( ( ( blockIdx.x * 4 ) + i24 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ]
+           * T1[ ( ( ( ( ( blockIdx.x * 4 ) + i24 ) * 128 ) + threadIdx.x ) * T1.stride[0] ) ];
       }
     }
   }
   if ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < T3.size[0] ) ) { 
-    for(size_t i41 = 0; i41 < 4; ++i41 ) {
-      T3[ ( ( ( ( ( blockIdx.x * 4 ) + i41 ) * 128 ) + threadIdx.x ) * T3.stride[0] ) ]
-         = T2[ i41 ]
-         * T0[ ( ( ( ( ( blockIdx.x * 4 ) + i41 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ];
+    for(size_t i25 = 0; i25 < 4; ++i25 ) {
+      T3[ ( ( ( ( ( blockIdx.x * 4 ) + i25 ) * 128 ) + threadIdx.x ) * T3.stride[0] ) ]
+         = T2[ i25 ]
+         * T0[ ( ( ( ( ( blockIdx.x * 4 ) + i25 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ];
     }
   } else { 
-    for(size_t i41 = 0; i41 < 4; ++i41 ) {
-      if ( ( ( ( ( ( blockIdx.x * 4 ) + i41 ) * 128 ) + threadIdx.x ) < T3.size[0] ) ) { 
-        T3[ ( ( ( ( ( blockIdx.x * 4 ) + i41 ) * 128 ) + threadIdx.x ) * T3.stride[0] ) ]
-           = T2[ i41 ]
-           * T0[ ( ( ( ( ( blockIdx.x * 4 ) + i41 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ];
+    for(size_t i25 = 0; i25 < 4; ++i25 ) {
+      if ( ( ( ( ( ( blockIdx.x * 4 ) + i25 ) * 128 ) + threadIdx.x ) < T3.size[0] ) ) { 
+        T3[ ( ( ( ( ( blockIdx.x * 4 ) + i25 ) * 128 ) + threadIdx.x ) * T3.stride[0] ) ]
+           = T2[ i25 ]
+           * T0[ ( ( ( ( ( blockIdx.x * 4 ) + i25 ) * 128 ) + threadIdx.x ) * T0.stride[0] ) ];
       }
     }
   }
@@ -1315,12 +1315,13 @@ int ceilDiv_(int a, int b) {
 void testGPU_FusionAdvancedComputeAt() {
   // Case 1
   /*
-   * tv1 = tv0 * -1
-   * tv2 = tv0 + 3
-   * tv3 = tv0 * 2
-   * tv4 = tv2 + tv1
-   * tv5 = tv4 + tv3
-   * tv6 = tv0 + tv3
+   * tv1 = tv0 * 0.5
+   * tv2 = tv1 * -1
+   * tv3 = tv1 + 3
+   * tv4 = tv1 * 2
+   * tv5 = tv3 + tv2
+   * tv6 = tv5 + tv4
+   * tv7 = tv1 + tv4
    */
   {
     torch::jit::fuser::cuda::CudaKernel prog;
@@ -1330,44 +1331,34 @@ void testGPU_FusionAdvancedComputeAt() {
     TensorView* tv0 = makeDummyTensor(2);
     fusion.addInput(tv0);
 
-    TensorView* tv1 = mul(tv0, new Float(-1.0));
-    TensorView* tv2 = add(tv0, new Float(3.0));
-    TensorView* tv3 = mul(tv0, new Float(2.0));
-    TensorView* tv4 = add(tv2, tv1);
+    TensorView* tv1 = mul(tv0, new Float(0.5));
+    TensorView* tv2 = mul(tv1, new Float(-1.0));
+    TensorView* tv3 = add(tv1, new Float(3.0));
+    TensorView* tv4 = mul(tv1, new Float(2.0));
+    TensorView* tv5 = add(tv3, tv2);
 
-    TensorView* tv5 = add(tv4, tv3);
-    TensorView* tv6 = add(tv0, tv3);
+    TensorView* tv6 = add(tv5, tv4);
+    TensorView* tv7 = add(tv1, tv4);
 
-    fusion.addOutput(tv5);
     fusion.addOutput(tv6);
-
-    tv0->computeAt(tv3, 1);
-
-    // Check propagation of this computeAt.
-    TORCH_CHECK(tv0->getComputeAtView() == tv3);
-    TORCH_CHECK(tv1->getComputeAtView() == tv4);
-    TORCH_CHECK(tv2->getComputeAtView() == tv4);
-    TORCH_CHECK(tv3->getComputeAtView() == tv6);
-    TORCH_CHECK(tv4->getComputeAtView() == tv5);
-    TORCH_CHECK(tv5->getComputeAtView() == tv6);
-    TORCH_CHECK(!tv6->hasComputeAt());
+    fusion.addOutput(tv7);
 
     // Lets setup to actually run
-    tv6->merge(0);
-    tv6->split(0, 128);
-    tv6->split(0, 4);
+    tv7->merge(0);
+    tv7->split(0, 128);
+    tv7->split(0, 4);
 
-    tv6->axis(0)->parallelize(ParallelType::BIDx);
+    tv7->axis(0)->parallelize(ParallelType::BIDx);
 
-    tv0->computeAt(tv6, 1);
+    tv0->computeAt(tv7, 1);
 
-    TORCH_CHECK(tv0->getComputeAtView() == tv6 && tv0->nDims() == 3);
-    TORCH_CHECK(tv1->getComputeAtView() == tv4 && tv1->nDims() == 3);
-    TORCH_CHECK(tv2->getComputeAtView() == tv4 && tv2->nDims() == 3);
-    TORCH_CHECK(tv3->getComputeAtView() == tv6 && tv3->nDims() == 3);
-    TORCH_CHECK(tv4->getComputeAtView() == tv5 && tv4->nDims() == 3);
+    TORCH_CHECK(tv1->hasComputeAt() && tv1->nDims() == 3);
+    TORCH_CHECK(tv2->getComputeAtView() == tv5 && tv2->nDims() == 3);
+    TORCH_CHECK(tv3->getComputeAtView() == tv5 && tv3->nDims() == 3);
+    TORCH_CHECK(tv4->hasComputeAt() && tv4->nDims() == 3);
     TORCH_CHECK(tv5->getComputeAtView() == tv6 && tv5->nDims() == 3);
-    TORCH_CHECK(!tv6->hasComputeAt());
+    TORCH_CHECK(tv6->getComputeAtView() == tv7 && tv6->nDims() == 3);
+    TORCH_CHECK(!tv7->hasComputeAt());
 
     for (Val* val : fusion.vals()) {
       if (!fusion.hasInput(val) &&
@@ -1382,15 +1373,16 @@ void testGPU_FusionAdvancedComputeAt() {
 
     at::Tensor t0 = at::randn({129, 127}, options);
 
-    auto t1 = t0.mul({-1.0});
-    auto t2 = t0.add({3.0});
-    auto t3 = t0.mul({2.0});
-    auto t4 = t2.add(t1);
-    auto t5 = t4.add(t3);
-    auto t6 = t0.add(t3);
+    auto t1 = t0.mul({0.5});
+    auto t2 = t1.mul({-1.0});
+    auto t3 = t1.add({3.0});
+    auto t4 = t1.mul({2.0});
+    auto t5 = t3.add(t2);
+    auto t6 = t5.add(t4);
+    auto t7 = t1.add(t4);
 
-    at::Tensor kernel_tv5 = at::empty_like(t0, options);
     at::Tensor kernel_tv6 = at::empty_like(t0, options);
+    at::Tensor kernel_tv7 = at::empty_like(t0, options);
 
     prog.device_ = 0;
 
@@ -1400,10 +1392,10 @@ void testGPU_FusionAdvancedComputeAt() {
     prog.block(128);
     torch::jit::fuser::cuda::compileKernel(&prog);
     torch::jit::fuser::cuda::runTestKernel(
-        &prog, {t0}, {kernel_tv5, kernel_tv6});
+        &prog, {t0}, {kernel_tv6, kernel_tv7});
 
-    TORCH_CHECK(at::allclose(kernel_tv5, t5));
     TORCH_CHECK(at::allclose(kernel_tv6, t6));
+    TORCH_CHECK(at::allclose(kernel_tv7, t7));
   }
 
   // Case 2
@@ -1436,7 +1428,6 @@ void testGPU_FusionAdvancedComputeAt() {
 
     tv2->computeAt(tv4, 1);
 
-    TORCH_CHECK(!tv0->hasComputeAt());
     TORCH_CHECK(!tv1->hasComputeAt());
     TORCH_CHECK(tv2->getComputeAtView() == tv4);
     TORCH_CHECK(!tv3->hasComputeAt());
@@ -3121,6 +3112,34 @@ void testGPU_FusionSoftmax() {
   //     "Error of: ",
   //     t2.sub(cg_output).abs().max());
 }
+
+// TODO: Fix the assert any throw below!
+void testGPU_FusionSoftmaxComputeAt() {
+  torch::jit::fuser::cuda::CudaKernel prog;
+  Fusion& fusion = *prog.fusion_;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeDummyTensor(2);
+  fusion.addInput(tv0);
+
+  auto tv1 = sum(tv0, {1});
+  auto tv2 = broadcast(tv1, {false, true});
+
+  auto tv3 = add(tv0, new Float(1.0));
+
+  auto tv4 = mul(tv2, tv3);
+
+  auto tv5 = sum(tv4, {1});
+  auto tv6 = broadcast(tv5, {false, true});
+
+  auto tv7 = sub(tv6, tv4);
+  fusion.addOutput(tv7);
+
+  // ASSERT_ANY_THROW(tv1->computeAt(tv7, -1));
+
+}
+
 // Similar to FusionReduction but uses grid reduction
 void testGPU_FusionGridReduction1() {
   const int gdimx = 32;
@@ -3882,4 +3901,4 @@ void testGPU_FusionZeroDimReduction() {
 
 } // namespace jit
 } // namespace torch
-#endif // #if defined(USE_CUDA)
+// #endif // #if defined(USE_CUDA)

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -3104,7 +3104,6 @@ void testGPU_FusionSoftmax() {
   //     t2.sub(cg_output).abs().max());
 }
 
-// TODO: Fix the assert any throw below!
 void testGPU_FusionSoftmaxComputeAt() {
   torch::jit::fuser::cuda::CudaKernel prog;
   Fusion& fusion = *prog.fusion_;
@@ -3127,7 +3126,8 @@ void testGPU_FusionSoftmaxComputeAt() {
   auto tv7 = sub(tv6, tv4);
   fusion.addOutput(tv7);
 
-  // ASSERT_ANY_THROW(tv1->computeAt(tv7, -1));
+  tv1->computeAt(tv7, 1);
+  ASSERT_ANY_THROW(tv1->computeAt(tv7, -1));
 }
 
 // Similar to FusionReduction but uses grid reduction

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1,4 +1,4 @@
-// #if defined(USE_CUDA)
+#if defined(USE_CUDA)
 #include <test/cpp/jit/test_base.h>
 
 #include <torch/csrc/jit/codegen/cuda/arith.h>
@@ -1425,15 +1425,6 @@ void testGPU_FusionAdvancedComputeAt() {
 
     fusion.addOutput(tv5);
     fusion.addOutput(tv6);
-
-    tv2->computeAt(tv4, 1);
-
-    TORCH_CHECK(!tv1->hasComputeAt());
-    TORCH_CHECK(tv2->getComputeAtView() == tv4);
-    TORCH_CHECK(!tv3->hasComputeAt());
-    TORCH_CHECK(!tv4->hasComputeAt());
-    TORCH_CHECK(!tv5->hasComputeAt());
-    TORCH_CHECK(!tv6->hasComputeAt());
 
     // Lets setup to actually run
     tv6->merge(0);
@@ -3137,7 +3128,6 @@ void testGPU_FusionSoftmaxComputeAt() {
   fusion.addOutput(tv7);
 
   // ASSERT_ANY_THROW(tv1->computeAt(tv7, -1));
-
 }
 
 // Similar to FusionReduction but uses grid reduction
@@ -3901,4 +3891,4 @@ void testGPU_FusionZeroDimReduction() {
 
 } // namespace jit
 } // namespace torch
-// #endif // #if defined(USE_CUDA)
+#endif // #if defined(USE_CUDA)

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -150,6 +150,7 @@ namespace jit {
   _(GPU_FusionSimpleBCast)        \
   _(GPU_FusionSimpleGemm)         \
   _(GPU_FusionSoftmax)            \
+  _(GPU_FusionSoftmaxComputeAt)   \
   _(GPU_FusionGridReduction1)     \
   _(GPU_FusionGridReduction2)     \
   _(GPU_FusionGridReduction3dim1) \

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
+#include <torch/csrc/jit/codegen/cuda/transform_iter.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 
 #include <torch/csrc/jit/codegen/cuda/compute_at.h>
@@ -8,6 +9,77 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
+ComputeAtData::ComputeAtData(TensorView* tv)
+    : tv_ref_(tv),
+      original_has_compute_at_(tv->hasComputeAt()),
+      original_compute_at_position(tv->getThisComputeAtAxis()),
+      original_domain_(tv->domain()) {}
+
+// Clear pass based data
+void ComputeAtData::clearPass() {
+  // If the last pass set a position, update the new_compute_at_position if
+  // latest position would be greater than previously set.
+  auto pass_pos = current_traversal_position_set ? current_traversal_position
+                                                 : new_compute_at_position;
+
+  new_compute_at_position =
+      pass_pos > new_compute_at_position ? pass_pos : new_compute_at_position;
+
+  current_traversal_position_set = false;
+  current_traversal_position = 0;
+}
+
+void ComputeAtData::setPassPosition(unsigned int pos) {
+  if (current_traversal_position_set) {
+    // A single traversal cannot try to enforce more than one position on a
+    // TensorView as it would produce in incorrect code. If this is hit, then
+    // the given tensor and its production should be duplicated.
+    TORCH_CHECK(
+        pos == current_traversal_position,
+        "Error during computeAt. ComputeAt pass wanted to set position of ",
+        tv_ref_,
+        " at position ",
+        pos,
+        " but was already set to position ",
+        current_traversal_position,
+        ". This tensor would have to be recomputed to satsify the selected computeAt position.");
+  }
+
+  current_traversal_position = pos;
+  touched_ = true;
+  current_traversal_position_set = true;
+}
+
+unsigned int ComputeAtData::getNewPosition() const {
+  // If the last pass set a position, update the new_compute_at_position if
+  // latest position would be greater than previously set.
+  auto pass_pos = current_traversal_position_set ? current_traversal_position
+                                                 : new_compute_at_position;
+
+  return pass_pos > new_compute_at_position ? pass_pos
+                                            : new_compute_at_position;
+}
+
+void ComputeAtData::validateNewComputeAt() const {
+  TORCH_INTERNAL_ASSERT(
+      getNewPosition() >= original_compute_at_position,
+      "Invalid computeAt detected. This computeAt would invalidate the set computeAt on ",
+      tv_ref_,
+      " as the new computeAt position was found to be ",
+      getNewPosition(),
+      ".");
+  auto mismatch = BestEffortReplay::findFirstMismatchedID(
+      tv_ref_->domain(), original_domain_);
+  TORCH_CHECK(
+      mismatch >= original_compute_at_position,
+      "Invalid computeAt detected. This computeAt call would invalidate the set computeAt on ",
+      tv_ref_,
+      " as the previous set computeAt was on the domain ",
+      original_domain_,
+      " with a computeAt position of ",
+      original_compute_at_position,
+      ".");
+}
 
 namespace {
 // Wrapper around set_intersection
@@ -25,7 +97,7 @@ std::set<T> set_intersection(const std::set<T>& set1, const std::set<T>& set2) {
 
 // convert an iterable of Val* to be an iterable of TensorView*
 template <typename T1, typename T2>
-T1 tv_iterable(const T2& val_iterable) {
+T1 tvIterable(const T2& val_iterable) {
   T1 tv_iterable = T1();
   std::transform(
       val_iterable.begin(),
@@ -40,16 +112,13 @@ T1 tv_iterable(const T2& val_iterable) {
   return tv_iterable;
 }
 
-std::deque<std::deque<TensorView*>> getAllTVUseChains(TensorView* tv) {
-  // Grab all paths from producer to  of producer in fusion.
-  auto val_all_use_chains = DependencyCheck::getAllUseChains(tv);
-
-  // Convert dep chains to tensor view chains.
-  std::deque<std::deque<TensorView*>> producer_use_chains_;
-  for (const auto& val_dep_chain : val_all_use_chains)
-    producer_use_chains_.push_back(
-        tv_iterable<std::deque<TensorView*>>(val_dep_chain));
-  return producer_use_chains_;
+std::deque<std::deque<TensorView*>> tvChains(
+    std::deque<std::deque<Val*>> val_chains) {
+  std::deque<std::deque<TensorView*>> tv_chains(val_chains.size());
+  for (size_t i = 0; i < val_chains.size(); i++) {
+    tv_chains[i] = tvIterable<std::deque<TensorView*>>(val_chains[i]);
+  }
+  return tv_chains;
 }
 } // namespace
 
@@ -57,7 +126,6 @@ void ComputeAt::run(
     TensorView* producer,
     TensorView* consumer,
     unsigned int consumer_position) {
-
   // Make sure the correct fusion is setup between this and consumer.
   TORCH_CHECK(
       producer->fusion() == consumer->fusion(),
@@ -76,7 +144,7 @@ void ComputeAt::run(
   // producer that are in a dependency between prodcer and consumer.
   if (producer->fusion()->hasInput(producer)) {
     auto all_chains =
-        DependencyCheck::getAllDependencyChains(producer, consumer);
+        tvChains(DependencyCheck::getAllDependencyChains(producer, consumer));
 
     TORCH_CHECK(
         !all_chains.empty(),
@@ -90,11 +158,9 @@ void ComputeAt::run(
 
     // Remove all TVs from producer to consumer as common consumer must be at or
     // after consumer
-    for (const auto& dep_chain : all_chains) {
-      auto tv_chain = tv_iterable<std::deque<TensorView*>>(dep_chain);
-      // If not just a direct dependency
-      if(tv_chain.size()>2){
-        if(added_producers.find(tv_chain[1]) == added_producers.end()){
+    for (const auto& tv_chain : all_chains) {
+      if (tv_chain.size() > 2) {
+        if (added_producers.find(tv_chain[1]) == added_producers.end()) {
           producers.push_back(tv_chain[1]);
           added_producers.emplace(tv_chain[1]);
         }
@@ -106,8 +172,8 @@ void ComputeAt::run(
   }
 
   // Run computeAt on our potentially modified producer(s)
-  if(!producers.empty()){
-    for(auto producer_to_run : producers){
+  if (!producers.empty()) {
+    for (auto producer_to_run : producers) {
       ComputeAt ca(producer_to_run, consumer, consumer_position);
       ca.runPass();
     }
@@ -115,48 +181,42 @@ void ComputeAt::run(
 }
 
 // Actually applies transformation
-void ComputeAt::computeAt_impl(
+unsigned int ComputeAt::backwardComputeAt_impl(
     TensorView* producer,
     TensorView* consumer,
     unsigned int consumer_compute_at_axis) {
-  // Reset view otherwise will conflict with replay.
-  producer->clearComputeAt();
-  // replay this as consumer / producer as consumer
+  auto& entry = tv_data.at(producer);
+
+  // Use TensorDomain interface so it doesn't set computeAt automatically
   auto replay = TransformReplay::replayPasC(
       producer, consumer, (int)consumer_compute_at_axis);
-  producer->setComputeAt(consumer, replay.second);
-}
 
-// Runs replay, and checks computeAt position. If higher than that provided,
-// actually applies.
-void ComputeAt::maybe_computeAt_impl(
-    TensorView* producer,
-    TensorView* consumer,
-    unsigned int consumer_compute_at_axis) {
-  unsigned int prev_pos = 0;
-  if (producer->hasComputeAt())
-    prev_pos = producer->getThisComputeAtAxis();
+  entry.setPassPosition(replay.second);
 
-  auto replay = TransformReplay::replayPasC(
-      producer->domain(), consumer->domain(), (int)consumer_compute_at_axis);
-
-  if (replay.second > prev_pos) {
-    producer->setDomain(replay.first);
-    producer->setComputeAt(consumer, replay.second);
+  if (entry.shouldSetComputeAt(replay.second)) {
+    producer->setComputeAt(consumer, consumer_compute_at_axis);
   }
+
+  return replay.second;
 }
 
 // Actually applies transformation
-void ComputeAt::forwardComputeAt_impl(
+unsigned int ComputeAt::forwardComputeAt_impl(
     TensorView* producer,
     TensorView* consumer,
     unsigned int producer_compute_at_axis) {
-  // Reset view otherwise will conflict with replay. Don't think this is true
-  // anymore.
-  producer->clearComputeAt();
+  auto& consumer_entry = tv_data.at(consumer);
+  const auto& producer_entry = tv_data.at(producer);
+
   auto replay = TransformReplay::replayCasP(
       consumer, producer, (int)producer_compute_at_axis);
-  producer->setComputeAt(consumer, replay.second);
+
+  consumer_entry.setPassPosition(replay.second);
+  if (producer_entry.shouldSetComputeAt(producer_compute_at_axis)) {
+    producer->setComputeAt(consumer, replay.second);
+  }
+
+  return replay.second;
 }
 
 void ComputeAt::setCommonConsumer() {
@@ -166,13 +226,14 @@ void ComputeAt::setCommonConsumer() {
 
   // Run through all use chains of producer, and intersect them to find common
   // TVs
-  for (auto dep_chain : producer_use_chains_)
+  for (auto tv_chain : producer_use_chains_) {
     common_consumers = set_intersection(
         common_consumers,
-        std::set<TensorView*>(dep_chain.begin(), dep_chain.end()));
+        std::set<TensorView*>(tv_chain.begin(), tv_chain.end()));
+  }
 
   auto all_chains =
-      DependencyCheck::getAllDependencyChains(producer_, consumer_);
+      tvChains(DependencyCheck::getAllDependencyChains(producer_, consumer_));
 
   // Right now we only support compute at if at some point in the graph consumer
   // is dependent on producer.
@@ -186,8 +247,7 @@ void ComputeAt::setCommonConsumer() {
 
   // Remove all TVs from producer to consumer as common consumer must be at or
   // after consumer
-  for (const auto& dep_chain : all_chains) {
-    auto tv_chain = tv_iterable<std::deque<TensorView*>>(dep_chain);
+  for (const auto& tv_chain : all_chains) {
     for (auto tv : tv_chain) {
       if (tv != consumer_)
         common_consumers.erase(tv);
@@ -197,187 +257,15 @@ void ComputeAt::setCommonConsumer() {
   // If there is a common consumer, grab the first one at or after consumer
   common_consumer_ = nullptr;
   if (!common_consumers.empty()) {
-    for (TensorView* tv : producer_use_chains_.front())
+    for (auto tv : producer_use_chains_.front()) {
       if (common_consumers.find(tv) != common_consumers.end()) {
         common_consumer_ = tv;
         break;
       }
+    }
     TORCH_INTERNAL_ASSERT(
         common_consumer_ != nullptr,
         "Hit a logical inconsistency in the computeAt pass.");
-  }
-}
-
-void ComputeAt::traverseAllKnown() {
-  std::deque<std::deque<Val*>> chains;
-
-  // propagate backwards through all dep chains from producer to consumer
-
-  // Grab all chains from consumer to producer
-  chains = DependencyCheck::getAllDependencyChains(producer_, consumer_);
-
-  TORCH_CHECK(
-      !chains.empty(),
-      "Producer and consumer in a computeAt call must have a dependency between them even if indirect.");
-
-  for (const auto& val_chain : chains) {
-    auto tv_chain = tv_iterable<std::deque<TensorView*>>(val_chain);
-    TensorView* running_consumer = nullptr;
-    TensorView* running_producer = tv_chain.back();
-    unsigned int running_consumer_pos = consumer_position_;
-
-    tv_chain.pop_back();
-
-    while (!tv_chain.empty()) {
-      running_consumer = running_producer;
-      running_producer = tv_chain.back();
-      tv_chain.pop_back();
-
-      if (compute_at_ed.find(running_producer) != compute_at_ed.end() &&
-          known_positions.find(running_producer) != known_positions.end()) {
-        running_consumer_pos = known_positions.at(running_producer);
-        continue;
-      }
-
-      computeAt_impl(running_producer, running_consumer, running_consumer_pos);
-      running_consumer_pos = running_producer->getThisComputeAtAxis();
-
-      // Update both compute_at_ed and compute_at_axis_lookup
-      compute_at_ed.emplace(running_producer);
-
-      if (known_positions.find(running_producer) != known_positions.end()) {
-        TORCH_INTERNAL_ASSERT(
-            known_positions.at(running_producer) ==
-                running_producer->getThisComputeAtAxis(),
-            "Hit a logical inconsistency in the computeAt pass.");
-      } else {
-        known_positions[running_producer] =
-            running_producer->getThisComputeAtAxis();
-      }
-    }
-  }
-
-  // propagate forward through all consumer use_chains or from consumer to
-  // common_consumer if common_consumer exists, mark as finished.
-
-  if (common_consumer_ == nullptr) {
-    chains = DependencyCheck::getAllUseChains(consumer_);
-  } else if (common_consumer_ != consumer_) {
-    chains =
-        DependencyCheck::getAllDependencyChains(consumer_, common_consumer_);
-  }
-
-  for (const auto& dep_chain : chains) {
-    TORCH_INTERNAL_ASSERT(
-        !dep_chain.empty(), "Computed an invalid common_consumer.");
-
-
-    // propagate forward through all chains
-    unsigned int running_producer_pos = consumer_position_;
-
-    std::deque<TensorView*> tv_dep_chain =
-        tv_iterable<std::deque<TensorView*>>(dep_chain);
-
-    TensorView* running_consumer = tv_dep_chain.front();
-    tv_dep_chain.pop_front();
-
-    TensorView* running_producer = nullptr;
-
-    while (!tv_dep_chain.empty()) {
-      running_producer = running_consumer;
-      running_consumer = tv_dep_chain.front();
-      tv_dep_chain.pop_front();
-
-      if (compute_at_ed.find(running_producer) != compute_at_ed.end() &&
-          known_positions.find(running_consumer) != known_positions.end()) {
-        running_producer_pos = known_positions.at(running_consumer);
-        continue;
-      }
-
-      forwardComputeAt_impl(
-          running_producer, running_consumer, running_producer_pos);
-
-      running_producer_pos = running_producer->getRelativeComputeAtAxis();
-
-      compute_at_ed.emplace(running_producer);
-
-      if (known_positions.find(running_consumer) != known_positions.end()) {
-        TORCH_INTERNAL_ASSERT(
-            known_positions.at(running_consumer) ==
-                running_producer->getRelativeComputeAtAxis(),
-            "Hit a logical inconsistency in computeAt pass.");
-      } else {
-        known_positions[running_consumer] =
-            running_producer->getRelativeComputeAtAxis();
-      }
-    }
-  }
-}
-
-// Similar to forward traversal in traverseAllKnown but we don't know if the
-// positions are actually correct
-void ComputeAt::traverseForward() {
-  // propagate forward through all *producer* use_chains or from *producer* to
-  // common_consumer if common_consumer exists.
-  std::deque<std::deque<Val*>> chains;
-  if (common_consumer_ == nullptr) {
-    chains = DependencyCheck::getAllUseChains(producer_);
-  } else if (common_consumer_ != consumer_) {
-    chains =
-        DependencyCheck::getAllDependencyChains(producer_, common_consumer_);
-  }
-
-  // propagate forward through all chains
-  for (const auto& dep_chain : chains) {
-    int running_producer_pos = known_positions.at(producer_);
-    TORCH_INTERNAL_ASSERT(
-        !dep_chain.empty(), "Computed an invalid common_consumer.");
-
-    std::deque<TensorView*> tv_dep_chain =
-        tv_iterable<std::deque<TensorView*>>(dep_chain);
-
-    TensorView* running_consumer = tv_dep_chain.front();
-    tv_dep_chain.pop_front();
-
-    TensorView* running_producer = nullptr;
-
-    while (!tv_dep_chain.empty()) {
-      running_producer = running_consumer;
-      running_consumer = tv_dep_chain.front();
-      tv_dep_chain.pop_front();
-
-      if (compute_at_ed.find(running_producer) != compute_at_ed.end() &&
-          known_positions.find(running_consumer) != known_positions.end()) {
-        running_producer_pos = known_positions.at(running_consumer);
-        continue;
-      }
-
-      forwardComputeAt_impl(
-          running_producer, running_consumer, running_producer_pos);
-
-
-
-      running_producer_pos = running_producer->getRelativeComputeAtAxis();
-
-      compute_at_ed.emplace(running_producer);
-
-      if (known_positions.find(running_consumer) != known_positions.end()) {
-        TORCH_INTERNAL_ASSERT(
-            known_positions.at(running_consumer) ==
-                running_producer_pos,
-            "Hit a logical inconsistency in computeAt pass.");
-      }
-    }
-    if(common_consumer_==nullptr){
-      if(touched_outputs.find(running_consumer) == touched_outputs.end()){
-        touched_outputs[running_consumer] = running_producer_pos;
-      }else{
-        TORCH_INTERNAL_ASSERT(
-            touched_outputs.at(running_consumer) ==
-                running_producer_pos,
-            "Hit a logical inconsistency in computeAt pass.");
-      }
-    }
   }
 }
 
@@ -387,105 +275,116 @@ void ComputeAt::traverseBackward() {
   // propagate *backward* through all *producer* use_chains or from *producer*
   // to common_consumer if common_consumer exists. Only apply transform if
   // increases computeAt position.
-  std::deque<std::deque<Val*>> chains;
-  if (common_consumer_ == nullptr) {
-    chains = DependencyCheck::getAllUseChains(producer_);
-  } else if (common_consumer_ != consumer_) {
-    chains =
-        DependencyCheck::getAllDependencyChains(producer_, common_consumer_);
-  }
+  auto chains =
+      tvChains(DependencyCheck::getAllDependencyChains(producer_, consumer_));
 
-  for (const auto& val_chain : chains) {
-    auto tv_chain = tv_iterable<std::deque<TensorView*>>(val_chain);
-    TensorView* running_consumer = nullptr;
+  for (auto tv_chain : chains) {
     TensorView* running_producer = tv_chain.back();
-    auto it = known_positions.find(running_producer);
-
-    if (it == known_positions.end()) {
-      TORCH_INTERNAL_ASSERT(
-          common_consumer_ == nullptr,
-          "Hit a logical inconsistency in computeAt pass.");
-      continue;
-    }
-
-    unsigned int running_consumer_pos = it->second;
-
+    TensorView* running_consumer = nullptr;
+    unsigned int running_consumer_pos = consumer_position_;
     tv_chain.pop_back();
+
+    TORCH_INTERNAL_ASSERT(running_producer == consumer_);
 
     while (!tv_chain.empty()) {
       running_consumer = running_producer;
       running_producer = tv_chain.back();
       tv_chain.pop_back();
 
-      if (compute_at_ed.find(running_producer) != compute_at_ed.end() &&
-          known_positions.find(running_producer) != known_positions.end()) {
-        running_consumer_pos = known_positions.at(running_producer);
-        continue;
-      }
+      running_consumer_pos = backwardComputeAt_impl(
+          running_producer, running_consumer, running_consumer_pos);
+    }
+  }
+}
 
-      // If we're already at consumer_position_ that's the max position we could
-      // hope for, don't bother running again.
-      if (running_producer->getThisComputeAtAxis() != consumer_position_) {
-        maybe_computeAt_impl(
-            running_producer, running_consumer, running_consumer_pos);
-      }
-      running_consumer_pos = running_producer->getThisComputeAtAxis();
+void ComputeAt::traverseForward() {
+  // propagate forward through all *producer* use_chains or from *producer* to
+  // common_consumer if common_consumer exists.
+  auto chains = producer_use_chains_;
+  if (common_consumer_ != nullptr) {
+    chains = tvChains(
+        DependencyCheck::getAllDependencyChains(producer_, common_consumer_));
+  }
 
-      if (known_positions.find(running_producer) != known_positions.end()) {
-        TORCH_INTERNAL_ASSERT(
-            known_positions.at(running_producer) ==
-                running_producer->getThisComputeAtAxis(),
-            "Hit a logical inconsistency in the computeAt pass.");
-      }
+  unsigned int producer_pos = tv_data.at(producer_).getNewPosition();
+
+  // propagate forward through all chains
+  for (auto tv_dep_chain : chains) {
+    TensorView* running_producer = nullptr;
+    TensorView* running_consumer = tv_dep_chain.front();
+    tv_dep_chain.pop_front();
+    unsigned int running_producer_pos = producer_pos;
+
+    TORCH_INTERNAL_ASSERT(running_consumer == producer_);
+
+    while (!tv_dep_chain.empty()) {
+      running_producer = running_consumer;
+      running_consumer = tv_dep_chain.front();
+      tv_dep_chain.pop_front();
+
+      running_producer_pos = forwardComputeAt_impl(
+          running_producer, running_consumer, running_producer_pos);
     }
   }
 }
 
 void ComputeAt::runPass() {
-  // Propagate in a way we know result will be correct, which is forward from
-  // consumer and backward from consumer to producer
-  traverseAllKnown();
+  // Initialize tv_data for all TensorViews we may modify
+  auto chains = producer_use_chains_;
+  if (common_consumer_ != nullptr) {
+    chains = tvChains(
+        DependencyCheck::getAllDependencyChains(producer_, common_consumer_));
+  }
 
-  TORCH_INTERNAL_ASSERT(
-      producer_->hasComputeAt(),
-      "Hit a logical inconsistency in the computeAt pass.");
+  for (auto tv_chain : chains) {
+    for (auto tv : tv_chain) {
+      if (tv_data.find(tv) == tv_data.end()) {
+        tv_data[tv] = ComputeAtData(tv);
+      }
+    }
+  }
 
-  // Start at producer and traverse forward
-  traverseForward();
-
-  // Propagate backward from consumer or common consumer, check if it increase
-  // computeAt position on tensors, if so take it!
+  // Traverse backward through all dep chains from producer to consumer
   traverseBackward();
 
+  // Clear data from backward traversal:
+  for (auto entry : tv_data) {
+    entry.second.clearPass();
+  }
+
+  // Start at producer and traverse forward through all chains
+  traverseForward();
+
   setupOutputs();
+
+  for (auto entry : tv_data) {
+    entry.second.validateNewComputeAt();
+  }
 }
 
 void ComputeAt::setupOutputs() {
   if (common_consumer_ != nullptr)
     return;
 
-  std::vector<TensorView*> touched_output_order(touched_outputs.size());
+  std::vector<TensorView*> touched_output_order;
 
-  {
-    size_t i = 0;
-    for (auto out : FusionGuard::getCurFusion()->outputs()) {
-      if (out->getValType() == ValType::TensorView) {
-        if (touched_outputs.find(out->as<TensorView>()) !=
-            touched_outputs.end()) {
-          touched_output_order[i++] = out->as<TensorView>();
+  for (auto out : FusionGuard::getCurFusion()->outputs()) {
+    if (out->getValType() == ValType::TensorView) {
+      if (tv_data.find(out->as<TensorView>()) != tv_data.end()) {
+        if (tv_data[out->as<TensorView>()].touched()) {
+          touched_output_order.push_back(out->as<TensorView>());
         }
       }
     }
-    TORCH_INTERNAL_ASSERT(
-        i == touched_output_order.size(),
-        "Hit a logical inconsistency in the computeAt pass.");
   }
 
-  for (size_t i = 0; i < touched_output_order.size() - 1; i++) {
-    touched_output_order[i]->setComputeAt(
-        touched_output_order[i + 1],
-        touched_outputs.at(touched_output_order[i]),
-        touched_outputs.at(touched_output_order[i + 1]));
+  if (touched_output_order.size() > 0) {
+    for (size_t i = 0; i < touched_output_order.size() - 1; i++) {
+      touched_output_order[i]->setComputeAt(
+          touched_output_order[i + 1],
+          tv_data.at(touched_output_order[i]).getNewPosition(),
+          tv_data.at(touched_output_order[i + 1]).getNewPosition());
+    }
   }
 }
 
@@ -496,14 +395,25 @@ ComputeAt::ComputeAt(
     : producer_(_producer),
       consumer_(_consumer),
       consumer_position_(_consumer_position) {
+  if (consumer_position_ < 0)
+    consumer_position_ += consumer_->nDims();
 
-  producer_use_chains_ = getAllTVUseChains(producer_);
+  TORCH_INTERNAL_ASSERT(
+      consumer_position_ >= 0 && consumer_position_ <= consumer_->nDims(),
+      "Invalid computeAt axis, received ",
+      _consumer_position,
+      " but should be > -",
+      consumer_->nDims(),
+      " and <= ",
+      consumer_->nDims(),
+      ".");
+
+  producer_use_chains_ = tvChains(DependencyCheck::getAllUseChains(producer_));
 
   // Look through all the use chains of producer. Check if there's a single
   // consumer for all chains at or after the consumer specified in the computeAt
   // call.
   setCommonConsumer();
-
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -75,17 +75,14 @@ class ComputeAt {
   // Producer use chains set in, used in a few spots.
   std::deque<std::deque<TensorView*>> producer_use_chains_;
 
-  // Order for forward computeAt pass
-  std::vector<std::pair<TensorView*, TensorView*>> forward_compute_at_order;
-
-  // Order for backward computeAt pass
-  std::vector<std::pair<TensorView*, TensorView*>> backward_compute_at_order;
-
   // TensorViews we've set computeAt of, in this computeAt pass
   std::unordered_set<TensorView*> compute_at_ed;
 
   // TensorViews of which we know their correct computeAt position
   std::unordered_map<TensorView*, unsigned int> known_positions;
+
+  // Outputs if we touched them, and their position.
+  std::unordered_map<TensorView*, unsigned int> touched_outputs;
 
   ComputeAt(
       TensorView* _producer,

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -13,6 +13,71 @@ namespace fuser {
 
 class TensorView;
 
+// We're going to keep data related to the computeAt pass for each TensorView in
+// this structure, this will allow us to keep a single entry in a map from a
+// TensorView to this one.
+struct ComputeAtData {
+ public:
+  ComputeAtData() = default;
+  ComputeAtData(TensorView* tv);
+
+  // Clear after a given traversal. There will be more than one.
+  void clearPass();
+
+  // Makes sure value matches current_traversal_position if
+  // current_traversal_position_set is true. If this is not the case we're in
+  // an invalid compute_at that would require tensor replication.
+  void setPassPosition(unsigned int pos);
+
+  // Returns if new postion is greater or equal to previous seen
+  bool shouldSetComputeAt(unsigned int pos) const {
+    return pos > original_compute_at_position &&
+        pos > new_compute_at_position && pos >= current_traversal_position;
+  }
+
+  // Will return new_compute_at_position, after making sure we cleared out the
+  // last pass
+  unsigned int getNewPosition() const;
+
+  // Will make sure we haven't invalidated previous computeAt calls by
+  // checking that any axes previously in computeAt are still there.
+  void validateNewComputeAt() const;
+
+  // Did we ever compute a value for this TV?
+  bool touched() const {
+    return touched_;
+  }
+
+  // Traversal domain, public as it can freely be set without impacting any
+  // other data. Just a convenience to have it included here.
+  TensorDomain* traversal_domain = nullptr;
+
+ private:
+  // Position to update after a traversal
+  unsigned int new_compute_at_position = 0;
+
+  // Was the position ever modified?
+  bool touched_ = false;
+
+  // Hold onto the provided TensorView
+  TensorView* tv_ref_ = nullptr;
+
+  // Did this tv have computeAt set before calling this computeAt pass?
+  bool original_has_compute_at_ = false;
+
+  // What was the computeAt position before the computeAt pass started
+  unsigned int original_compute_at_position = 0;
+
+  // and what was the previous domain that position was set relative to.
+  TensorDomain* original_domain_ = nullptr;
+
+  // Position we can update during a traversal
+  unsigned int current_traversal_position = 0;
+
+  // Did this traversal set a position or not yet
+  bool current_traversal_position_set = false;
+};
+
 class ComputeAt {
  public:
   static void run(
@@ -25,23 +90,16 @@ class ComputeAt {
   TensorView* consumer_;
   unsigned int consumer_position_;
 
-  // Only keeping these as member functions as ComputeAt is friend of TensorView
-  // Don't want to keep expanding things that are friends of TV.
-  // Runs replayPasC and sets producer computeAt settings
-  void computeAt_impl(
+  // Runs replayPasC and sets producer computeAt settings. Returns
+  // producer_compute_at_axis.
+  unsigned int backwardComputeAt_impl(
       TensorView* producer,
       TensorView* consumer,
       unsigned int consumer_compute_at_axis);
 
-  // Runs replay, and checks computeAt position of producer. If new position
-  // would be higher, actually runs operation.
-  void maybe_computeAt_impl(
-      TensorView* producer,
-      TensorView* consumer,
-      unsigned int consumer_compute_at_axis);
-
-  // Runs replayCasP and sets producer computeAt settings
-  void forwardComputeAt_impl(
+  // Runs replayCasP and sets producer computeAt settings. Returns
+  // consumer_compute_at_axis.
+  unsigned int forwardComputeAt_impl(
       TensorView* producer,
       TensorView* consumer,
       unsigned int producer_compute_at_axis);
@@ -51,17 +109,13 @@ class ComputeAt {
   // call.
   void setCommonConsumer();
 
-  // Propagate in a way we know result will be correct, which is forward from
-  // consumer and backward from consumer to producer
-  void traverseAllKnown();
-
-  // Traverse from producer to common_consumer if exists or through all uses of
-  // producer
-  void traverseForward();
-
-  // Propagate backward from consumer or common consumer, check if it increase
+  // Propagate backward from consumer to producer, check if it increase
   // computeAt position on tensors, if so take it!
   void traverseBackward();
+
+  // Traverse from producer to common_consumer if it exists or through all uses
+  // of producer
+  void traverseForward();
 
   // Run the computeAt pass
   void runPass();
@@ -75,19 +129,18 @@ class ComputeAt {
   // Producer use chains set in, used in a few spots.
   std::deque<std::deque<TensorView*>> producer_use_chains_;
 
-  // TensorViews we've set computeAt of, in this computeAt pass
-  std::unordered_set<TensorView*> compute_at_ed;
-
-  // TensorViews of which we know their correct computeAt position
-  std::unordered_map<TensorView*, unsigned int> known_positions;
-
-  // Outputs if we touched them, and their position.
-  std::unordered_map<TensorView*, unsigned int> touched_outputs;
+  // All we need to know and keep track of for each TensorView in this pass.
+  std::unordered_map<TensorView*, ComputeAtData> tv_data;
 
   ComputeAt(
       TensorView* _producer,
       TensorView* _consumer,
       unsigned int _consumer_position);
+
+  ComputeAt() = delete;
+  ~ComputeAt() = default;
+  ComputeAt(ComputeAt&) = delete;
+  ComputeAt& operator=(const ComputeAt& other) = delete;
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
@@ -114,7 +114,7 @@ void UnrollPass::handle(ForLoop* fl) {
     // Setup unrolled loop information:
 
     // Indices used to detect when we can unroll a loop safely
-    // For loops outside the unroll, it's just he index, for loops inside
+    // For loops outside the unroll, it's just the index, for loops inside
     // the unroll, if it's a thread it's the thread index, otherwise it's
     // the size-1
     std::vector<Val*> unroll_pred_inds;

--- a/torch/csrc/jit/codegen/cuda/transform_iter.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.cpp
@@ -250,7 +250,8 @@ BestEffortReplay::BestEffortReplay(
   std::string err_str(
       "Error during replay, a computeAt was called that conflicts with an rfactor call.");
 
-  // Iterate through target IterDomains' history and compare with what we recorded from replay_domain
+  // Iterate through target IterDomains' history and compare with what we
+  // recorded from replay_domain
   for (auto t_expr : t_exprs) {
     // Going to map the target_domain inputs/outputs to replay_domain
     // inputs/outputs
@@ -364,8 +365,8 @@ BestEffortReplay::BestEffortReplay(
 // "Same" means the DAG to generate td1[i] and td2[i] are the
 // equivelent.
 int BestEffortReplay::findFirstMismatchedID(
-    TensorDomain* td1,
-    TensorDomain* td2) {
+    const TensorDomain* td1,
+    const TensorDomain* td2) {
   std::unordered_map<IterDomain*, IterDomain*> id_map;
   auto rd1 = td1->rootDomain();
   std::unordered_set<IterDomain*> rd2_set(
@@ -374,7 +375,7 @@ int BestEffortReplay::findFirstMismatchedID(
   // Find matching root IterDomains, we could make this O(nlog(n)) if we could
   // sort IterDomains.
   for (size_t i = 0; i < rd1.size(); i++) {
-    for(IterDomain* rd2_id : rd2_set){
+    for (IterDomain* rd2_id : rd2_set) {
       if (rd1[i]->sameAs(rd2_id)) {
         id_map[rd1[i]] = rd2_id;
         rd2_set.erase(rd2_id);
@@ -385,8 +386,8 @@ int BestEffortReplay::findFirstMismatchedID(
 
   BestEffortReplay ber(td2->domain(), td1->domain(), id_map);
 
-  for(size_t i=0; i<td1->domain().size(); i++){
-    if(ber.getReplay().find(td1->axis(i)) == ber.getReplay().end())
+  for (size_t i = 0; i < td1->domain().size(); i++) {
+    if (ber.getReplay().find(td1->axis(i)) == ber.getReplay().end())
       return i;
   }
   return td1->nDims();

--- a/torch/csrc/jit/codegen/cuda/transform_iter.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.cpp
@@ -222,6 +222,7 @@ BestEffortReplay::BestEffortReplay(
   for (auto entry : id_map_)
     leaf_ids_[entry.second] = counter++;
 
+  // Grab expr history of iter domains in target_domain
   std::vector<Expr*> t_exprs = Exprs::getFrom(
       std::vector<Val*>(target_domain.begin(), target_domain.end()));
 
@@ -231,6 +232,7 @@ BestEffortReplay::BestEffortReplay(
   // replay_domain domain. This will be used to propagate the target_domain to
   // replay_domain map.
 
+  // Maps replay domain's IterDomains to the Exprs they're used in
   std::vector<Expr*> r_exprs = Exprs::getFrom(
       std::vector<Val*>(replay_domain.begin(), replay_domain.end()));
   std::unordered_map<IterDomain*, Expr*> replay_expr_map;
@@ -248,6 +250,7 @@ BestEffortReplay::BestEffortReplay(
   std::string err_str(
       "Error during replay, a computeAt was called that conflicts with an rfactor call.");
 
+  // Iterate through target IterDomains' history and compare with what we recorded from replay_domain
   for (auto t_expr : t_exprs) {
     // Going to map the target_domain inputs/outputs to replay_domain
     // inputs/outputs
@@ -355,6 +358,38 @@ BestEffortReplay::BestEffortReplay(
       }
     }
   }
+}
+
+// Find the first position i where td1[i] is not the same as td2[i].
+// "Same" means the DAG to generate td1[i] and td2[i] are the
+// equivelent.
+int BestEffortReplay::findFirstMismatchedID(
+    TensorDomain* td1,
+    TensorDomain* td2) {
+  std::unordered_map<IterDomain*, IterDomain*> id_map;
+  auto rd1 = td1->rootDomain();
+  std::unordered_set<IterDomain*> rd2_set(
+      td2->rootDomain().begin(), td2->rootDomain().end());
+
+  // Find matching root IterDomains, we could make this O(nlog(n)) if we could
+  // sort IterDomains.
+  for (size_t i = 0; i < rd1.size(); i++) {
+    for(IterDomain* rd2_id : rd2_set){
+      if (rd1[i]->sameAs(rd2_id)) {
+        id_map[rd1[i]] = rd2_id;
+        rd2_set.erase(rd2_id);
+        break;
+      }
+    }
+  }
+
+  BestEffortReplay ber(td2->domain(), td1->domain(), id_map);
+
+  for(size_t i=0; i<td1->domain().size(); i++){
+    if(ber.getReplay().find(td1->axis(i)) == ber.getReplay().end())
+      return i;
+  }
+  return td1->nDims();
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_iter.h
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.h
@@ -208,7 +208,9 @@ class TORCH_CUDA_API BestEffortReplay {
 
   // Find the first position i where td1[i] is not the same as td2[i]. "Same"
   // means the DAG and input IDs to generate td1[i] and td2[i] are the same.
-  static int findFirstMismatchedID(TensorDomain* td1, TensorDomain* td2);
+  static int findFirstMismatchedID(
+      const TensorDomain* td1,
+      const TensorDomain* td2);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_iter.h
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.h
@@ -113,6 +113,8 @@ class TORCH_CUDA_API ReplayTransformations : public IterVisitor {
 };
 
 /*
+ * Motivation:
+ *
  * Consider the following program:
  *
  * T1[I0, R1] = T0[I0, I1]
@@ -145,6 +147,9 @@ class TORCH_CUDA_API ReplayTransformations : public IterVisitor {
  * RFactor roots are mapped to intermediate IterDomains  in the target and start
  * replay from there.
  *
+ *
+ * SHORT DESCRIPTION:
+ *
  * This class will validate/do the above. It will also run through
  * transformations in target according to replay_map. If equal transformations
  * already exist in replay_domain history, we will not redo those
@@ -152,13 +157,14 @@ class TORCH_CUDA_API ReplayTransformations : public IterVisitor {
  * existing transformations. This later part is the "best effort" replay. Though
  * we include rfactor replay and validation here.
  *
- * SHORT DESCRIPTION:
- *
  * Given an Expr in target_domain, check if its inputs are in replay_map. If so,
  * check if the mapped domain in replay_map are recorded to be transformed by an
  * equivelent operation in replay_domain's history. If so, "forward" the
  * operation and update replay_map to the outputs of target_domain's output(s),
  * to the output of the equivlent expr's outputs in relpay_domain's history.
+ *
+ * replay_map maps root IDs in the history of target_domain to root IDs in the
+ * history replay_domain
  */
 
 class TORCH_CUDA_API BestEffortReplay {
@@ -173,14 +179,18 @@ class TORCH_CUDA_API BestEffortReplay {
       const std::vector<IterDomain*>& target_domain,
       std::unordered_map<IterDomain*, IterDomain*> replay_map);
 
+  // Return iter domain map from target_domain IDs to their "replayed"
+  // replay_domain IDs. If not in map, was not replayed.
   const std::unordered_map<IterDomain*, IterDomain*>& getReplay() const {
     return id_map_;
   }
 
+  // ids in replay that did not have matching transforms in target_domain
   const std::unordered_map<IterDomain*, size_t>& getUnorderedLeafIDs() {
     return leaf_ids_;
   }
 
+  // Returned ordered set of IDs in getUnorderedLeafIDs
   std::vector<IterDomain*> getLeafIDs() {
     std::set<std::pair<IterDomain*, size_t>, id_int_lt> ordered_set;
     for (auto entry : leaf_ids_)
@@ -195,6 +205,10 @@ class TORCH_CUDA_API BestEffortReplay {
         [](std::pair<IterDomain*, size_t> entry) { return entry.first; });
     return leaf_vec_;
   }
+
+  // Find the first position i where td1[i] is not the same as td2[i]. "Same"
+  // means the DAG and input IDs to generate td1[i] and td2[i] are the same.
+  static int findFirstMismatchedID(TensorDomain* td1, TensorDomain* td2);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_replay.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.cpp
@@ -248,6 +248,7 @@ std::pair<TensorDomain*, unsigned int> TransformReplay::replayPasC(
   BestEffortReplay forward_replay(
       producer->domain(), consumer_CA_ids, replay_root_map);
 
+  // Make a new map based on all the leaves resulting from best effort replay
   id_map forwarded_replay_map;
   for (auto entry : forward_replay.getReplay()) {
     if (forward_replay.getUnorderedLeafIDs().find(entry.second) !=


### PR DESCRIPTION
Reworked the logic of computeAt. Make sure that new computeAt calls do not invalidate previous ones as this can get us in a bad state. If there are conflicts on tensors, i.e. the computeAt call cannot simply reuse intermediate tensors without invalidating previous/current computeAt calls, we will error out. What we would like in this case, is an option where tensors are automatically recomputed if they need to be.