### PR TITLE
Cache Before and Cache After

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -4605,6 +4605,343 @@ void testGPU_FusionReductionScheduler() {
       aten_output.sub(cg_output).abs().max());
 }
 
+void testGPU_FusionCacheBefore() {
+  // TVM Cache Write
+  torch::jit::fuser::cuda::CudaKernel prog;
+  prog.setFusionPtr(std::make_unique<Fusion>());
+  Fusion* fusion = prog.fusion();
+  FusionGuard fg(fusion);
+
+  TensorView* tv0 = makeDummyTensor(2);
+  TensorView* tv1 = add(tv0, new Float(1.0));
+  TensorView* tv2 = mul(tv1, new Float(3.0));
+  fusion->addInput(tv0);
+  fusion->addOutput(tv2);
+  // Before: TV2 = TV1 * 3
+  // After:  TV3 = TV1 * 3;
+  //         TV2 = TV3;
+  // Algorithm
+
+  constexpr int BSX = 32;
+  tv2->split(-1, BSX);
+  tv0->computeAt(tv2, -1);
+
+  // cache_before automatically applies ComputeAt to the cache TensorView
+  TensorView* tv3 = tv2->cache_before();
+  // Schedule
+  // fusion->printMath();
+
+  tv2->axis(0)->parallelize(ParallelType::BIDx);
+  tv2->axis(-1)->parallelize(ParallelType::TIDx);
+  // Thread and Block binding
+  // fusion->printKernel();
+
+  constexpr int M = 32, N = 750;
+  prog.setDevice(0);
+  setupLaunchConfig(
+      prog.fusion(),
+      BSX, // tid_x
+      1, // tid_y
+      1, // tid_z
+      M, // gid_x
+      1, // gid_y
+      1, // gid_z
+      0 // shared_memory size
+  );
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::rand({M, N}, options);
+  at::Tensor cg_output = at::empty({M, N}, options);
+
+  torch::jit::fuser::cuda::compileKernel(&prog);
+  torch::jit::fuser::cuda::runKernel(&prog, {input}, {cg_output}, c10::nullopt);
+
+  at::Tensor aten_output = (input + 1.0) * 3.0;
+  TORCH_CHECK(
+      aten_output.allclose(cg_output, 1e-5, 1e-5),
+      "Error of: ",
+      aten_output.sub(cg_output).abs().sum());
+}
+
+void testGPU_FusionCacheAfter() {
+  // TVM Cache Read
+  torch::jit::fuser::cuda::CudaKernel prog;
+  prog.setFusionPtr(std::make_unique<Fusion>());
+  Fusion* fusion = prog.fusion();
+  FusionGuard fg(fusion);
+
+  TensorView* tv0 = makeDummyTensor(2);
+  TensorView* tv1 = add(tv0, new Float(1.0));
+  TensorView* tv2 = mul(tv1, new Float(3.0));
+  fusion->addInput(tv0);
+  fusion->addOutput(tv2);
+  // Before: TV1 = TV0 + 1
+  // After:  TV3 = TV0;
+  //         TV1 = TV3 + 1
+  // Algorithm
+
+  constexpr int BSX = 32;
+  tv2->split(-1, BSX);
+  tv0->computeAt(tv2, -1);
+
+  // cache_after automatically applies ComputeAt to the cache TensorView
+  TensorView* tv3 = tv0->cache_after();
+  // Schedule
+  // fusion->printMath();
+
+  tv2->axis(0)->parallelize(ParallelType::BIDx);
+  tv2->axis(-1)->parallelize(ParallelType::TIDx);
+  // Thread and Block binding
+  // fusion->printKernel();
+
+  constexpr int M = 32, N = 457;
+  prog.setDevice(0);
+  setupLaunchConfig(
+      prog.fusion(),
+      BSX, // tid_x
+      1, // tid_y
+      1, // tid_z
+      M, // gid_x
+      1, // gid_y
+      1, // gid_z
+      0 // shared_memory size
+  );
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::rand({M, N}, options);
+  at::Tensor cg_output = at::empty({M, N}, options);
+
+  torch::jit::fuser::cuda::compileKernel(&prog);
+  torch::jit::fuser::cuda::runKernel(&prog, {input}, {cg_output}, c10::nullopt);
+
+  at::Tensor aten_output = (input + 1.0) * 3.0;
+  TORCH_CHECK(
+      aten_output.allclose(cg_output, 1e-5, 1e-5),
+      "Error of: ",
+      aten_output.sub(cg_output).abs().sum());
+}
+
+void testGPU_FusionCacheIndirect() {
+  torch::jit::fuser::cuda::CudaKernel prog;
+  prog.setFusionPtr(std::make_unique<Fusion>());
+  Fusion* fusion = prog.fusion();
+  FusionGuard fg(fusion);
+
+  TensorView* tv0 = makeDummyTensor(2);
+  TensorView* tv1 = makeDummyTensor(2);
+  TensorView* tv2 = makeDummyTensor(2);
+  TensorView* tv3 = makeDummyTensor(2);
+  TensorView* tv4 = sub(tv2, tv3);
+  TensorView* tv5 = add(tv1, tv4);
+  TensorView* tv6 = sub(tv5, tv0);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(tv3);
+  fusion->addOutput(tv6);
+  // t6 = ((t1 + (t2 - t3)) - t0)
+
+  // cache_after on inputs placed before schedule
+
+  constexpr int BSX = 32;
+  tv6->split(-1, BSX);
+  tv2->computeAt(tv6, -1);
+
+  TensorView* tv7 = tv5->cache_after();
+  TensorView* tv8 = tv5->cache_before();
+  // Schedule
+  // fusion->printMath();
+
+  tv6->axis(0)->parallelize(ParallelType::BIDx);
+  tv6->axis(-1)->parallelize(ParallelType::TIDx);
+  // Thread and Block binding
+  // fusion->printKernel();
+
+  constexpr int M = 32, N = 810;
+  prog.setDevice(0);
+  setupLaunchConfig(
+      prog.fusion(),
+      BSX, // tid_x
+      1, // tid_y
+      1, // tid_z
+      M, // gid_x
+      1, // gid_y
+      1, // gid_z
+      0 // shared_memory size
+  );
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor in0 = at::rand({M, N}, options);
+  at::Tensor in1 = at::rand({M, N}, options);
+  at::Tensor in2 = at::rand({M, N}, options);
+  at::Tensor in3 = at::rand({M, N}, options);
+  at::Tensor cg_output = at::empty({M, N}, options);
+
+  torch::jit::fuser::cuda::compileKernel(&prog);
+  torch::jit::fuser::cuda::runKernel(
+      &prog, {in0, in1, in2, in3}, {cg_output}, c10::nullopt);
+
+  at::Tensor aten_output = (in1 + (in2 - in3)) - in0;
+  TORCH_CHECK(
+      aten_output.allclose(cg_output, 1e-5, 1e-5),
+      "Error of: ",
+      aten_output.sub(cg_output).abs().sum());
+}
+
+void testGPU_FusionCacheBcast() {
+  torch::jit::fuser::cuda::CudaKernel prog;
+  prog.setFusionPtr(std::make_unique<Fusion>());
+  Fusion* fusion = prog.fusion();
+  FusionGuard fg(fusion);
+
+  TensorView* tv0 = makeDummyTensor(1); // (M, 1)
+  TensorView* tv1 = broadcast(tv0, {false, true});
+  TensorView* tv2 = makeDummyTensor(1); // (1, N)
+  TensorView* tv3 = broadcast(tv2, {true, false});
+  TensorView* tv4 = mul(tv1, tv3);
+  fusion->addInput(tv0);
+  fusion->addInput(tv2);
+  fusion->addOutput(tv4);
+  // Algorithm
+
+  constexpr int BSX = 128;
+  tv4->split(0, BSX);
+  tv4->split(-1, BSX);
+  tv4->reorder({{0, 0}, {1, 2}, {2, 1}, {3, 3}});
+  // M/BSX, N/BSY, BSX, BSY
+  tv0->computeAt(tv4, 2);
+  tv2->computeAt(tv4, 2);
+  // 0, 1 | 2, 3, 4
+
+  // Case 1
+  TensorView* tv5 = tv0->cache_after();
+
+  // Case 2
+  // TensorView* tv5 = tv1->cache_before();
+
+  // Case 3
+  // TensorView* tv5 = tv1->cache_after();
+
+  // Case 4
+  TensorView* tv6 = tv4->cache_before();
+  // Schedule
+  // fusion->printMath();
+
+  tv4->axis(0)->parallelize(ParallelType::BIDx);
+  tv4->axis(1)->parallelize(ParallelType::BIDy);
+  tv4->axis(-1)->parallelize(ParallelType::TIDx);
+  // Manual Replay on TV3
+  tv3->axis(-1)->parallelize(ParallelType::TIDx);
+  tv6->axis(-1)->parallelize(ParallelType::TIDx);
+  // Thread and Block binding
+  // fusion->printKernel();
+
+  constexpr int M = 92, N = 500;
+  const int Mr = ceilDiv_(M, BSX);
+  const int Nr = ceilDiv_(N, BSX);
+  prog.setDevice(0);
+  setupLaunchConfig(
+      prog.fusion(),
+      BSX, // tid_x
+      1, // tid_y
+      1, // tid_z
+      Mr, // gid_x
+      Nr, // gid_y
+      1, // gid_z
+      0 // shared_memory size
+  );
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({M}, options);
+  at::Tensor t1 = at::randn({N}, options);
+  at::Tensor cg_output = at::empty({M, N}, options);
+
+  torch::jit::fuser::cuda::compileKernel(&prog);
+  torch::jit::fuser::cuda::runKernel(
+      &prog, {t0, t1}, {cg_output}, c10::nullopt);
+
+  at::Tensor aten_output = t0.unsqueeze(1).matmul(t1.unsqueeze(0));
+  TORCH_CHECK(
+      aten_output.allclose(cg_output, 1e-5, 1e-5),
+      "Error of: ",
+      aten_output.sub(cg_output).abs().max());
+}
+
+void testGPU_FusionCacheComplex() {
+  torch::jit::fuser::cuda::CudaKernel prog;
+  prog.setFusionPtr(std::make_unique<Fusion>());
+  Fusion* fusion = prog.fusion();
+  FusionGuard fg(fusion);
+
+  TensorView* tv0 = makeDummyTensor(2); // (N, N)
+  TensorView* tv1 = makeDummyTensor(1); // (N)
+  TensorView* tv2 = sum(tv0, {1}); // (N)
+  TensorView* tv3 = broadcast(tv2, {false, true}); // (N, 1)
+  TensorView* tv4 = broadcast(tv1, {true, false}); // (1, N)
+  TensorView* tv5 = mul(tv3, tv4); // (N, N)
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv5);
+  // Algorithm
+
+  // Exception: Cache-Before on reduction Op
+  // TensorView* tv9 = tv2->cache_before();
+
+  constexpr int BSX = 128;
+  tv5->split(0, BSX);
+  tv5->split(-1, BSX);
+  // M/BSX, BSX, N/BSX, BSX
+  tv5->reorder({{0, 0}, {1, 2}, {2, 1}, {3, 3}});
+  // M/BSX, N/BSY, BSX, BSY
+  tv0->computeAt(tv5, 2);
+  tv1->computeAt(tv5, 2);
+  // 0, 1 | 2, 3, 4
+
+  TensorView* tv6 = tv2->cache_after();
+  TensorView* tv7 = tv5->cache_before();
+  // Schedule
+  // fusion->printMath();
+
+  tv5->axis(0)->parallelize(ParallelType::BIDx);
+  tv5->axis(1)->parallelize(ParallelType::BIDy);
+  tv5->axis(-1)->parallelize(ParallelType::TIDx);
+
+  tv4->axis(-1)->parallelize(ParallelType::TIDx);
+  tv7->axis(-1)->parallelize(ParallelType::TIDx);
+  // Thread and Block binding
+  // fusion->printKernel();
+
+  constexpr int N = 800;
+  const int Nr = ceilDiv_(N, BSX);
+  prog.setDevice(0);
+  setupLaunchConfig(
+      prog.fusion(),
+      BSX, // tid_x
+      1, // tid_y
+      1, // tid_z
+      Nr, // gid_x
+      Nr, // gid_y
+      1, // gid_z
+      0 // shared_memory size
+  );
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input1 = at::rand({N, N}, options);
+  at::Tensor input2 = at::rand({N}, options);
+  at::Tensor cg_output = at::empty({N, N}, options);
+
+  torch::jit::fuser::cuda::compileKernel(&prog);
+  torch::jit::fuser::cuda::runKernel(
+      &prog, {input1, input2}, {cg_output}, c10::nullopt);
+
+  at::Tensor aten_output =
+      matmul(sum(input1, 1).unsqueeze(1), input2.unsqueeze(0));
+  TORCH_CHECK(
+      aten_output.allclose(cg_output, 1e-5, 1e-5),
+      "Error of: ",
+      aten_output.sub(cg_output).abs().sum());
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -4817,13 +4817,13 @@ void testGPU_FusionCacheBcast() {
   TensorView* tv5 = tv0->cache_after();
 
   // Case 2
-  TensorView* tv7 = tv1->cache_before();
+  TensorView* tv6 = tv1->cache_before();
 
   // Case 3
-  TensorView* tv8 = tv1->cache_after();
+  TensorView* tv7 = tv1->cache_after();
 
   // Case 4
-  TensorView* tv9 = tv4->cache_before();
+  TensorView* tv8 = tv4->cache_before();
   // Schedule
   // fusion->printMath();
 
@@ -4832,7 +4832,7 @@ void testGPU_FusionCacheBcast() {
   tv4->axis(-1)->parallelize(ParallelType::TIDx);
   // Manual Replay on TV3
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
-  tv9->axis(-1)->parallelize(ParallelType::TIDx);
+  tv8->axis(-1)->parallelize(ParallelType::TIDx);
   // Thread and Block binding
   // fusion->printKernel();
 
@@ -4961,13 +4961,18 @@ void testGPU_FusionCacheMultiConsumer() {
   tv1->computeAt(tv2, -1);
   tv3->computeAt(tv4, -1);
 
-  std::cout << "Before caching\n";
-  fusion->printKernel();
+  // std::cout << "Before caching\n";
+  // fusion->printKernel();
 
-  tv0->cache_after();
+  // Passes
+  auto tv5 = tv1->cache_before();
+  auto tv6 = tv3->cache_before();
 
-  std::cout << "After caching\n";
-  fusion->printKernel();
+  // Fails because tensor must be recomputed twice
+  // auto tv7 = tv0->cache_after();
+
+  // std::cout << "After caching\n";
+  // fusion->printKernel();
 
   prog.setDevice(0);
   torch::jit::fuser::cuda::compileKernel(&prog);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -4817,13 +4817,13 @@ void testGPU_FusionCacheBcast() {
   TensorView* tv5 = tv0->cache_after();
 
   // Case 2
-  // TensorView* tv5 = tv1->cache_before();
+  TensorView* tv7 = tv1->cache_before();
 
   // Case 3
-  // TensorView* tv5 = tv1->cache_after();
+  TensorView* tv8 = tv1->cache_after();
 
   // Case 4
-  TensorView* tv6 = tv4->cache_before();
+  TensorView* tv9 = tv4->cache_before();
   // Schedule
   // fusion->printMath();
 
@@ -4832,7 +4832,7 @@ void testGPU_FusionCacheBcast() {
   tv4->axis(-1)->parallelize(ParallelType::TIDx);
   // Manual Replay on TV3
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
-  tv6->axis(-1)->parallelize(ParallelType::TIDx);
+  tv9->axis(-1)->parallelize(ParallelType::TIDx);
   // Thread and Block binding
   // fusion->printKernel();
 

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -176,7 +176,8 @@ namespace jit {
   _(GPU_FusionCacheAfter)             \
   _(GPU_FusionCacheIndirect)          \
   _(GPU_FusionCacheBcast)             \
-  _(GPU_FusionCacheComplex)
+  _(GPU_FusionCacheComplex)           \
+  _(GPU_FusionCacheMultiConsumer)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -171,7 +171,12 @@ namespace jit {
   _(GPU_FusionZeroDimReduction)       \
   _(GPU_FusionReductionMultiConsumer) \
   _(GPU_FusionBCastAfterReduce)       \
-  _(GPU_FusionReductionScheduler)
+  _(GPU_FusionReductionScheduler)     \
+  _(GPU_FusionCacheBefore)            \
+  _(GPU_FusionCacheAfter)             \
+  _(GPU_FusionCacheIndirect)          \
+  _(GPU_FusionCacheBcast)             \
+  _(GPU_FusionCacheComplex)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -301,13 +301,12 @@ class TORCH_CUDA_API TensorView : public Val {
   TensorView* rFactor(const std::vector<int>& axes);
 
   // Create a TensorView before the original tensor. A common use case is to
-  // read original tensor into shared memory or local registers. Analogous to
-  // TVM Cache_Write
+  // write results into shared memory or registers before moving to global
+  // memory. Analogous to TVM Cache_Write
   TensorView* cache_before();
 
   // Create a TensorView after the original tensor. A common use case is to
-  // write results into shared memory or local registers before moving to global
-  // memory. Analogous to TVM Cache_Read
+  // read tensor into shared memory or registers. Analogous to TVM Cache_Read
   TensorView* cache_after();
 
   MemoryType getMemoryType() const {
@@ -352,10 +351,16 @@ class TORCH_CUDA_API TensorView : public Val {
   }
 
  private:
-  // Create New Expr given consumer - [output of the expression]
+  // In Cache Before, for the origin expr of the original tensor,
+  // we create a new operation where the original tensor is replaced
+  // with the new cache tensor. This function creates a new expr
+  // given the consumer, the output of the expression.
   void createExprConsumer(Expr* expr, TensorView* consumer);
 
-  // Create New Expr given producer - [an input for the expression]
+  // In Cache After, for all the uses of the original tensor, we create
+  // a new operation where the original tensor is replaced with the new
+  // cache tensor. This function creates a new expr given a producer,
+  // an input for the expression.
   void createExprProducer(
       Expr* expr,
       TensorView* current,

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -187,7 +187,7 @@ class GPULower;
  * The reason we need both TensorView and TensorDomain is that we need to have a
  * record of both what is being computed and how it is being computed. For
  * Example we may have the operation: TV3[I, J, K] = TV2[I, J, K] + TV1[I, J, K]
- * The mathematical operationss here are on the tensor views TV1, TV2, and TV3.
+ * The mathematical operations here are on the tensor views TV1, TV2, and TV3.
  * This operation is a pointwise operation. To compute this pointwise operation
  * we iterate over the 3D TensorDomain [I, J, K], where K is the fastest
  * changing dimension.
@@ -300,6 +300,16 @@ class TORCH_CUDA_API TensorView : public Val {
   //
   TensorView* rFactor(const std::vector<int>& axes);
 
+  // Create a TensorView before the original tensor. A common use case is to
+  // read original tensor into shared memory or local registers. Analogous to
+  // TVM Cache_Write
+  TensorView* cache_before();
+
+  // Create a TensorView after the original tensor. A common use case is to
+  // write results into shared memory or local registers before moving to global
+  // memory. Analogous to TVM Cache_Read
+  TensorView* cache_after();
+
   MemoryType getMemoryType() const {
     return memory_type_;
   }
@@ -342,6 +352,15 @@ class TORCH_CUDA_API TensorView : public Val {
   }
 
  private:
+  // Create New Expr given consumer - [output of the expression]
+  void createExprConsumer(Expr* expr, TensorView* consumer);
+
+  // Create New Expr given producer - [an input for the expression]
+  void createExprProducer(
+      Expr* expr,
+      TensorView* current,
+      TensorView* producer);
+
   // Make a copy of the domain (used for Tensor based constructor), likely to be
   // removed soon.
   void copyDomain(const TensorDomain* td);

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -135,7 +135,7 @@ class TORCH_CUDA_API BroadcastOp : public Expr {
 };
 
 /*
- * Reduction operatoin. Out is first initialized to _init. Then
+ * Reduction operation. Out is first initialized to _init. Then
  * _reduction_op_type is used to update out as out = reductionOp(out, in).
  * Output's axes marked as reduction will be reduced to produce an output
  * tensor. The output tensors size will be the size of all

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1027,7 +1027,6 @@ Allocate::Allocate(Val* _val, Val* _size)
         ".");
   }
   addInput(_size);
-  addInput(_val);
   this->name_ = FusionGuard::getCurFusion()->registerExpr(this);
 }
 

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -440,8 +440,17 @@ TensorView* TensorView::cache_after() {
   // After:  This TV -> [Set Op] -> New CA TV -> [Use Op] -> Next TV
 
   // Expr* consumer_uses =
+  size_t count = 0;
   for (auto expr : fusion()->unordered_uses(this)) {
     createExprProducer(expr, this, consumer);
+    ++count;
+  }
+
+  if (count > 1) {
+    std::cout
+        << "WARNING: Cache_After with multiple consumers can create incorrect "
+           "kernels depending on computeAt configuration."
+        << std::endl;
   }
 
   // Expr* consumer_origin =

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -314,6 +314,322 @@ TensorView* TensorView::rFactor(const std::vector<int>& axes) {
   return producer;
 }
 
+// Create a TensorView before the original tensor. A common use case is to read
+// original tensor into shared memory or local registers.
+// Analogous to TVM Cache_Write
+TensorView* TensorView::cache_before() {
+  FusionGuard fg(this->fusion());
+
+  Expr* origin_expr = this->fusion()->origin(this);
+  TORCH_CHECK(
+      origin_expr != nullptr && !this->fusion()->hasInput(this),
+      "Error adding cache_before ",
+      this,
+      " its origin is a nullptr and we restrict using cache_before on an input.");
+
+  TORCH_CHECK(
+      origin_expr != nullptr &&
+          origin_expr->getExprType() != ExprType::ReductionOp,
+      "Error adding cache_before ",
+      this,
+      " its origin is a reduction, instead please use cache_after.");
+
+  // Create Producer Domain
+  // Keep Broadcast Axis (Permanent)
+  auto root_domain = getRootDomain();
+  std::vector<IterDomain*> new_root_domain;
+  for (auto root : root_domain) {
+    if (root->isBroadcast()) {
+      new_root_domain.push_back(new IterDomain(
+          root->start(),
+          root->extent(),
+          root->parallel_method(),
+          false,
+          false,
+          true));
+    } else if (!root->isBroadcast() && !root->isReduction()) {
+      new_root_domain.push_back(new IterDomain(
+          root->start(), root->extent(), root->parallel_method()));
+    }
+  }
+
+  // This domain will be the consumer, so create the producer
+  TensorView* producer = new TensorView(
+      new TensorDomain(new_root_domain), this->getDataType().value());
+
+  // Set domain of consumer
+  TensorView* consumer = this;
+
+  // Insert producer - Cache_Before (CB) - before this TV.
+  // Before: Prev TV -> [Origin Op] -> This TV
+  // After:  Prev TV -> [Origin Op] -> New CB TV -> [Set Op] -> This TV
+
+  // Get inputs for origin expression
+  auto expr_inputs = origin_expr->inputs();
+
+  // Expr* producer_origin =
+  createExprConsumer(origin_expr, producer);
+
+  // Expr* producer_uses =
+  new UnaryOp(UnaryOpType::Set, consumer, producer);
+
+  // Before: This TV -> Next TV
+  // After:  New TV (CB) -> This TV -> Next TV
+  if (this->hasComputeAt()) {
+    TransformReplay::replayPasC(producer, consumer, -1);
+    auto this_ca_pos = this->getThisComputeAtAxis();
+    producer->computeAt(consumer, this_ca_pos);
+  }
+
+  // Before: Prev TV -> This TV
+  // After:  Prev TV -> New TV (CB) -> This TV
+  // Iterate over origin expression inputs for cache_before on outputs
+  for (Val* v : expr_inputs) {
+    if (v->getValType().value() == ValType::TensorView) {
+      TensorView* origin_input = dynamic_cast<TensorView*>(v);
+      if (origin_input->hasComputeAt() &&
+          origin_input->getComputeAtView() == this) {
+        TransformReplay::replayPasC(producer, consumer, -1);
+
+        auto origin_ca_pos = origin_input->getThisComputeAtAxis();
+        auto origin_rel_ca_pos = origin_input->getRelativeComputeAtAxis();
+        origin_input->computeAt(producer, origin_ca_pos);
+        producer->setComputeAt(consumer, origin_rel_ca_pos);
+      }
+    }
+  }
+
+  return producer;
+}
+
+// Create a TensorView after the original tensor. A common use case is to write
+// results into shared memory or local registers before moving to global memory.
+// Analogous to TVM Cache_Read
+TensorView* TensorView::cache_after() {
+  FusionGuard fg(this->fusion());
+
+  // Get all the uses for this Tensorview
+  TORCH_CHECK(
+      !this->fusion()->hasOutput(this),
+      "Error adding cache_after ",
+      this,
+      " we restrict using cache_after on an output.");
+
+  // Create Consumer Domain
+  // Keep Broadcast Axis (Permanent)
+  auto root_domain = getRootDomain();
+  std::vector<IterDomain*> new_root_domain;
+  for (auto root : root_domain) {
+    if (root->isBroadcast()) {
+      new_root_domain.push_back(new IterDomain(
+          root->start(),
+          root->extent(),
+          root->parallel_method(),
+          false,
+          false,
+          true));
+    } else if (!root->isBroadcast() && !root->isReduction()) {
+      new_root_domain.push_back(new IterDomain(
+          root->start(), root->extent(), root->parallel_method()));
+    }
+  }
+
+  // This domain will be the producer, so create the consumer
+  TensorView* consumer = new TensorView(
+      new TensorDomain(new_root_domain), this->getDataType().value());
+
+  // Set domain of producer - No Change
+  TensorView* producer = this;
+
+  // Insert consumer - Cache_After (CA) - after this TV.
+  // Before: This TV -> [Use Op] -> Next TV
+  // After:  This TV -> [Set Op] -> New CA TV -> [Use Op] -> Next TV
+
+  // Expr* consumer_uses =
+  std::unordered_set<Expr*> uses_expr = this->fusion()->unordered_uses(this);
+  for (auto expr : uses_expr) {
+    createExprProducer(expr, this, consumer);
+  }
+
+  // Expr* consumer_origin =
+  new UnaryOp(UnaryOpType::Set, consumer, producer);
+
+  // Before: This TV -> Next TV
+  // After:  This TV -> New TV (After) -> Next TV
+  if (this->hasComputeAt()) {
+    TransformReplay::replayCasP(consumer, producer, -1);
+
+    auto rel_ca_pos = this->getRelativeComputeAtAxis();
+    auto this_ca_pos = this->getThisComputeAtAxis();
+    auto this_ca_view = this->getComputeAtView();
+
+    this->computeAt(consumer, this_ca_pos);
+    consumer->setComputeAt(this_ca_view, rel_ca_pos);
+  }
+
+  // Check users of this TV for computeAt for cache_after on inputs
+  std::unordered_set<Expr*> consumer_uses =
+      this->fusion()->unordered_uses(consumer);
+  for (auto expr : consumer_uses) {
+    auto expr_outputs = expr->outputs();
+    for (Val* v : expr_outputs) {
+      if (v->getValType().value() == ValType::TensorView) {
+        TensorView* output = dynamic_cast<TensorView*>(v);
+        if (output->hasComputeAt()) {
+          TransformReplay::replayPasC(consumer, output, -1);
+          auto output_ca_pos = output->getThisComputeAtAxis();
+          consumer->setComputeAt(output, output_ca_pos);
+        }
+      }
+    }
+  }
+
+  return consumer;
+}
+
+// Create New Expr given consumer - [output of the expression]
+struct CreateExprConsumer : public OptInDispatch {
+ public:
+  static void create(Expr* expr, TensorView* consumer) {
+    CreateExprConsumer cec(consumer);
+    cec.handle(expr);
+  }
+
+ private:
+  explicit CreateExprConsumer(TensorView* consumer) : consumer_(consumer) {}
+
+  void handle(Expr* expr) final {
+    OptInDispatch::handle(expr);
+  }
+
+  void handle(UnaryOp* unary_expr) final {
+    new UnaryOp(unary_expr->getUnaryOpType(), consumer_, unary_expr->in());
+  }
+
+  void handle(BinaryOp* binary_expr) final {
+    new BinaryOp(
+        binary_expr->getBinaryOpType(),
+        consumer_,
+        binary_expr->lhs(),
+        binary_expr->rhs());
+  }
+
+  void handle(TernaryOp* ternary_expr) final {
+    new TernaryOp(
+        ternary_expr->getTernaryOpType(),
+        consumer_,
+        ternary_expr->in1(),
+        ternary_expr->in2(),
+        ternary_expr->in3());
+  }
+
+  void handle(ReductionOp* reduction_expr) final {
+    new ReductionOp(
+        reduction_expr->getReductionOpType(),
+        reduction_expr->init(),
+        consumer_,
+        reduction_expr->in());
+  }
+
+  void handle(BroadcastOp* broadcast_expr) final {
+    new BroadcastOp(consumer_, broadcast_expr->in());
+  }
+
+ private:
+  TensorView* consumer_;
+};
+
+// Create New Expr given producer - [an input for the expression]
+struct CreateExprProducer : public OptInDispatch {
+ public:
+  static void create(Expr* expr, TensorView* current, TensorView* producer) {
+    CreateExprProducer cep(current, producer);
+    cep.handle(expr);
+  }
+
+ private:
+  explicit CreateExprProducer(TensorView* current, TensorView* producer)
+      : current_(current), producer_(producer) {}
+
+  void handle(Expr* expr) final {
+    OptInDispatch::handle(expr);
+  }
+
+  void handle(UnaryOp* unary_expr) final {
+    new UnaryOp(unary_expr->getUnaryOpType(), unary_expr->out(), producer_);
+  }
+
+  void handle(BinaryOp* binary_expr) final {
+    if (binary_expr->lhs()->sameAs(current_)) {
+      new BinaryOp(
+          binary_expr->getBinaryOpType(),
+          binary_expr->out(),
+          producer_,
+          binary_expr->rhs());
+    } else {
+      new BinaryOp(
+          binary_expr->getBinaryOpType(),
+          binary_expr->out(),
+          binary_expr->lhs(),
+          producer_);
+    }
+  }
+
+  void handle(TernaryOp* ternary_expr) final {
+    if (ternary_expr->in1()->sameAs(current_)) {
+      new TernaryOp(
+          ternary_expr->getTernaryOpType(),
+          ternary_expr->out(),
+          producer_,
+          ternary_expr->in2(),
+          ternary_expr->in3());
+    } else if (ternary_expr->in2()->sameAs(current_)) {
+      new TernaryOp(
+          ternary_expr->getTernaryOpType(),
+          ternary_expr->out(),
+          ternary_expr->in1(),
+          producer_,
+          ternary_expr->in3());
+    } else {
+      new TernaryOp(
+          ternary_expr->getTernaryOpType(),
+          ternary_expr->out(),
+          ternary_expr->in1(),
+          ternary_expr->in2(),
+          producer_);
+    }
+  }
+
+  void handle(ReductionOp* reduction_expr) final {
+    new ReductionOp(
+        reduction_expr->getReductionOpType(),
+        reduction_expr->init(),
+        reduction_expr->out(),
+        producer_);
+  }
+
+  void handle(BroadcastOp* broadcast_expr) final {
+    new BroadcastOp(broadcast_expr->out(), producer_);
+  }
+
+ private:
+  TensorView* current_;
+  TensorView* producer_;
+};
+
+// Create New Expr given consumer - [output of the expression]
+void TensorView::createExprConsumer(Expr* expr, TensorView* consumer) {
+  CreateExprConsumer::create(expr, consumer);
+}
+
+// Create New Expr given producer - [an input for the expression]
+void TensorView::createExprProducer(
+    Expr* expr,
+    TensorView* current,
+    TensorView* producer) {
+  CreateExprProducer::create(expr, current, producer);
+}
+
 } // namespace fuser
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/codegen/cuda/transform_replay.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.cpp
@@ -430,7 +430,7 @@ std::pair<TensorDomain*, unsigned int> TransformReplay::replayCasP(
     size_t itc = 0, itp = 0;
     while (itc < consumer_root.size() || itp < producer_root.size()) {
       if (itc < consumer_root.size() && consumer_root[itc]->isBroadcast() &&
-          (itp > producer_root.size() || !producer_root[itp]->isBroadcast())) {
+          (itp >= producer_root.size() || !producer_root[itp]->isBroadcast())) {
         itc++;
         continue;
       }


### PR DESCRIPTION
Add [cache_read](https://docs.tvm.ai/api/python/schedule.html#tvm.schedule.Schedule.cache_read) and [cache_write](https://docs.tvm.ai/api/python/schedule.html#tvm.schedule.Schedule.cache_write) support.

- [X] Rename cache_read and cache_write to cache_before and cache_after respectively
- [X] Insert new TensorView Reader before current TensorView 
 e.g. For `TV2 = TV1.cache_before();` insert `TV2` before `TV1`
- [X] Insert new TensorView Reader after current TensorView 
 e.g. For `TV2 = TV1.cache_after();` insert `TV2` after `TV1`
- [x] Initial ComputeAt support - Call `TV2->computeAt(TV1, axis)` automatically if there exists a `computeAt` on `TV1`
- [x] Broadcast / Reduction support + Automatic ComputeAt replay