### PR TITLE
Fix grid reduction predication

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -3603,7 +3603,7 @@ void testGPU_FusionGridReduction6() {
 }
 
 void testGPU_FusionGridReduction7() {
-  const int gdimx = 1;
+  const int gdimx = 4;
   const int bdimx = 128;
 
   Fusion fusion;
@@ -3643,7 +3643,7 @@ void testGPU_FusionGridReduction7() {
   int numel_x = 100;
   int numel_y = 1000;
 
-  //fusion.printKernel();
+  // fusion.printKernel();
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input = at::rand({numel_x, numel_y}, options);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -3602,64 +3602,6 @@ void testGPU_FusionGridReduction6() {
   TORCH_CHECK(aten_output.allclose(cg_output));
 }
 
-void testGPU_FusionGridReduction7() {
-  const int gdimx = 4;
-  const int bdimx = 128;
-
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  TensorView* tv0 = makeDummyTensor(2);
-  fusion.addInput(tv0);
-
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
-  TensorView* tv2 = unaryOp(UnaryOpType::Neg, tv1);
-  TensorView* tv3 = add(tv0, new Float(2));
-
-  fusion.addOutput(tv3);
-  fusion.addOutput(tv2);
-
-  tv1->split(1, bdimx);
-  tv1->split(1, gdimx);
-  tv3->split(1, bdimx);
-  tv3->split(1, gdimx);
-
-  TensorView* tv1_rf = tv1->rFactor({1});
-
-  tv1->computeAt(tv2, -1);
-
-  tv1->axis(0)->parallelize(ParallelType::BIDy);
-  tv1_rf->axis(0)->parallelize(ParallelType::BIDy);
-  tv2->axis(0)->parallelize(ParallelType::BIDy);
-  tv1->axis(-2)->parallelize(ParallelType::BIDx);
-  tv1_rf->axis(-2)->parallelize(ParallelType::BIDx);
-  tv1->axis(-1)->parallelize(ParallelType::TIDx);
-  tv1_rf->axis(-1)->parallelize(ParallelType::TIDx);
-
-  tv3->axis(3)->parallelize(ParallelType::TIDx);
-  tv3->axis(2)->parallelize(ParallelType::BIDx);
-  tv3->axis(0)->parallelize(ParallelType::BIDy);
-
-  int numel_x = 100;
-  int numel_y = 1000;
-
-  // fusion.printKernel();
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input = at::rand({numel_x, numel_y}, options);
-  at::Tensor cg_output_tv2 = at::empty({numel_x}, options);
-  at::Tensor cg_output_tv3 = at::empty_like(input, options);
-
-  torch::jit::fuser::cuda::FusionExecutor fe;
-  fe.compileFusion(&fusion);
-  fe.runFusion({input}, {cg_output_tv3, cg_output_tv2});
-
-  auto aten_output_tv2 = -input.sum({1});
-  TORCH_CHECK(aten_output_tv2.allclose(cg_output_tv2));
-  auto aten_output_tv3 = input + 2.0;
-  TORCH_CHECK(aten_output_tv3.allclose(cg_output_tv3));
-}
-
 void testGPU_FusionNonRedAxisBind() {
   int bid_x = 3;
   int tid_x = 2;
@@ -4998,6 +4940,63 @@ void testGPU_FusionTraversalOrder7() {
       t5.allclose(cg_output_tv5),
       "tv5 error of: ",
       t5.sub(cg_output_tv5).abs().max());
+}
+
+// Test predication of grid reduction
+void testGPU_FusionThreadPredicate() {
+  const int gdimx = 4;
+  const int bdimx = 128;
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeDummyTensor(2);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv2 = unaryOp(UnaryOpType::Neg, tv1);
+  TensorView* tv3 = add(tv0, new Float(2));
+
+  fusion.addOutput(tv3);
+  fusion.addOutput(tv2);
+
+  tv1->split(1, bdimx);
+  tv1->split(1, gdimx);
+  tv3->split(1, bdimx);
+  tv3->split(1, gdimx);
+
+  TensorView* tv1_rf = tv1->rFactor({1});
+
+  tv1->computeAt(tv2, -1);
+
+  tv1->axis(0)->parallelize(ParallelType::BIDy);
+  tv1_rf->axis(0)->parallelize(ParallelType::BIDy);
+  tv2->axis(0)->parallelize(ParallelType::BIDy);
+  tv1->axis(-2)->parallelize(ParallelType::BIDx);
+  tv1_rf->axis(-2)->parallelize(ParallelType::BIDx);
+  tv1->axis(-1)->parallelize(ParallelType::TIDx);
+  tv1_rf->axis(-1)->parallelize(ParallelType::TIDx);
+
+  tv3->axis(3)->parallelize(ParallelType::TIDx);
+  tv3->axis(2)->parallelize(ParallelType::BIDx);
+  tv3->axis(0)->parallelize(ParallelType::BIDy);
+
+  int numel_x = 100;
+  int numel_y = 1000;
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::rand({numel_x, numel_y}, options);
+  at::Tensor cg_output_tv2 = at::empty({numel_x}, options);
+  at::Tensor cg_output_tv3 = at::empty_like(input, options);
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  fe.runFusion({input}, {cg_output_tv3, cg_output_tv2});
+
+  auto aten_output_tv2 = -input.sum({1});
+  TORCH_CHECK(aten_output_tv2.allclose(cg_output_tv2));
+  auto aten_output_tv3 = input + 2.0;
+  TORCH_CHECK(aten_output_tv3.allclose(cg_output_tv3));
 }
 
 } // namespace jit

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -3602,6 +3602,64 @@ void testGPU_FusionGridReduction6() {
   TORCH_CHECK(aten_output.allclose(cg_output));
 }
 
+void testGPU_FusionGridReduction7() {
+  const int gdimx = 1;
+  const int bdimx = 128;
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeDummyTensor(2);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv2 = unaryOp(UnaryOpType::Neg, tv1);
+  TensorView* tv3 = add(tv0, new Float(2));
+
+  fusion.addOutput(tv3);
+  fusion.addOutput(tv2);
+
+  tv1->split(1, bdimx);
+  tv1->split(1, gdimx);
+  tv3->split(1, bdimx);
+  tv3->split(1, gdimx);
+
+  TensorView* tv1_rf = tv1->rFactor({1});
+
+  tv1->computeAt(tv2, -1);
+
+  tv1->axis(0)->parallelize(ParallelType::BIDy);
+  tv1_rf->axis(0)->parallelize(ParallelType::BIDy);
+  tv2->axis(0)->parallelize(ParallelType::BIDy);
+  tv1->axis(-2)->parallelize(ParallelType::BIDx);
+  tv1_rf->axis(-2)->parallelize(ParallelType::BIDx);
+  tv1->axis(-1)->parallelize(ParallelType::TIDx);
+  tv1_rf->axis(-1)->parallelize(ParallelType::TIDx);
+
+  tv3->axis(3)->parallelize(ParallelType::TIDx);
+  tv3->axis(2)->parallelize(ParallelType::BIDx);
+  tv3->axis(0)->parallelize(ParallelType::BIDy);
+
+  int numel_x = 100;
+  int numel_y = 1000;
+
+  //fusion.printKernel();
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::rand({numel_x, numel_y}, options);
+  at::Tensor cg_output_tv2 = at::empty({numel_x}, options);
+  at::Tensor cg_output_tv3 = at::empty_like(input, options);
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  fe.runFusion({input}, {cg_output_tv3, cg_output_tv2});
+
+  auto aten_output_tv2 = -input.sum({1});
+  TORCH_CHECK(aten_output_tv2.allclose(cg_output_tv2));
+  auto aten_output_tv3 = input + 2.0;
+  TORCH_CHECK(aten_output_tv3.allclose(cg_output_tv3));
+}
+
 void testGPU_FusionNonRedAxisBind() {
   int bid_x = 3;
   int tid_x = 2;

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -161,7 +161,6 @@ namespace jit {
   _(GPU_FusionGridReduction4)                       \
   _(GPU_FusionGridReduction5)                       \
   _(GPU_FusionGridReduction6)                       \
-  _(GPU_FusionGridReduction7)                       \
   _(GPU_FusionNonRedAxisBind)                       \
   _(GPU_FusionBCastInnerDim)                        \
   _(GPU_FusionBCastReduce)                          \
@@ -193,7 +192,8 @@ namespace jit {
   _(GPU_FusionTraversalOrder4)                      \
   _(GPU_FusionTraversalOrder5)                      \
   _(GPU_FusionTraversalOrder6)                      \
-  _(GPU_FusionTraversalOrder7)
+  _(GPU_FusionTraversalOrder7)                      \
+  _(GPU_FusionThreadPredicate)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -161,6 +161,7 @@ namespace jit {
   _(GPU_FusionGridReduction4)                       \
   _(GPU_FusionGridReduction5)                       \
   _(GPU_FusionGridReduction6)                       \
+  _(GPU_FusionGridReduction7)                       \
   _(GPU_FusionNonRedAxisBind)                       \
   _(GPU_FusionBCastInnerDim)                        \
   _(GPU_FusionBCastReduce)                          \

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -142,6 +142,10 @@ Expr* Val::getOrigin() {
   return (fusion_->origin(this));
 }
 
+const Expr* Val::getOrigin() const {
+  return (fusion_->origin(this));
+}
+
 // We don't register with the active fusion in Expr as this needs to be done
 // after inputs and outputs are registered with the Expr
 Expr::Expr(ExprType _type) : type_{_type} {

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.h
@@ -233,6 +233,7 @@ class TORCH_CUDA_API Val : public Statement {
   // Returns the Expr that this value is an output of, returns nullptr if none
   // was found
   Expr* getOrigin();
+  const Expr* getOrigin() const;
 
   virtual bool sameType(const Statement* other) {
     return Statement::sameType(other) &&

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -491,7 +491,8 @@ void IRPrinter::handle(const kir::GridReduction* gr) {
   indent();
   // Since block-level reduction is already done, those dimensions
   // with tidx/y/z being true do not participate in the grid reduction.
-  os << "reduction::gridReduce< " << (bidx ? "true" : "false") << ", "
+  os << "bool " << kir::getPredicateFlagName(out->view()) << " = "
+     << "reduction::gridReduce< " << (bidx ? "true" : "false") << ", "
      << (bidy ? "true" : "false") << ", " << (bidz ? "true" : "false") << ", "
      << (!tidx ? "true" : "false") << ", " << (!tidy ? "true" : "false") << ", "
      << (!tidz ? "true" : "false") << " >"

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -198,6 +198,12 @@ GridReduction::GridReduction(const GridReduction* src, IrCloner* ir_cloner)
       reduction_buffer_(ir_cloner->clone(src->reduction_buffer_)),
       sync_buffer_(ir_cloner->clone(src->sync_buffer_)) {}
 
+std::string getPredicateFlagName(const TensorView* val) {
+  std::stringstream ss;
+  ss << "T" << val->name() << "_pred";
+  return ss.str();
+}
+
 } // namespace kir
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -279,6 +279,8 @@ class TORCH_CUDA_API GridReduction : public Expr {
   Allocate* sync_buffer_ = nullptr;
 };
 
+std::string getPredicateFlagName(const TensorView* val);
+
 } // namespace kir
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
@@ -488,6 +488,8 @@ Function parameters:
 - sync_flags: A vector of integers for synchronizations
 - shared_buf: Shared memory buffer for intra-block reduction
 
+Return true when the thread block has the valid result.
+
 Template parameters:
 - X/Y/Z_BLOCK: When true, reduces across thread blocks along the X/Y/Z
   dimensions
@@ -522,7 +524,7 @@ final results.
 template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK,
           bool X_THREAD, bool Y_THREAD, bool Z_THREAD,
           typename T, typename Func>
-__device__ void gridReduce(T& out, T inp_val, Func reduction_op,
+__device__ bool gridReduce(T& out, T inp_val, Func reduction_op,
                            volatile T* work_buf,
                            Tensor<int64_t, 1> sync_flags,
                            T* shared_buf) {
@@ -561,6 +563,9 @@ __device__ void gridReduce(T& out, T inp_val, Func reduction_op,
     gridReduceLastBlock<X_THREAD, Y_THREAD, Z_THREAD>(
         out, (T*)work_buf, seg_size * rblock_size,
         reduction_op, shared_buf);
+    return true;
+  } else {
+    return false;
   }
 }
 } // namespace reduction

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -161,9 +161,7 @@ void LoopNestGenerator::initReduction(
   // Unsafe clone, as we want an exact replica of tv so we can create a UnaryOp
   // to set the buffer to the init_val.
   auto clone = tv->unsafeClone();
-  if (thread_predicates_.find(tv) != thread_predicates_.end()) {
-    thread_predicates_[clone] = thread_predicates_[tv];
-  }
+  thread_predicates_.duplicate(clone, tv);
   // The initilization stmt that will be located inside the loop nest (if there
   // is one)
   auto init_stmt = new UnaryOp(UnaryOpType::Set, clone, init_val);

--- a/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
@@ -10,11 +10,24 @@ namespace fuser {
 
 namespace {
 
-Val* threadPredicate(ParallelType pt) {
-  return eq(NamedScalar::getParallelIndex(pt), new Int(0));
+Val* threadPredicate(
+    ParallelType pt,
+    const ThreadPredicateMap::SourceMapType::mapped_type& sources) {
+  if (pt == ParallelType::BIDx || pt == ParallelType::BIDy ||
+      pt == ParallelType::BIDz) {
+    TORCH_INTERNAL_ASSERT(!sources.empty(), "No predicate source found");
+    TORCH_INTERNAL_ASSERT(sources.size() == 1, "Multiple sources detected");
+    auto src = *sources.begin();
+    auto flag_name = kir::getPredicateFlagName(src);
+    return new NamedScalar(flag_name, DataType::Bool);
+  } else {
+    return eq(NamedScalar::getParallelIndex(pt), new Int(0));
+  }
 }
 
-Bool* getThreadPredicate(const ir_utils::ParallelTypeBitmap& bits) {
+Bool* getThreadPredicate(
+    const ir_utils::ParallelTypeBitmap& bits,
+    const ThreadPredicateMap::SourceMapType& sources) {
   if (bits.none()) {
     return new Bool(true);
   }
@@ -23,11 +36,8 @@ Bool* getThreadPredicate(const ir_utils::ParallelTypeBitmap& bits) {
 
   for (const auto& pt_bool : bits.getMap()) {
     if (pt_bool.second) {
-      if (pred == nullptr) {
-        pred = threadPredicate(pt_bool.first);
-      } else {
-        pred = andOp(pred, threadPredicate(pt_bool.first));
-      }
+      auto tp = threadPredicate(pt_bool.first, sources.at(pt_bool.first));
+      pred = pred == nullptr ? tp : andOp(pred, tp);
     }
   }
 
@@ -39,6 +49,31 @@ Bool* getThreadPredicate(const ir_utils::ParallelTypeBitmap& bits) {
       "Tried to return a predicate that is not a bool val.");
 
   return pred->as<Bool>();
+}
+
+void mergeSourceMap(
+    ThreadPredicateMap::SourceMapType& dst,
+    const ThreadPredicateMap::SourceMapType& src) {
+  for (const auto& kv : src) {
+    const auto& src_key = kv.first;
+    const auto& src_value = kv.second;
+    std::unordered_set<const TensorView*>& dst_set = dst[src_key];
+    for (const auto& src_tensor : src_value) {
+      dst_set.insert(src_tensor);
+    }
+  }
+}
+
+void addToSouceMap(
+    ThreadPredicateMap::SourceMapType& dst,
+    const TensorView* tv,
+    const ir_utils::ParallelTypeBitmap& reducton_pred) {
+  for (const auto& kv : reducton_pred.getMap()) {
+    if (kv.second) {
+      ParallelType ptype = kv.first;
+      dst[ptype].insert(tv);
+    }
+  }
 }
 
 } // namespace
@@ -54,6 +89,8 @@ void ThreadPredicateMap::updateBitSet(Expr* expr) {
   // Which dims are bcast in inputs
   ir_utils::ParallelTypeBitmap input_bcasts;
 
+  SourceMapType src_map;
+
   // Run through inputs and update bitsets
   for (const auto* inp : expr->inputs()) {
     if (!ir_utils::isTV(inp))
@@ -65,7 +102,9 @@ void ThreadPredicateMap::updateBitSet(Expr* expr) {
         "Thread predicate map was not initialized, couldn't find ",
         inp);
 
-    input_preds |= thread_predicates_[tv_inp];
+    input_preds |= at(tv_inp).first;
+
+    mergeSourceMap(src_map, at(tv_inp).second);
 
     ir_utils::ParallelTypeBitmap id_reductions;
     ir_utils::ParallelTypeBitmap id_bcasts;
@@ -100,6 +139,11 @@ void ThreadPredicateMap::updateBitSet(Expr* expr) {
     // Accumulate
     input_reductions |= id_reductions;
     input_bcasts |= id_bcasts;
+
+    if (id_reductions.any()) {
+      // add tv_inp as a source
+      addToSouceMap(src_map, tv_inp, id_reductions);
+    }
   }
 
   // Update map for this tv, before accumulating to other inputs
@@ -119,15 +163,19 @@ void ThreadPredicateMap::updateBitSet(Expr* expr) {
   for (const auto* out : expr->outputs()) {
     if (!ir_utils::isTV(out))
       continue;
-    thread_predicates_[ir_utils::asConstTV(out)] = output_preds;
+    TORCH_INTERNAL_ASSERT(find(ir_utils::asConstTV(out)) == end());
+    emplace(ir_utils::asConstTV(out), output_preds, src_map);
   }
 }
 
 ThreadPredicateMap::ThreadPredicateMap(Fusion* _fusion) : fusion_(_fusion) {
+  // Initialize mapping for input tensors
   for (auto inp : fusion_->inputs()) {
     if (ir_utils::isTV(inp)) {
-      thread_predicates_[ir_utils::asConstTV(inp)] =
-          ir_utils::ParallelTypeBitmap();
+      emplace(
+          ir_utils::asConstTV(inp),
+          ir_utils::ParallelTypeBitmap(),
+          SourceMapType());
     }
   }
   for (auto expr : fusion_->exprs(true)) {
@@ -144,23 +192,46 @@ ThreadPredicateMap::const_iterator ThreadPredicateMap::end() const {
   return thread_predicates_.end();
 }
 
-const ir_utils::ParallelTypeBitmap& ThreadPredicateMap::at(
+const ThreadPredicateMap::MapType::mapped_type& ThreadPredicateMap::at(
     const TensorView* tv) const {
   return thread_predicates_.at(tv);
 }
 
-ir_utils::ParallelTypeBitmap& ThreadPredicateMap::at(const TensorView* tv) {
+ThreadPredicateMap::MapType::mapped_type& ThreadPredicateMap::at(
+    const TensorView* tv) {
   return thread_predicates_.at(tv);
 }
 
-ir_utils::ParallelTypeBitmap& ThreadPredicateMap::operator[](
+ThreadPredicateMap::MapType::mapped_type& ThreadPredicateMap::operator[](
     const TensorView* tv) {
   return thread_predicates_[tv];
 }
 
+void ThreadPredicateMap::emplace(
+    const TensorView* tv,
+    const ir_utils::ParallelTypeBitmap& pred,
+    const SourceMapType& src_map) {
+  emplace(tv, std::make_pair(pred, src_map));
+}
+
+void ThreadPredicateMap::emplace(
+    const TensorView* tv,
+    const std::pair<ir_utils::ParallelTypeBitmap, SourceMapType>&
+        pred_and_src) {
+  thread_predicates_.emplace(tv, pred_and_src);
+}
+
+void ThreadPredicateMap::duplicate(
+    const TensorView* copy,
+    const TensorView* origin) {
+  if (find(origin) != end()) {
+    emplace(copy, at(origin).first, at(origin).second);
+  }
+}
+
 Bool* ThreadPredicateMap::getExpr(const TensorView* tv) const {
   TORCH_INTERNAL_ASSERT(find(tv) != end(), "Couldn't find ", tv);
-  return getThreadPredicate(at(tv));
+  return getThreadPredicate(at(tv).first, at(tv).second);
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
@@ -76,6 +76,17 @@ void addToSouceMap(
   }
 }
 
+void maskSouceMap(
+    ThreadPredicateMap::SourceMapType& src_map,
+    const ir_utils::ParallelTypeBitmap& mask) {
+  for (const auto& kv : mask.getMap()) {
+    if (!kv.second) {
+      ParallelType ptype = kv.first;
+      src_map[ptype].clear();
+    }
+  }
+}
+
 } // namespace
 
 // Update the reduction_deps bitset based on provided Expr
@@ -158,6 +169,8 @@ void ThreadPredicateMap::updateBitSet(Expr* expr) {
 
   // Get rid of any reductions which are bcasted
   output_preds &= bcast_reset_map;
+  // Similarly, drop non-relevant source tensos
+  maskSouceMap(src_map, bcast_reset_map);
 
   // Run through outputs and set bitset predicates
   for (const auto* out : expr->outputs()) {

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -589,7 +589,7 @@ ParallelTypeBitmap getParallelBroadcastDomains(
   if (preds.find(out_tv) == preds.end()) {
     return ParallelTypeBitmap();
   }
-  const ParallelTypeBitmap& out_pred = preds.at(out_tv);
+  const ParallelTypeBitmap& out_pred = preds.at(out_tv).first;
 
   ParallelTypeBitmap parallel_broadcast;
   const auto& iter_domains = out_tv->domain()->domain();


### PR DESCRIPTION
This PR is to fix thread predicate after grid reductions. As summarized in #219, in our current implementation, the code after grid reductions looks like this:

```
  reduction::gridReduce< true, false, false, false, true, true > ( T1[ 0 ], block_result, reduction_add_float, &T7[0], T8, 
  reinterpret_cast<float*>(shared_mem));
  if ( ( ( blockIdx.x == 0 ) && ( threadIdx.x == 0 ) ) ) {
    T2[ ( blockIdx.y * T2.stride[0] ) ]
       = -T1[ 0 ];
  }
```
We generate the predicate expression for `T2 = -T1`. The predicate is correct for `threadIdx` as 0-th threads always have valid reduction results. However, that is random for `blockIdx`, so using 0-th blocks as shown above isn't correct.

With this PR, the generated code looks like this:

```
  bool T1_pred = reduction::gridReduce< true, false, false, false, true, true > ( T1[ 0 ], block_result, reduction_add_float, &T7[0], T8, reinterpret_cast<float*>(shared_mem));
  if ( ( T1_pred && ( threadIdx.x == 0 ) ) ) {
    T2[ ( blockIdx.y * T2.stride[0] ) ]
       = -T1[ 0 ];
  }
```

`gridReduce` now returns a validity flag indicating whether the calling block gets valid results. Expressions using the reduction results use the predicate flag instead of just always using 0-th blocks.

To do so, this PR extends class `ThreadPredicateMap` so that it also records for each tensor its source tensor that cause predication, if exists. More specifically, for each of `TIDx/y/z` and `BIDx/y/z`, it associates a set of `TensorView` that are outputs of reductions and cause predication on that `ParallelType`. There can be multiple such tensors for `TIDx/y/z`, but there must be at most one for `BIDx/y/z` since for `TIDx/y/z` we just use 0-th threads no matter which tensors are associated, but for `BIDx/y/z`, having multiple source tensors mean that there would be multiple predicate flags, but we can't guarantee there exists a thread block that have `true` for all of the flags.

Fixes #219 