### PR TITLE
Enable Static Shared Memory Buffers

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -182,7 +182,7 @@ namespace jit {
   _(GPU_FusionSmem)                                 \
   _(GPU_FusionSmemReduce)                           \
   _(GPU_FusionSmemBlockGemm)                        \
-  _(GPU_FusionSmemSimpleGemm)                       \
+  _(GPU_FusionSmemBlockGemmCache)                   \
   _(GPU_FusionConstCheck)                           \
   _(GPU_FusionSymbolicReduction)                    \
   _(GPU_FusionUnrollWithAlloc)                      \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -179,6 +179,10 @@ namespace jit {
   _(GPU_FusionCacheBcast)                           \
   _(GPU_FusionCacheComplex)                         \
   _(GPU_FusionCacheMultiConsumer)                   \
+  _(GPU_FusionSmem)                                 \
+  _(GPU_FusionSmemReduce)                           \
+  _(GPU_FusionSmemBlockGemm)                        \
+  _(GPU_FusionSmemSimpleGemm)                       \
   _(GPU_FusionConstCheck)                           \
   _(GPU_FusionSymbolicReduction)                    \
   _(GPU_FusionUnrollWithAlloc)                      \

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -158,7 +158,9 @@ void Expr::dispatch(T handler, Expr* expr) {
     case ExprType::Allocate:
       ptr(handler)->handle(expr->as<kir::Allocate>());
       return;
-
+    case ExprType::Sync:
+      ptr(handler)->handle(expr->as<kir::Sync>());
+      return;
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
   }
@@ -293,7 +295,9 @@ void Expr::constDispatch(T handler, const Expr* expr) {
     case ExprType::Allocate:
       ptr(handler)->handle(expr->as<kir::Allocate>());
       return;
-
+    case ExprType::Sync:
+      ptr(handler)->handle(expr->as<kir::Sync>());
+      return;
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
   }
@@ -378,6 +382,8 @@ Statement* Expr::mutatorDispatch(T mutator, Expr* expr) {
       return ptr(mutator)->mutate(expr->as<kir::IfThenElse>());
     case ExprType::Allocate:
       return ptr(mutator)->mutate(expr->as<kir::Allocate>());
+    case ExprType::Sync:
+      return ptr(mutator)->mutate(expr->as<kir::Sync>());
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
   }

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -161,6 +161,7 @@ void Expr::dispatch(T handler, Expr* expr) {
     case ExprType::Sync:
       ptr(handler)->handle(expr->as<kir::Sync>());
       return;
+
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
   }
@@ -298,6 +299,7 @@ void Expr::constDispatch(T handler, const Expr* expr) {
     case ExprType::Sync:
       ptr(handler)->handle(expr->as<kir::Sync>());
       return;
+
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
   }

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -94,6 +94,7 @@ class Allocate;
 class ForLoop;
 class IfThenElse;
 class GridReduction;
+class Sync;
 
 } // namespace kir
 
@@ -154,6 +155,7 @@ class TORCH_CUDA_API OptOutConstDispatch {
   virtual void handle(const kir::ForLoop*) {}
   virtual void handle(const kir::IfThenElse*) {}
   virtual void handle(const kir::Allocate*) {}
+  virtual void handle(const kir::Sync*) {}
 };
 
 class TORCH_CUDA_API OptOutDispatch {
@@ -209,6 +211,7 @@ class TORCH_CUDA_API OptOutDispatch {
   virtual void handle(kir::ForLoop*) {}
   virtual void handle(kir::IfThenElse*) {}
   virtual void handle(kir::Allocate*) {}
+  virtual void handle(kir::Sync*) {}
 };
 
 class TORCH_CUDA_API OptInConstDispatch {
@@ -321,6 +324,9 @@ class TORCH_CUDA_API OptInConstDispatch {
   }
   virtual void handle(const kir::Allocate*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Allocate.");
+  }
+  virtual void handle(const kir::Sync*) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Sync.");
   }
   virtual void handle(const kir::IfThenElse*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for IfThenElse.");
@@ -445,6 +451,9 @@ class TORCH_CUDA_API OptInDispatch {
   virtual void handle(kir::Allocate*) {
     AT_ERROR("Handle not overriden for Allocate.");
   }
+  virtual void handle(kir::Sync*) {
+    AT_ERROR("Handle not overriden for Sync.");
+  }
   virtual void handle(kir::IfThenElse*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for IfThenElse.");
   }
@@ -512,6 +521,7 @@ class TORCH_CUDA_API OptOutMutator {
   virtual Statement* mutate(kir::ForLoop*);
   virtual Statement* mutate(kir::IfThenElse*);
   virtual Statement* mutate(kir::Allocate*);
+  virtual Statement* mutate(kir::Sync*);
 };
 
 class TORCH_CUDA_API OptInMutator {
@@ -596,6 +606,9 @@ class TORCH_CUDA_API OptInMutator {
   }
   virtual Statement* mutate(kir::Allocate*) {
     AT_ERROR("Mutate not overriden for Allocate.");
+  }
+  virtual Statement* mutate(kir::Sync*) {
+    AT_ERROR("Mutate not overriden for Sync.");
   }
   virtual Statement* mutate(kir::IfThenElse*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for IfThenElse.");

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -297,7 +297,7 @@ class TORCH_CUDA_API OptInConstDispatch {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
   }
   virtual void handle(const kir::NamedScalar*) {
-    AT_ERROR("Handle not overriden for NamedScalar.");
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for NamedScalar.");
   }
 
   virtual void handle(const kir::UnaryOp*) {
@@ -376,7 +376,7 @@ class TORCH_CUDA_API OptInDispatch {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
   }
   virtual void handle(NamedScalar*) {
-    AT_ERROR("Handle not overriden for NamedScalar.");
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for NamedScalar.");
   }
 
   // Exprs
@@ -420,10 +420,10 @@ class TORCH_CUDA_API OptInDispatch {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
   }
   virtual void handle(kir::NamedScalar*) {
-    AT_ERROR("Handle not overriden for NamedScalar.");
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for NamedScalar.");
   }
   virtual void handle(kir::TensorIndex*) {
-    AT_ERROR("Handle not overriden for TensorIndex.");
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for TensorIndex.");
   }
 
   virtual void handle(kir::UnaryOp*) {
@@ -449,10 +449,10 @@ class TORCH_CUDA_API OptInDispatch {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for ForLoop.");
   }
   virtual void handle(kir::Allocate*) {
-    AT_ERROR("Handle not overriden for Allocate.");
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Allocate.");
   }
   virtual void handle(kir::Sync*) {
-    AT_ERROR("Handle not overriden for Sync.");
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Sync.");
   }
   virtual void handle(kir::IfThenElse*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for IfThenElse.");
@@ -561,7 +561,7 @@ class TORCH_CUDA_API OptInMutator {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for TensorView.");
   }
   virtual Statement* mutate(kir::TensorIndex*) {
-    AT_ERROR("Mutate not overriden for TensorIndex.");
+    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for TensorIndex.");
   }
   virtual Statement* mutate(Bool*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Bool.");
@@ -573,7 +573,7 @@ class TORCH_CUDA_API OptInMutator {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Int.");
   }
   virtual Statement* mutate(NamedScalar*) {
-    AT_ERROR("Mutate not overriden for NamedScalar.");
+    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for NamedScalar.");
   }
 
   // Exprs
@@ -605,10 +605,10 @@ class TORCH_CUDA_API OptInMutator {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for ForLoop.");
   }
   virtual Statement* mutate(kir::Allocate*) {
-    AT_ERROR("Mutate not overriden for Allocate.");
+    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Allocate.");
   }
   virtual Statement* mutate(kir::Sync*) {
-    AT_ERROR("Mutate not overriden for Sync.");
+    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Sync.");
   }
   virtual Statement* mutate(kir::IfThenElse*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for IfThenElse.");

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
@@ -160,6 +160,10 @@ void IrCloner::handle(const kir::Allocate* node) {
   clone_ = new kir::Allocate(node, this);
 }
 
+void IrCloner::handle(const kir::Sync* node) {
+  clone_ = new kir::Sync(node, this);
+}
+
 void IrCloner::handle(const kir::ForLoop* node) {
   clone_ = new kir::ForLoop(node, this);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -81,6 +81,7 @@ class TORCH_CUDA_API IrCloner : private OptInConstDispatch {
 
   void handle(const kir::TensorIndex*) override;
   void handle(const kir::Allocate*) override;
+  void handle(const kir::Sync*) override;
   void handle(const kir::ForLoop*) override;
   void handle(const kir::IfThenElse*) override;
   void handle(const kir::GridReduction*) override;

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -488,6 +488,10 @@ void IrGraphGenerator::handle(const kir::Allocate* allocate) {
   addArc(allocate->buffer(), allocate);
 }
 
+void IrGraphGenerator::handle(const kir::Sync* sync) {
+  printExpr(sync, "SyncThreads");
+}
+
 void IrGraphGenerator::handle(const Split* split) {
   printExpr(split, IrNodeLabel::gen(split));
   addArc(split->in(), split);

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -84,6 +84,7 @@ class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
   void handle(const kir::ForLoop*) override;
   void handle(const kir::IfThenElse*) override;
   void handle(const kir::Allocate*) override;
+  void handle(const kir::Sync*) override;
 
   void handle(const Split*) override;
   void handle(const Merge*) override;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -328,12 +328,15 @@ class TORCH_CUDA_API TensorView : public Val {
 
   void setMemoryType(MemoryType mt) {
     memory_type_ = mt;
-    bool is_inp_or_out =
-        this->fusion()->hasInput(this) || this->fusion()->hasOutput(this);
-    if (is_inp_or_out)
+    if (fusion()->hasInput(this) || fusion()->hasOutput(this)) {
       TORCH_INTERNAL_ASSERT(
           mt == MemoryType::Global,
           "Tried to set an input or output to the fusion to a non-global memory type.");
+    } else {
+      TORCH_INTERNAL_ASSERT(
+          mt != MemoryType::Global,
+          "Tried to set an intermediate tensor in the fusion to the global memory type.");
+    }
   }
 
   friend TORCH_CUDA_API TransformReplay;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -326,6 +326,16 @@ class TORCH_CUDA_API TensorView : public Val {
     return memory_type_;
   }
 
+  void setMemoryType(MemoryType mt) {
+    memory_type_ = mt;
+    bool is_inp_or_out =
+        this->fusion()->hasInput(this) || this->fusion()->hasOutput(this);
+    if (is_inp_or_out)
+      TORCH_INTERNAL_ASSERT(
+          mt == MemoryType::Global,
+          "Tried to set an input or output to the fusion to a non-global memory type.");
+  }
+
   friend TORCH_CUDA_API TransformReplay;
   friend TORCH_CUDA_API OptOutMutator;
   friend TORCH_CUDA_API LoopNestGenerator;
@@ -352,16 +362,6 @@ class TORCH_CUDA_API TensorView : public Val {
   // Set all computeAt members without checking any correctness. Useful for
   // computeAt with outputs relative to eachother
   void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
-
-  void setMemoryType(MemoryType mt) {
-    memory_type_ = mt;
-    bool is_inp_or_out =
-        this->fusion()->hasInput(this) || this->fusion()->hasOutput(this);
-    if (is_inp_or_out)
-      TORCH_INTERNAL_ASSERT(
-          mt == MemoryType::Global,
-          "Tried to set an input or output to the fusion to a non-global memory type.");
-  }
 
  private:
   int normalizeAxisPos(int pos) const {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -872,6 +872,11 @@ void IRPrinter::handle(const kir::Allocate* a) {
   }
 }
 
+void IRPrinter::handle(const kir::Sync* a) {
+  indent();
+  os << "__syncthreads();\n";
+}
+
 void IRPrinter::handle(const Split* s) {
   os << "Split: ";
   handle(s->in());

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -42,6 +42,7 @@ namespace kir {
 
 class TensorIndex;
 class Allocate;
+class Sync;
 class ForLoop;
 class IfThenElse;
 class GridReduction;
@@ -134,6 +135,7 @@ class TORCH_CUDA_API IRPrinter : public OptInConstDispatch {
   void handle(const kir::ForLoop*) override;
   void handle(const kir::IfThenElse*) override;
   void handle(const kir::Allocate*) override;
+  void handle(const kir::Sync*) override;
 
   void handle(const Split*) override;
   void handle(const Merge*) override;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -339,8 +339,7 @@ Sync::Sync() : Expr(ExprType::Sync) {
   this->name_ = FusionGuard::getCurFusion()->registerExpr(this);
 }
 
-Sync::Sync(const Sync* src, IrCloner* ir_cloner)
-    : Expr(src, ir_cloner) {}
+Sync::Sync(const Sync* src, IrCloner* ir_cloner) : Expr(src, ir_cloner) {}
 
 GridReduction::GridReduction(ReductionOp* reduction_op)
     : Expr(ExprType::GridReduction), reduction_op_(reduction_op) {

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -336,7 +336,7 @@ Allocate::Allocate(const Allocate* src, IrCloner* ir_cloner)
       size_(ir_cloner->clone(src->size_)) {}
 
 Sync::Sync() : Expr(ExprType::Sync) {
-  this->name_ = FusionGuard::getCurFusion()->registerExpr(this);
+  name_ = FusionGuard::getCurFusion()->registerExpr(this);
 }
 
 Sync::Sync(const Sync* src, IrCloner* ir_cloner) : Expr(src, ir_cloner) {}

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -335,6 +335,13 @@ Allocate::Allocate(const Allocate* src, IrCloner* ir_cloner)
       memory_type_(src->memory_type_),
       size_(ir_cloner->clone(src->size_)) {}
 
+Sync::Sync() : Expr(ExprType::Sync) {
+  this->name_ = FusionGuard::getCurFusion()->registerExpr(this);
+}
+
+Sync::Sync(const Sync* src, IrCloner* ir_cloner)
+    : Expr(src, ir_cloner) {}
+
 GridReduction::GridReduction(ReductionOp* reduction_op)
     : Expr(ExprType::GridReduction), reduction_op_(reduction_op) {
   TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -352,6 +352,15 @@ class TORCH_CUDA_API Allocate : public Expr {
   Val* size_ = nullptr;
 };
 
+/*
+ * Sync represents __syncthreads barrier for block level coordination.
+ */
+class TORCH_CUDA_API Sync : public Expr {
+ public:
+  explicit Sync();
+  Sync(const Sync* src, IrCloner* ir_cloner);
+};
+
 class TORCH_CUDA_API Scope {
  public:
   Scope() = default;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -352,12 +352,10 @@ class TORCH_CUDA_API Allocate : public Expr {
   Val* size_ = nullptr;
 };
 
-/*
- * Sync represents __syncthreads barrier for block level coordination.
- */
+// Sync represents __syncthreads barrier for block level coordination.
 class TORCH_CUDA_API Sync : public Expr {
  public:
-  explicit Sync();
+  Sync();
   Sync(const Sync* src, IrCloner* ir_cloner);
 };
 

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -255,6 +255,10 @@ void IndexLowering::handle(kir::Allocate* allocate) {
   pushBack(allocate);
 }
 
+void IndexLowering::handle(kir::Sync* sync) {
+  pushBack(sync);
+}
+
 void IndexLowering::generate(const std::vector<Expr*>& exprs) {
   // Run through loop nests and further lower the expressions
   for (auto* expr : exprs) {

--- a/torch/csrc/jit/codegen/cuda/lower_index.h
+++ b/torch/csrc/jit/codegen/cuda/lower_index.h
@@ -39,6 +39,7 @@ class TORCH_CUDA_API IndexLowering : public OptInDispatch {
   void handle(ReductionOp*) final;
   void handle(BroadcastOp*) final;
   void handle(kir::Allocate*) final;
+  void handle(kir::Sync*) final;
 
   void generate(const std::vector<Expr*>& exprs);
 

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -539,6 +539,8 @@ void reorderExprsForComputeAt(std::vector<Expr*>& exprs) {
 void LoopNestGenerator::generate(const std::vector<Expr*>& exprs) {
   FusionGuard fg(fusion_);
 
+  // Identify all shared memory TensorViews
+  // Initialize Modified status
   for (auto v : fusion_->vals()) {
     if (v->getValType().value() == ValType::TensorView) {
       TensorView* tv = dynamic_cast<TensorView*>(v);

--- a/torch/csrc/jit/codegen/cuda/lower_loops.h
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.h
@@ -52,11 +52,11 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   void cleanSharedMemory();
 
   // Toggle modify status for this shared memory buffer
-  void modifySharedMemory(Val* const key);
+  void modifySharedMemory(Val* key);
 
   // Return the status of the shared memory buffer
   // False if TensorView is not shared memory buffer
-  bool statusSharedMemory(Val* const key) const;
+  bool isModifiedSharedMemory(Val* key) const;
 
   // Create, place, and return the allocation for tv
   Expr* pushAlloc(TensorView*);

--- a/torch/csrc/jit/codegen/cuda/lower_loops.h
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.h
@@ -44,6 +44,20 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   // initialization
   ThreadPredicateMap& thread_predicates_;
 
+  // Fusion shared_memory values
+  // Tracks if shared memory is modified
+  std::unordered_map<Val*, bool> smem_;
+
+  // Clear the modify status for all shared memory buffers
+  void cleanSharedMemory();
+
+  // Toggle modify status for this shared memory buffer
+  void modifySharedMemory(Val* const key);
+
+  // Return the status of the shared memory buffer
+  // False if TensorView is not shared memory buffer
+  bool statusSharedMemory(Val* const key) const;
+
   // Create, place, and return the allocation for tv
   Expr* pushAlloc(TensorView*);
 

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -144,8 +144,7 @@ Statement* OptOutMutator::mutate(kir::Allocate* a) {
 }
 
 Statement* OptOutMutator::mutate(kir::Sync* a) {
-  FusionGuard::getCurFusion()->removeExpr(a);
-  return new kir::Sync();
+  return a;
 }
 
 Statement* OptOutMutator::mutate(Split* s) {

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -143,6 +143,11 @@ Statement* OptOutMutator::mutate(kir::Allocate* a) {
   }
 }
 
+Statement* OptOutMutator::mutate(kir::Sync* a) {
+  FusionGuard::getCurFusion()->removeExpr(a);
+  return new kir::Sync();
+}
+
 Statement* OptOutMutator::mutate(Split* s) {
   IterDomain* ot = mutateAsVal(s->outer())->as<IterDomain>();
   IterDomain* inr = mutateAsVal(s->inner())->as<IterDomain>();

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -91,6 +91,8 @@ static const char* expr_type2string(ExprType t) {
       return "IfThenElse";
     case ExprType::Allocate:
       return "Allocate";
+    case ExprType::Sync:
+      return "SyncThreads";
     case ExprType::Split:
       return "Split";
     case ExprType::Merge:

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -44,6 +44,7 @@ enum class ExprType {
   ForLoop,
   IfThenElse,
   Allocate,
+  Sync,
   KirUnaryOp,
   KirBinaryOp,
   KirTernaryOp,


### PR DESCRIPTION
- [X] Support for static shared_memory allocation
- [X] Create Sync node to represent `__syncthreads` instruction
- [X] Track if Shared Memory is modified in LoopNestGenerator
- [X] Apply `__syncthreads` before reading from shared memory only if the shared memory buffer is modified.
- [X] `__syncthreads` node clears modified status for all shared memory buffers in Fusion
- [X] Create Shared Memory Gemm Example
- [X] Modified Cache_Before to allow reductions on output TV