### PR TITLE
Fix alloc and unroll logic

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1219,8 +1219,8 @@ void testGPU_FusionSimplePWise() {
   tv3->merge(0);
 
   // Split by n_threads
-  tv3->split(-1, 128 * 2);
-  tv3->split(-1, 128);
+  tv3->split(0, 128);
+  tv3->split(0, 4);
 
   // For all inputs, computeAt the output inline, temporaries should be squeezed
   // between them
@@ -1229,7 +1229,7 @@ void testGPU_FusionSimplePWise() {
 
   // Parallelize TV3
   tv3->axis(0)->parallelize(ParallelType::BIDx);
-  tv3->axis(-2)->parallelize(ParallelType::TIDy);
+  tv3->axis(-2)->parallelize(ParallelType::Unroll);
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);


### PR DESCRIPTION
There was a bug in the allocation of tensor views associated with unrolling. When we tried to figure out what size to allocate the intermediate tensor, we would check the computeAt axes. These axes hold important information about if a thread is bound to them, but if the computeAt axis has a reduction in it, we would not use that dimension in the local allocation, even though the local tensor did not have a reduction on that axis. Changed this to use a combination of compute at and local tensor view information.