### PR TITLE
[WIP] Indexing on contiguity information

### DIFF
--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -83,7 +83,9 @@ TensorView* newOutputTV(const std::vector<Val*>& vals, DataType dtype) {
     }
   }
 
-  return new TensorView(new TensorDomain(out_domain), dtype);
+  return new TensorView(
+      new TensorDomain(out_domain, std::vector<bool>(out_domain.size(), true)),
+      dtype);
 }
 
 std::vector<Val*> maybeBroadcast(const std::vector<Val*>& vals) {
@@ -430,7 +432,8 @@ static TensorView* newForReduction(
         isReduction ? IterType::Reduction : id->getIterType()));
   }
 
-  TensorDomain* td = new TensorDomain(new_domain);
+  TensorDomain* td =
+      new TensorDomain(new_domain, std::vector<bool>(new_domain.size(), true));
   return new TensorView(td, tv->getDataType().value());
 }
 
@@ -535,8 +538,10 @@ TensorView* broadcast(
     }
     ibdim++;
   }
-  TensorView* out_tensor =
-      new TensorView(new TensorDomain(out_domain), inp->getDataType().value());
+
+  TensorView* out_tensor = new TensorView(
+      new TensorDomain(out_domain, std::vector<bool>(out_domain.size(), true)),
+      inp->getDataType().value());
   new BroadcastOp(out_tensor, inp);
   return out_tensor;
 }

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -192,6 +192,7 @@ IndexCompute::IndexCompute(
     return;
   }
 
+  // We may or may not have indices associated with reductions.
   const bool exclude_reduction = td_->nDims() > indices.size();
 
   TORCH_INTERNAL_ASSERT(
@@ -220,13 +221,17 @@ IndexCompute::IndexCompute(
   traverseFrom(indices[0]->fusion(), domain_vals, false);
 
   for (auto id : td_->rootDomain()) {
-    if (exclude_reduction && id->isReduction())
+    if (exclude_reduction && id->isReduction()) {
       continue;
-    auto it = index_map_.find(id);
-    TORCH_INTERNAL_ASSERT(
-        it != index_map_.end(),
-        "Error during index compute, missed computing a value.");
-    indices_.push_back(it->second);
+    } else if (id->getIterType() == IterType::BroadcastWithStride) {
+      indices_.push_back(new Int(0));
+    } else {
+      auto it = index_map_.find(id);
+      TORCH_INTERNAL_ASSERT(
+          it != index_map_.end(),
+          "Error during index compute, missed computing a value.");
+      indices_.push_back(it->second);
+    }
   }
 }
 
@@ -255,6 +260,7 @@ std::vector<bool> IndexCompute::contiguityAnd(
   return contig3;
 }
 
+// TODO: use new mapping functions
 std::vector<bool> IndexCompute::contiguityPasC(
     TensorDomain* producer,
     TensorDomain* consumer) {
@@ -289,84 +295,207 @@ std::vector<bool> IndexCompute::contiguityPasC(
   return as_consumer_contiguity;
 }
 
-kir::TensorIndex* Index::getGlobalProducerIndex(
-    const TensorView* producer,
-    const TensorView* consumer,
-    const std::vector<kir::ForLoop*>& loops) {
-  // Grab indices from the loops
-  std::vector<Val*> indices(loops.size());
-  std::transform(
-      loops.begin(), loops.end(), indices.begin(), [](kir::ForLoop* fl) {
-        return fl->index();
-      });
+namespace {
+// Note returned vector is relative to the producer root (rfactor domain is
+// taken here for producer if there is one as this is the root domain relative
+// to consumer)
+//
+// Consider: T3[ iS{( 1 * i5 )}, iS{i7} ] compute_at( 4, 1 )
+//                 = broadcast( T1[ iS{i5}, iS{i7} ] )
+// which could generate the loop nest:
+//   for(size_t i18 = 0; i18 < ( T4.size[0] * T4.size[1] ); ++i18 ) {
+//     float T3[T1.size[2]];
+//     for(size_t i19 = 0; i19 < T3.size[2]; ++i19 ) {
+//       T2[ 0 ]
+//         = T1[...];
+//
+// Here the first dimension to index T1 must be i18 % T4.size[1], because T3 has
+// a dimension being broadcasted to the extent of T4. This function is looking
+// for these types of cases: where there's a dimension merged into an entry into
+// consumer->domain(), but this dimension does not exist in producer_root.
+// Then we need these dimensions mapped to producer_root, so we know which ones
+// we need to access with modulo. We could go consumer->domain() =>
+// consumer->rootDomain() => producer_root however producer_root could =
+// producer->rfactorDomain() then we still might have to map to
+// producer->rootDomain(). Therefore we might as well go consumer->domain() =>
+// producer->domain() => producer->rootDomain().
+std::vector<bool> getBCastMergedIndices(
+    const TensorDomain* producer,
+    const TensorDomain* consumer) {
+  auto c_root = consumer->rootDomain();
+  auto p_root = producer->hasRFactor() ? producer->rfactorDomain()
+                                       : producer->rootDomain();
 
-  // What would the consumer indices be if it was global, keeping in mind
-  // reduction axes. We have to do the indexing based on consumer because we
-  // could hit instances where we have a loop nest generated based on:
-  // consumer[b{1}, i1, i2] with consumer->merge(0) => consumer[b{1}*i1, i2],
-  // but producer would just be producer[i1, i2]. It would be very hard to
-  // generate indices directly on producer, but if we do it on consumer, and
-  // grab the root axes we need (i1 and i2), it's easy to do.
-  const std::vector<Val*> c_inds = IndexCompute::get(
-      consumer->domain(),
-      indices,
-      IndexCompute::contiguityPasC(producer->domain(), consumer->domain()));
+  auto root_c2p_idmap = TensorDomain::mapRootCtoP(consumer, producer);
 
-  // Computed consumer indices should have everything we need for the producer
-  std::vector<Val*> p_inds;
-  auto p_root = TensorDomain::noReductions(producer->getRootDomain());
-  // Number of root dims that are broadcasted
-  size_t implicit_bcast_dims = 0;
-  {
-    auto c_root = consumer->getRootDomain();
-    size_t it_c = 0, it_p = 0;
-    while (it_c < c_root.size() && it_p < p_root.size()) {
-      const bool is_bcast = p_root[it_p]->isBroadcast();
-      if (c_root[it_c]->isBroadcast() && !p_root[it_p]->isBroadcast()) {
-        it_c++;
-      } else {
-        if (!p_root[it_p]->isBroadcast()) {
-          p_inds.push_back(c_inds[it_c]);
-        } else {
-          if (p_root[it_p]->getIterType() == IterType::BroadcastWithStride) {
-            p_inds.push_back(new Int(0));
-          } else {
-            implicit_bcast_dims++;
-          }
-        }
-        it_c++;
-        it_p++;
-      }
+  std::unordered_set<IterDomain*> bcast_not_in_P;
+  for (auto c_id : c_root) {
+    if (c_id->isBroadcast() &&
+        root_c2p_idmap.find(c_id) == root_c2p_idmap.end()) {
+      bcast_not_in_P.emplace(c_id);
     }
   }
+
+  // If there are no broadcasts in consumer_root that are not in producer_root,
+  // we have nothing to track here.
+  if (bcast_not_in_P.empty()) {
+    return std::vector<bool>(p_root.size(), false);
+  }
+
+  // We want to know what domains in consumer have a merged root broadcast
+  // domain not present in producer root. We then want to map that to the
+  // consumer_root axes impacted by this (the non-bcast axes merged with these
+  // bcast axes). Then we want to map this to producer_root.
+
+  std::vector<bool> c_bcast_merged(consumer->nDims(), false);
+
+  for (size_t c_i = 0; c_i < consumer->nDims(); c_i++) {
+    auto c_id = consumer->axis(c_i);
+    bool missing_bcast = false;
+    bool non_missing_bcast = false;
+
+    auto c_id_inps = ir_utils::iterDomainInputsOf({c_id});
+
+    for (auto inp : c_id_inps) {
+      if (bcast_not_in_P.find(inp) != bcast_not_in_P.end()) {
+        missing_bcast = true;
+      } else {
+        non_missing_bcast = true;
+      }
+    }
+
+    // this domain c_i is guilty.
+    c_bcast_merged[c_i] = missing_bcast && non_missing_bcast;
+  }
+
+  // If these missing axes aren't merged with non-missing axes, we have nothing
+  // to track here.
+  if (std::none_of(c_bcast_merged.begin(), c_bcast_merged.end(), [](bool b) {
+        return b;
+      })) {
+    return std::vector<bool>(p_root.size(), false);
+  }
+
+  // map c_bcast_merged to producer
+  std::vector<bool> p_bcast_merged(producer->nDims(), false);
+  auto c2p =
+      TensorDomain::mapDomainCtoP(consumer->domain(), producer->domain());
+
+  for (size_t c_i = 0; c_i < c2p.size(); c_i++) {
+    auto p_i = c2p[c_i];
+    if (p_i != -1) {
+      p_bcast_merged[p_i] = c_bcast_merged[c_i];
+    }
+  }
+
+  // map p_bcast_merged to producer->root
+  std::vector<bool> p_root_bcast_merged(producer->nDims(), false);
+
+  // map producer root IterDomain to it's position in producer->rootDomain()
+  std::unordered_map<IterDomain*, int> p_root_id_to_index;
+  for (size_t p_i = 0; p_i < producer->rootDomain().size(); p_i++) {
+    p_root_id_to_index[producer->rootDomain()[p_i]] = p_i;
+  }
+
+  for (size_t p_i = 0; p_i < p_bcast_merged.size(); p_i++) {
+    if (!p_bcast_merged[p_i])
+      continue;
+    IterDomain* id = producer->axis((int)p_i);
+    auto id_inps = ir_utils::iterDomainInputsOf({id});
+    for (auto inp : id_inps) {
+      p_root_bcast_merged[p_root_id_to_index.at(id)] = true;
+    }
+  }
+
+  return p_root_bcast_merged;
+}
+} // namespace
+kir::TensorIndex* Index::getGlobalProducerIndex(
+    const TensorView* producer_tv,
+    const TensorView* consumer_tv,
+    const std::vector<kir::ForLoop*>& loops) {
+  // producer_tv->domain() is not replayed as the loop strucutre we were
+  // provided, so replay it to match consumer_tv which is.
+  auto producer = TransformReplay::replayPasC(
+                      producer_tv->domain(), consumer_tv->domain(), -1)
+                      .first;
+
+  auto p2c = TensorDomain::mapDomainPtoC(
+      producer->domain(), consumer_tv->domain()->domain());
+  std::vector<Val*> indices;
+  for (size_t i = 0; i < producer->domain().size(); i++) {
+    indices.push_back(loops[p2c[i]]->index());
+  }
+
+  std::vector<Val*> computed_inds =
+      IndexCompute::get(producer, indices, producer_tv->domain()->contiguity());
+
+  auto p_root = TensorDomain::noReductions(producer->rootDomain());
+
+  {
+    // remove implicit bcast dims from root
+    std::vector<IterDomain*> without_implicit_bcast;
+
+    size_t implicit_bcast_dims = 0;
+    for (auto id : p_root) {
+      if (id->getIterType() != IterType::BroadcastWithoutStride) {
+        without_implicit_bcast.push_back(id);
+      }
+    }
+    p_root = without_implicit_bcast;
+  }
+
   TORCH_INTERNAL_ASSERT(
-      p_inds.size() == p_root.size() - implicit_bcast_dims,
+      computed_inds.size() == p_root.size(),
       "Dimensionality error in code generator while computing tensor indices.");
 
   bool inner_most_dim_contig =
-      producer->getRootDomain()[producer->getRootDomain().size() - 1]
-              ->getIterType() == IterType::Iteration &&
-      producer->domain()->contiguity()[producer->getRootDomain().size() - 1];
+      p_root[p_root.size() - 1]->getIterType() == IterType::Iteration &&
+      producer->contiguity()[p_root.size() - 1];
+
+  // This function is projected as consumer->domain() => consumer->rootDomain()
+  // => producer->rootDomain()
+  auto p_root_bcast_merged =
+      getBCastMergedIndices(producer, consumer_tv->domain());
 
   std::vector<Val*> strided_inds;
-  for (size_t i = 0; i < p_inds.size(); i++) {
-    if (p_inds[i]->isZeroInt()) {
-      strided_inds.push_back(p_inds[i]);
-    } else if (i == p_inds.size() - 1 && inner_most_dim_contig) {
-      strided_inds.push_back(p_inds[i]);
+  for (size_t p_i = 0; p_i < p_root.size(); p_i++) {
+    Val* extent = nullptr;
+    if (computed_inds[p_i]->isZeroInt()) {
+      // If collapsing a dim, but need to module, we need extents multiplied
+      // together
+      if (p_root[p_i]->getIterType() == IterType::Iteration) {
+        if (extent == nullptr) {
+          extent = p_root[p_i]->extent();
+        } else {
+          extent = mul(extent, p_root[p_i]->extent());
+        }
+      }
+      continue;
+    }
+
+    auto maybe_modulo = computed_inds[p_i];
+    if (p_root_bcast_merged[p_i]) {
+      maybe_modulo =
+          mod(computed_inds[p_i],
+              extent == nullptr ? p_root[p_i]->extent()
+                                : mul(extent, p_root[p_i]->extent()));
+    }
+
+    if (p_i == computed_inds.size() - 1 && inner_most_dim_contig) {
+      strided_inds.push_back(maybe_modulo);
     } else {
       std::stringstream ss;
-      ss << "T" << producer->name() << ".stride[" << i << "]";
+      ss << "T" << producer_tv->name() << ".stride[" << p_i << "]";
       strided_inds.push_back(
-          mul(p_inds[i], new NamedScalar(ss.str(), DataType::Int)));
+          mul(maybe_modulo, new NamedScalar(ss.str(), DataType::Int)));
     }
   }
 
-  // Probably shouldn't ever hit this
   if (strided_inds.size() == 0)
     strided_inds.push_back(new Int(0));
 
-  return new kir::TensorIndex(producer, strided_inds);
+  return new kir::TensorIndex(producer_tv, strided_inds);
 }
 
 // Producer index for either shared or local memory
@@ -462,12 +591,11 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
       consumer->domain(), indices, consumer->domain()->contiguity());
 
   auto root_dom = consumer->getRootDomain();
-  TORCH_INTERNAL_ASSERT(
-      computed_inds.size() == TensorDomain::noReductions(root_dom).size() ||
-          computed_inds.size() == root_dom.size(),
-      "Dimensionality error in code generator while computing indexing.");
 
-  // Remove indices associated with reductions.
+  TORCH_INTERNAL_ASSERT(
+      computed_inds.size() == root_dom.size() ||
+          computed_inds.size() == TensorDomain::noReductions(root_dom).size(),
+      "Dimensionality error in code generator while computing indexing.");
   if (computed_inds.size() == root_dom.size()) {
     for (size_t i = 0; i < root_dom.size(); i++) {
       // Do this backwards so erase offset will be right
@@ -515,10 +643,12 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
               ->getIterType() == IterType::Iteration &&
       consumer->domain()->contiguity()[consumer->getRootDomain().size() - 1];
 
+  inner_most_dim_contig = false;
+
   std::vector<Val*> strided_inds;
   for (size_t i = 0; i < computed_inds.size(); i++) {
     if (computed_inds[i]->isZeroInt()) {
-      strided_inds.push_back(computed_inds[i]);
+      continue;
     } else if (i == computed_inds.size() - 1 && inner_most_dim_contig) {
       strided_inds.push_back(computed_inds[i]);
     } else {
@@ -529,7 +659,6 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
     }
   }
 
-  // Probably shouldn't ever hit this
   if (strided_inds.size() == 0)
     strided_inds.push_back(new Int(0));
 

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -2,11 +2,126 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 
 namespace torch {
 namespace jit {
 namespace fuser {
+
+namespace {
+
+struct ContigMergeInfo {
+  bool mergeable = false;
+  std::unordered_set<IterDomain*> zero_root_ids;
+  IterDomain* last_root_id = nullptr;
+};
+
+ContigMergeInfo isContiguousMerge(
+    Merge* merge,
+    const std::vector<IterDomain*>& root_domain,
+    const std::vector<bool>& root_contiguity) {
+  // Check if all inputs to merge operation are contiguous in root domain
+  // (consecutive, and marked contiguous)
+  ContigMergeInfo CMI;
+
+  auto merge_inputs = IterVisitor::getInputsTo({merge->out()});
+
+  std::unordered_set<IterDomain*> merge_input_ids;
+  for (auto inp : merge_inputs) {
+    if (inp->getValType().value() == ValType::IterDomain) {
+      merge_input_ids.emplace(inp->as<IterDomain>());
+    } else {
+      TORCH_INTERNAL_ASSERT(
+          inp->isAnInt(), "Found invalid input to merge heirarchy, ", inp, ".");
+    }
+  }
+
+  CMI.zero_root_ids = merge_input_ids;
+
+  bool contig_dims = true;
+
+  IterDomain* start = nullptr;
+  for (size_t i = 0; i < root_domain.size(); i++) {
+    auto id = root_domain[i];
+
+    if (merge_inputs.find(id) == merge_inputs.end()) {
+      if (start != nullptr) {
+        contig_dims = false;
+      }
+    }
+
+    if (!root_contiguity[i]) {
+      contig_dims = false;
+    }
+
+    CMI.last_root_id = id;
+
+    start = start == nullptr ? id : start;
+
+    if (start->getIterType() != id->getIterType()) {
+      break;
+    }
+
+    merge_input_ids.erase(root_domain[i]);
+  }
+
+  if (!(merge_input_ids.empty() && contig_dims)) {
+    CMI.zero_root_ids.clear();
+    CMI.last_root_id = nullptr;
+    return CMI;
+  }
+
+  CMI.zero_root_ids.erase(CMI.last_root_id);
+
+  auto exprs = ExprSort::getExprs(
+      merge->out()->fusion(), std::vector<Val*>({merge->out()}));
+  std::unordered_set<IterDomain*> expr_inputs;
+  std::unordered_set<IterDomain*> expr_outputs;
+
+  for (auto expr : exprs) {
+    if (expr->getExprType().value() == ExprType::Split) {
+      CMI.zero_root_ids.clear();
+      CMI.last_root_id = nullptr;
+      return CMI;
+    }
+
+    for (auto inp : expr->inputs()) {
+      if (inp->getValType().value() == ValType::IterDomain) {
+        expr_inputs.emplace(inp->as<IterDomain>());
+      }
+    }
+    for (auto out : expr->outputs()) {
+      if (out->getValType().value() == ValType::IterDomain) {
+        expr_outputs.emplace(out->as<IterDomain>());
+      }
+    }
+  }
+
+  expr_outputs.erase(merge->out()->as<IterDomain>());
+
+  for (auto val : root_domain) {
+    expr_inputs.erase(val->as<IterDomain>());
+  }
+
+  std::unordered_set<IterDomain*> inp_out_diff;
+  std::set_symmetric_difference(
+      expr_inputs.begin(),
+      expr_inputs.end(),
+      expr_outputs.begin(),
+      expr_outputs.end(),
+      std::inserter(inp_out_diff, inp_out_diff.begin()));
+
+  if (inp_out_diff.empty()) {
+    CMI.mergeable = true;
+  } else {
+    CMI.zero_root_ids.clear();
+    CMI.last_root_id = nullptr;
+  }
+  return CMI;
+}
+
+} // namespace
 
 void IndexCompute::handle(Split* split) {
   auto in_id = split->in();
@@ -36,6 +151,17 @@ void IndexCompute::handle(Merge* merge) {
 
   auto out_ind = out_it->second;
 
+  auto mergableInfo =
+      isContiguousMerge(merge, td_->rootDomain(), root_contiguity_);
+
+  if (mergableInfo.mergeable) {
+    index_map_[mergableInfo.last_root_id] = out_ind;
+    for (auto root_ind : mergableInfo.zero_root_ids) {
+      index_map_[root_ind] = new Int(0);
+    }
+    return;
+  }
+
   Val* I = inner_id->extent();
   Val* outer_ind = div(out_ind, I);
   Val* inner_ind = mod(out_ind, I);
@@ -57,30 +183,33 @@ void IndexCompute::handle(Expr* e) {
 }
 
 IndexCompute::IndexCompute(
-    const TensorDomain* td,
-    const std::vector<Val*>& indices) {
-  if (td->nDims() == 0 || indices.empty()) {
+    const TensorDomain* _td,
+    const std::vector<Val*>& indices,
+    const std::vector<bool>& _root_contiguity)
+    : td_(_td), root_contiguity_(_root_contiguity) {
+  if (td_->nDims() == 0 || indices.empty()) {
     indices_.push_back(new Int(0));
     return;
   }
 
-  const bool exclude_reduction = td->nDims() > indices.size();
+  const bool exclude_reduction = td_->nDims() > indices.size();
 
   TORCH_INTERNAL_ASSERT(
-      td->noReductions().size() == indices.size() ||
-          td->nDims() == indices.size(),
+      td_->noReductions().size() == indices.size() ||
+          td_->nDims() == indices.size(),
       "For IndexCompute the number of axes should match the number of dimensions in the TensorDomain.");
 
   {
     size_t i = 0;
-    for (auto id : td->domain()) {
+    for (auto id : td_->domain()) {
       if (exclude_reduction && id->isReduction())
         continue;
       index_map_[id] = indices[i++];
     }
   }
 
-  const std::vector<Val*> domain_vals(td->domain().begin(), td->domain().end());
+  const std::vector<Val*> domain_vals(
+      td_->domain().begin(), td_->domain().end());
 
   // Run the split/merge operations backwards. This will modify the index_map_
   // so it can be used to index the root TensorDomain. Each entry in the root
@@ -90,7 +219,7 @@ IndexCompute::IndexCompute(
   // map at the rfactor IterDomains.
   traverseFrom(indices[0]->fusion(), domain_vals, false);
 
-  for (auto id : td->rootDomain()) {
+  for (auto id : td_->rootDomain()) {
     if (exclude_reduction && id->isReduction())
       continue;
     auto it = index_map_.find(id);
@@ -103,9 +232,61 @@ IndexCompute::IndexCompute(
 
 std::vector<Val*> IndexCompute::get(
     const TensorDomain* td,
-    const std::vector<Val*>& _indices) {
-  IndexCompute ic(td, _indices);
+    const std::vector<Val*>& _indices,
+    const std::vector<bool>& _root_contiguity) {
+  IndexCompute ic(td, _indices, _root_contiguity);
   return ic.indices_;
+}
+
+std::vector<bool> IndexCompute::contiguityAnd(
+    const std::vector<bool>& contig1,
+    const std::vector<bool>& contig2) {
+  TORCH_INTERNAL_ASSERT(
+      contig1.size() == contig2.size(),
+      "Called contiguityAnd with mismatched vectors.");
+
+  std::vector<bool> contig3;
+  std::transform(
+      contig1.begin(),
+      contig1.end(),
+      contig2.begin(),
+      std::back_inserter(contig3),
+      std::logical_and<>());
+  return contig3;
+}
+
+std::vector<bool> IndexCompute::contiguityPasC(
+    TensorDomain* producer,
+    TensorDomain* consumer) {
+  const std::vector<bool>& producer_contiguity = producer->contiguity();
+  std::vector<bool> as_consumer_contiguity;
+
+  auto c_root = consumer->rootDomain();
+  auto p_root = producer->rootDomain();
+
+  size_t p_ind = 0;
+  size_t c_ind = 0;
+  while (p_ind < p_root.size()) {
+    if (p_root[p_ind]->isReduction()) {
+      p_ind++;
+    } else if (
+        c_root[c_ind]->isBroadcast() &&
+        p_root[p_ind]->getIterType() != c_root[c_ind]->getIterType()) {
+      c_ind++;
+      as_consumer_contiguity.push_back(false);
+    } else {
+      as_consumer_contiguity.push_back(producer_contiguity[p_ind]);
+      c_ind++;
+      p_ind++;
+    }
+  }
+
+  while (c_ind < c_root.size()) {
+    as_consumer_contiguity.push_back(false);
+    c_ind++;
+  }
+
+  return as_consumer_contiguity;
 }
 
 kir::TensorIndex* Index::getGlobalProducerIndex(
@@ -120,9 +301,16 @@ kir::TensorIndex* Index::getGlobalProducerIndex(
       });
 
   // What would the consumer indices be if it was global, keeping in mind
-  // reduction axes:
-  const std::vector<Val*> c_inds =
-      IndexCompute::get(consumer->domain(), indices);
+  // reduction axes. We have to do the indexing based on consumer because we
+  // could hit instances where we have a loop nest generated based on:
+  // consumer[b{1}, i1, i2] with consumer->merge(0) => consumer[b{1}*i1, i2],
+  // but producer would just be producer[i1, i2]. It would be very hard to
+  // generate indices directly on producer, but if we do it on consumer, and
+  // grab the root axes we need (i1 and i2), it's easy to do.
+  const std::vector<Val*> c_inds = IndexCompute::get(
+      consumer->domain(),
+      indices,
+      IndexCompute::contiguityPasC(producer->domain(), consumer->domain()));
 
   // Computed consumer indices should have everything we need for the producer
   std::vector<Val*> p_inds;
@@ -155,12 +343,23 @@ kir::TensorIndex* Index::getGlobalProducerIndex(
       p_inds.size() == p_root.size() - implicit_bcast_dims,
       "Dimensionality error in code generator while computing tensor indices.");
 
+  bool inner_most_dim_contig =
+      producer->getRootDomain()[producer->getRootDomain().size() - 1]
+              ->getIterType() == IterType::Iteration &&
+      producer->domain()->contiguity()[producer->getRootDomain().size() - 1];
+
   std::vector<Val*> strided_inds;
   for (size_t i = 0; i < p_inds.size(); i++) {
-    std::stringstream ss;
-    ss << "T" << producer->name() << ".stride[" << i << "]";
-    strided_inds.push_back(
-        mul(p_inds[i], new NamedScalar(ss.str(), DataType::Int)));
+    if (p_inds[i]->isZeroInt()) {
+      strided_inds.push_back(p_inds[i]);
+    } else if (i == p_inds.size() - 1 && inner_most_dim_contig) {
+      strided_inds.push_back(p_inds[i]);
+    } else {
+      std::stringstream ss;
+      ss << "T" << producer->name() << ".stride[" << i << "]";
+      strided_inds.push_back(
+          mul(p_inds[i], new NamedScalar(ss.str(), DataType::Int)));
+    }
   }
 
   // Probably shouldn't ever hit this
@@ -253,15 +452,14 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
     const std::vector<kir::ForLoop*>& loops) {
   // If we're initializing a reduction buffer, we won't have the reduction
   // loops. If we're actually performing the reduction, we will.
-
   std::vector<Val*> indices(loops.size());
   std::transform(
       loops.begin(), loops.end(), indices.begin(), [](kir::ForLoop* fl) {
         return fl->index();
       });
 
-  std::vector<Val*> computed_inds =
-      IndexCompute::get(consumer->domain(), indices);
+  std::vector<Val*> computed_inds = IndexCompute::get(
+      consumer->domain(), indices, consumer->domain()->contiguity());
 
   auto root_dom = consumer->getRootDomain();
   TORCH_INTERNAL_ASSERT(
@@ -269,6 +467,7 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
           computed_inds.size() == root_dom.size(),
       "Dimensionality error in code generator while computing indexing.");
 
+  // Remove indices associated with reductions.
   if (computed_inds.size() == root_dom.size()) {
     for (size_t i = 0; i < root_dom.size(); i++) {
       // Do this backwards so erase offset will be right
@@ -277,6 +476,9 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
         computed_inds.erase(computed_inds.begin() + axis);
     }
   }
+
+  // Number of root dims that are broadcasted
+  size_t implicit_bcast_dims = 0;
 
   {
     size_t root_i = 0, inds_i = 0;
@@ -288,6 +490,7 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
             IterType::BroadcastWithoutStride) {
           computed_inds.erase(computed_inds.begin() + inds_i);
           root_i++;
+          implicit_bcast_dims++;
         } else {
           if (root_dom[root_i]->getIterType() ==
               IterType::BroadcastWithStride) {
@@ -300,15 +503,30 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
     }
   }
 
+  TORCH_INTERNAL_ASSERT(
+      computed_inds.size() ==
+              TensorDomain::noReductions(root_dom).size() -
+                  implicit_bcast_dims ||
+          computed_inds.size() == root_dom.size() - implicit_bcast_dims,
+      "Dimensionality error in code generator while computing tensor indices.");
+
+  bool inner_most_dim_contig =
+      consumer->getRootDomain()[consumer->getRootDomain().size() - 1]
+              ->getIterType() == IterType::Iteration &&
+      consumer->domain()->contiguity()[consumer->getRootDomain().size() - 1];
+
   std::vector<Val*> strided_inds;
   for (size_t i = 0; i < computed_inds.size(); i++) {
     if (computed_inds[i]->isZeroInt()) {
-      continue;
+      strided_inds.push_back(computed_inds[i]);
+    } else if (i == computed_inds.size() - 1 && inner_most_dim_contig) {
+      strided_inds.push_back(computed_inds[i]);
+    } else {
+      std::stringstream ss;
+      ss << "T" << consumer->name() << ".stride[" << i << "]";
+      strided_inds.push_back(
+          mul(computed_inds[i], new NamedScalar(ss.str(), DataType::Int)));
     }
-    std::stringstream ss;
-    ss << "T" << consumer->name() << ".stride[" << i << "]";
-    strided_inds.push_back(
-        mul(computed_inds[i], new NamedScalar(ss.str(), DataType::Int)));
   }
 
   // Probably shouldn't ever hit this

--- a/torch/csrc/jit/codegen/cuda/index_compute.h
+++ b/torch/csrc/jit/codegen/cuda/index_compute.h
@@ -65,14 +65,31 @@ class IndexCompute : public BackwardVisitor {
   // Otherwise warning on runBackward as it hides an overloaded virtual
   // using TransformIter::runBackward;
 
-  IndexCompute(const TensorDomain* td, const std::vector<Val*>& _indices);
+  IndexCompute(
+      const TensorDomain* _td,
+      const std::vector<Val*>& indices,
+      const std::vector<bool>& _root_contiguity);
+
+  const TensorDomain* td_;
   std::unordered_map<IterDomain*, Val*> index_map_;
   std::vector<Val*> indices_;
+  const std::vector<bool> root_contiguity_;
 
  public:
   static std::vector<Val*> get(
-      const TensorDomain* td,
-      const std::vector<Val*>& _indices);
+      const TensorDomain* _td,
+      const std::vector<Val*>& _indices,
+      const std::vector<bool>& _root_contiguity);
+
+  // Map producer contiguity information to consumer, if entries don't match
+  // mark as false
+  static std::vector<bool> contiguityPasC(
+      TensorDomain* producer,
+      TensorDomain* consumer);
+
+  static std::vector<bool> contiguityAnd(
+      const std::vector<bool>& contig1,
+      const std::vector<bool>& contig2);
 };
 
 // Simple interface for IndexCompute

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -386,10 +386,6 @@ class TORCH_CUDA_API TensorView : public Val {
       TensorView* current,
       TensorView* producer);
 
-  // Make a copy of the domain (used for Tensor based constructor), likely to be
-  // removed soon.
-  void copyDomain(const TensorDomain* td);
-
   // Return position in compute_at_view that lines up with this->axis(pos)?
   int getComputeAtRelPos(int pos);
   void setThisComputeAtAxis();

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -462,6 +462,46 @@ class TORCH_CUDA_API TensorDomain : public Val {
   static bool hasBroadcast(const std::vector<IterDomain*>&);
   static bool hasReduction(const std::vector<IterDomain*>&);
 
+  // return mapping of consumer_domain[i] = producer_domain[result_vector[i]]
+  // assuming there exists a direct consumer-producer mapping. If axis exists in
+  // consumer (broadcast) but not in producer, mapping will be result_vector[i]
+  // = -1.
+  static std::vector<int64_t> mapDomainCtoP(
+      const std::vector<IterDomain*>& consumer,
+      const std::vector<IterDomain*>& producer);
+
+  // Create a map from consumer root IterDomains -> producer root IterDomains.
+  // Constrain will restrict which consumer root IterDomains we map to the
+  // producer IterDomains. Only those root consumer IDs present in
+  // consumer_root_dims_to_map will be attempted to map to their corresponding
+  // producer IDs.
+  static std::unordered_map<IterDomain*, IterDomain*> mapRootCtoP(
+      const TensorDomain* consumer,
+      const TensorDomain* producer,
+      bool constrain = false,
+      std::unordered_set<IterDomain*> consumer_root_dims_to_map =
+          std::unordered_set<IterDomain*>());
+
+  // return mapping of consumer_domain[i] = producer_domain[result_vector[i]]
+  // assuming there exists a direct consumer-producer mapping. If axis exists in
+  // consumer (broadcast) but not in producer, mapping will be result_vector[i]
+  // = -1.
+  static std::vector<int64_t> mapDomainPtoC(
+      const std::vector<IterDomain*>& producer,
+      const std::vector<IterDomain*>& consumer);
+
+  // Create a map from producer root IterDomains -> consumer root IterDomains.
+  // Constrain will restrict which producer root IterDomains we map to the
+  // consumer IterDomains. Only those root producer IDs present in
+  // producer_root_dims_to_map will be attempted to map to their corresponding
+  // consumer IDs.
+  static std::unordered_map<IterDomain*, IterDomain*> mapRootPtoC(
+      const TensorDomain* producer,
+      const TensorDomain* consumer,
+      bool constrain = false,
+      std::unordered_set<IterDomain*> producer_root_dims_to_map =
+          std::unordered_set<IterDomain*>());
+
   // pair is in order where second is the consumer of first
   std::pair<TensorDomain*, TensorDomain*> rFactor(const std::vector<int>& axes);
 

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -378,16 +378,20 @@ class TORCH_CUDA_API TensorDomain : public Val {
   TensorDomain(TensorDomain&& other) = delete;
   TensorDomain& operator=(TensorDomain&& other) = delete;
 
-  explicit TensorDomain(std::vector<IterDomain*> _domain);
+  explicit TensorDomain(
+      std::vector<IterDomain*> _domain,
+      std::vector<bool> _contiguity = std::vector<bool>());
 
   TensorDomain(
       std::vector<IterDomain*> _root_domain,
-      std::vector<IterDomain*> _domain);
+      std::vector<IterDomain*> _domain,
+      std::vector<bool> _contiguity = std::vector<bool>());
 
   TensorDomain(
       std::vector<IterDomain*> _root_domain,
       std::vector<IterDomain*> _rfactor_domain,
-      std::vector<IterDomain*> _domain);
+      std::vector<IterDomain*> _domain,
+      std::vector<bool> _contiguity = std::vector<bool>());
 
   TensorDomain(const TensorDomain* src, IrCloner* ir_cloner);
 
@@ -403,6 +407,18 @@ class TORCH_CUDA_API TensorDomain : public Val {
 
   const std::vector<IterDomain*>& domain() const {
     return domain_;
+  }
+
+  const std::vector<bool>& contiguity() const {
+    return contiguity_;
+  }
+
+  std::string getContiguityString() const {
+    std::stringstream ss;
+    for (auto b : contiguity()) {
+      ss << (b ? "t" : "f");
+    }
+    return ss.str();
   }
 
   bool hasReduction() const;
@@ -471,6 +487,7 @@ class TORCH_CUDA_API TensorDomain : public Val {
   std::vector<IterDomain*> no_bcast_domain_;
   std::vector<IterDomain*> no_reduction_domain_;
   const std::vector<IterDomain*> rfactor_domain_;
+  const std::vector<bool> contiguity_;
 };
 
 /*

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -171,14 +171,21 @@ void IRPrinter::handle(const IterDomain* id) {
 
 void IRPrinter::handle(const kir::TensorIndex* ti) {
   os << "T" << ti->view()->name();
-  if (ti->nDims() == 0) {
+  std::vector<Val*> non_zero_inds;
+  for (auto* ind : ti->indices()) {
+    if (!ind->isZeroInt()) {
+      non_zero_inds.push_back(ind);
+    }
+  }
+
+  if (non_zero_inds.size() == 0) {
     os << "[ 0 ]";
     return;
   }
 
   os << "[ ";
   bool first = true;
-  for (auto* ind : ti->indices()) {
+  for (auto* ind : non_zero_inds) {
     if (!first)
       os << " + ";
     print_inline(ind);

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -849,6 +849,127 @@ bool TensorDomain::hasReduction(const std::vector<IterDomain*>& td) {
   return false;
 }
 
+// return mapping of consumer_domain[i] = producer_domain[result_vector[i]]
+// assuming there exists a direct consumer-producer mapping. If axis exists in
+// consumer (broadcast) but not in producer, mapping will be result_vector[i] =
+// -1.
+std::vector<int64_t> TensorDomain::mapDomainCtoP(
+    const std::vector<IterDomain*>& consumer,
+    const std::vector<IterDomain*>& producer) {
+  std::vector<int64_t> consumer_to_producer(consumer.size(), -1);
+
+  size_t itc = 0, itp = 0;
+  while (itc < consumer.size() && itp < producer.size()) {
+    if (consumer[itc]->isBroadcast() && !producer[itp]->isBroadcast()) {
+      itc++;
+      continue;
+    }
+    if (producer[itp]->isReduction()) {
+      itp++;
+      continue;
+    }
+
+    consumer_to_producer[itc] = itp;
+    itc++;
+    itp++;
+  }
+  return consumer_to_producer;
+}
+
+// Create a map from consumer root IterDomains -> producer root IterDomains.
+// Constrain will restrict which consumer root IterDomains we map to the
+// producer IterDomains. Only those root consumer IDs present in
+// consumer_root_dims_to_map will be attempted to map to their corresponding
+// producer IDs.
+std::unordered_map<IterDomain*, IterDomain*> TensorDomain::mapRootCtoP(
+    const TensorDomain* consumer,
+    const TensorDomain* producer,
+    bool constrain,
+    std::unordered_set<IterDomain*> consumer_root_dims_to_map) {
+  auto consumer_root = consumer->rootDomain();
+  auto producer_root = producer->hasRFactor() ? producer->rfactorDomain()
+                                              : producer->rootDomain();
+
+  auto c_to_p = mapDomainCtoP(consumer_root, producer_root);
+
+  std::unordered_map<IterDomain*, IterDomain*> root_id_map;
+
+  for (int64_t itc = 0; itc < c_to_p.size(); itc++) {
+    int64_t itp = c_to_p[itc];
+    if (itp == -1)
+      continue;
+
+    if (!constrain ||
+        (constrain &&
+         consumer_root_dims_to_map.find(consumer_root[itc]) !=
+             consumer_root_dims_to_map.end())) {
+      root_id_map[consumer_root[itc]] = producer_root[itp];
+    }
+  }
+  return root_id_map;
+}
+
+// return mapping of consumer_domain[i] = producer_domain[result_vector[i]]
+// assuming there exists a direct consumer-producer mapping. If axis exists in
+// consumer (broadcast) but not in producer, mapping will be result_vector[i] =
+// -1.
+std::vector<int64_t> TensorDomain::mapDomainPtoC(
+    const std::vector<IterDomain*>& producer,
+    const std::vector<IterDomain*>& consumer) {
+  std::vector<int64_t> producer_to_consumer(producer.size(), -1);
+
+  size_t itc = 0, itp = 0;
+  while (itc < consumer.size() && itp < producer.size()) {
+    if (consumer[itc]->isBroadcast() && !producer[itp]->isBroadcast()) {
+      itc++;
+      continue;
+    }
+    if (producer[itp]->isReduction()) {
+      itp++;
+      continue;
+    }
+
+    producer_to_consumer[itp] = itc;
+    itc++;
+    itp++;
+  }
+
+  return producer_to_consumer;
+}
+
+// Create a map from producer root IterDomains -> consumer root IterDomains.
+// Constrain will restrict which producer root IterDomains we map to the
+// consumer IterDomains. Only those root producer IDs present in
+// producer_root_dims_to_map will be attempted to map to their corresponding
+// consumer IDs.
+std::unordered_map<IterDomain*, IterDomain*> TensorDomain::mapRootPtoC(
+    const TensorDomain* producer,
+    const TensorDomain* consumer,
+    bool constrain,
+    std::unordered_set<IterDomain*> producer_root_dims_to_map) {
+  auto consumer_root = consumer->rootDomain();
+  auto producer_root = producer->hasRFactor() ? producer->rfactorDomain()
+                                              : producer->rootDomain();
+
+  auto p_to_c = mapDomainPtoC(producer_root, consumer_root);
+
+  std::unordered_map<IterDomain*, IterDomain*> root_id_map;
+
+  for (int64_t itp = 0; itp < p_to_c.size(); itp++) {
+    int64_t itc = p_to_c[itp];
+    if (itc == -1)
+      continue;
+
+    if (!constrain ||
+        (constrain &&
+         producer_root_dims_to_map.find(producer_root[itp]) !=
+             producer_root_dims_to_map.end())) {
+      root_id_map[producer_root[itp]] = consumer_root[itc];
+    }
+  }
+  return root_id_map;
+}
+
 // pair is in order where second is the consumer of first
 std::pair<TensorDomain*, TensorDomain*> TensorDomain::rFactor(
     const std::vector<int>& axes_) {

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -468,18 +468,42 @@ Val* IterDomain::extent() const {
   return extent_;
 }
 
-TensorDomain::TensorDomain(std::vector<IterDomain*> _domain)
-    : Val(ValType::TensorDomain), root_domain_(std::move(_domain)) {
+TensorDomain::TensorDomain(
+    std::vector<IterDomain*> _domain,
+    std::vector<bool> _contiguity)
+    : Val(ValType::TensorDomain),
+      root_domain_(std::move(_domain)),
+      contiguity_(
+          _contiguity.empty() ? std::vector<bool>(root_domain_.size(), false)
+                              : std::move(_contiguity)) {
+  TORCH_CHECK(
+      contiguity_.size() == root_domain_.size(),
+      "Invalid contiguity information provided, incorrect size. Recieved vector of size ",
+      contiguity_.size(),
+      " but needed one of size ",
+      root_domain_.size());
+
   domain_ = std::vector<IterDomain*>(root_domain_.begin(), root_domain_.end());
   resetDomains();
 }
 
 TensorDomain::TensorDomain(
     std::vector<IterDomain*> _root_domain,
-    std::vector<IterDomain*> _domain)
+    std::vector<IterDomain*> _domain,
+    std::vector<bool> _contiguity)
     : Val(ValType::TensorDomain, DataType::Null, false),
       root_domain_(std::move(_root_domain)),
-      domain_(std::move(_domain)) {
+      domain_(std::move(_domain)),
+      contiguity_(
+          _contiguity.empty() ? std::vector<bool>(root_domain_.size(), false)
+                              : std::move(_contiguity)) {
+  TORCH_CHECK(
+      contiguity_.size() == root_domain_.size(),
+      "Invalid contiguity information provided, incorrect size. Recieved vector of size ",
+      contiguity_.size(),
+      " but needed one of size ",
+      root_domain_.size());
+
   std::vector<Val*> domain_vals(domain_.begin(), domain_.end());
   auto inps = IterVisitor::getInputsTo(domain_vals);
 
@@ -503,11 +527,22 @@ TensorDomain::TensorDomain(
 TensorDomain::TensorDomain(
     std::vector<IterDomain*> _root_domain,
     std::vector<IterDomain*> _rfactor_domain,
-    std::vector<IterDomain*> _domain)
+    std::vector<IterDomain*> _domain,
+    std::vector<bool> _contiguity)
     : Val(ValType::TensorDomain, DataType::Null, false),
       root_domain_(std::move(_root_domain)),
       domain_(std::move(_domain)),
-      rfactor_domain_(std::move(_rfactor_domain)) {
+      rfactor_domain_(std::move(_rfactor_domain)),
+      contiguity_(
+          _contiguity.empty() ? std::vector<bool>(root_domain_.size(), false)
+                              : std::move(_contiguity)) {
+  TORCH_CHECK(
+      contiguity_.size() == root_domain_.size(),
+      "Invalid contiguity information provided, incorrect size. Recieved vector of size ",
+      contiguity_.size(),
+      " but needed one of size ",
+      root_domain_.size());
+
   auto inps = IterVisitor::getInputsTo(
       std::vector<Val*>(domain_.begin(), domain_.end()));
 
@@ -543,7 +578,8 @@ TensorDomain::TensorDomain(const TensorDomain* src, IrCloner* ir_cloner)
       domain_(ir_cloner->clone(src->domain_)),
       no_bcast_domain_(ir_cloner->clone(src->no_bcast_domain_)),
       no_reduction_domain_(ir_cloner->clone(src->no_reduction_domain_)),
-      rfactor_domain_(ir_cloner->clone(src->rfactor_domain_)) {}
+      rfactor_domain_(ir_cloner->clone(src->rfactor_domain_)),
+      contiguity_(src->contiguity()) {}
 
 bool TensorDomain::sameAs(const TensorDomain* const other) const {
   if (nDims() != other->nDims())

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
@@ -30,18 +30,66 @@ void UnrollPass::handle(Expr* expr) {
 }
 
 namespace {
-Bool* getPredicate(TensorView* tv, std::vector<Val*> inds_, Bool* thread_pred) {
+Bool* getPredicate(
+    std::vector<Expr*> tv_ops,
+    std::vector<Val*> inds_,
+    Bool* thread_pred) {
   TORCH_INTERNAL_ASSERT(
-      inds_.size() == tv->nDims() ||
-      inds_.size() == tv->domain()->noReductions().size());
+      !tv_ops.empty() && !inds_.empty(),
+      "Provided empty values to getPredicate.");
+
+  // Need to start with an output to (effectively) grab its root domain size
+  std::vector<bool> overall_contiguity =
+      ir_utils::getTVOutput(tv_ops[0])->domain()->contiguity();
+
+  // We want to get all the contiguity information from all TensorViews in the
+  // exprs provided we need to support checking the predicate with the worst
+  // case contiguity information across these TVs.
+  for (auto tv_op : tv_ops) {
+    TensorView* consumer_tv = nullptr;
+
+    for (auto out : tv_op->outputs()) {
+      if (!ir_utils::isTV(out))
+        continue;
+      consumer_tv = out->as<TensorView>();
+
+      TORCH_INTERNAL_ASSERT(
+          inds_.size() == consumer_tv->nDims() ||
+              inds_.size() == consumer_tv->domain()->noReductions().size(),
+          "Invalid indices vector provided for getPredicate");
+
+      TORCH_INTERNAL_ASSERT(
+          consumer_tv->domain()->contiguity().size() ==
+              overall_contiguity.size(),
+          "Invalid expressions in getPredicate, their out domains don't match up,",
+          " they shouldn't be in the same loop nest together.");
+
+      overall_contiguity = IndexCompute::contiguityAnd(
+          overall_contiguity, consumer_tv->domain()->contiguity());
+    }
+
+    for (auto inp : tv_op->inputs()) {
+      if (!ir_utils::isTV(inp))
+        continue;
+      overall_contiguity = IndexCompute::contiguityAnd(
+          overall_contiguity,
+          IndexCompute::contiguityPasC(
+              inp->as<TensorView>()->domain(), consumer_tv->domain()));
+    }
+  }
+
+  // Need a tv to base the indexing on, just grab the first.
+  auto consumer_tv = ir_utils::getTVOutput(tv_ops[0]);
 
   // Do we need to adjust for reduction axes?
-  bool reductions = inds_.size() != tv->nDims();
+  bool reductions = inds_.size() != consumer_tv->nDims();
 
+  // Sanitize the indices
   std::vector<Val*> inds;
   if (reductions) {
-    for (size_t ind_i = 0, tv_i = 0; tv_i < tv->nDims();) {
-      if (tv->axis(tv_i++)->isReduction()) {
+    for (size_t ind_i = 0, consumer_tv_i = 0;
+         consumer_tv_i < consumer_tv->nDims();) {
+      if (consumer_tv->axis(consumer_tv_i++)->isReduction()) {
         inds.push_back(new Int(0));
       } else {
         TORCH_INTERNAL_ASSERT(
@@ -53,15 +101,14 @@ Bool* getPredicate(TensorView* tv, std::vector<Val*> inds_, Bool* thread_pred) {
     inds = inds_;
   }
 
-  if (tv->nDims() > inds.size()) {
-    for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
-      if (tv->axis(i)->isReduction())
-        inds.insert(inds.begin() + i, new Int(0));
-    }
-  }
-  std::vector<Bool*> all_preds = PredicateCompute::computePredicates(
-      new kir::TensorIndex(tv, IndexCompute::get(tv->domain(), inds)));
+  // Compute indices based on consumer_tv and all contiguity information
+  // combined
+  std::vector<Bool*> all_preds =
+      PredicateCompute::computePredicates(new kir::TensorIndex(
+          consumer_tv,
+          IndexCompute::get(consumer_tv->domain(), inds, overall_contiguity)));
 
+  // If we have thread predicates, add those
   if (thread_pred != nullptr) {
     all_preds.push_back(thread_pred);
   }
@@ -89,6 +136,7 @@ Bool* getPredicate(TensorView* tv, std::vector<Val*> inds_, Bool* thread_pred) {
 
   return cond->as<Bool>();
 }
+
 } // namespace
 
 // This function is one huge mess that should be refactored.
@@ -103,20 +151,15 @@ void UnrollPass::handle(kir::ForLoop* fl) {
     OptOutDispatch::handle(expr);
   }
 
-  TensorView* out = nullptr;
-  bool has_global = false;
-  for (Expr* expr : fl->body().exprs())
+  std::vector<Expr*> tv_ops;
+  for (Expr* expr : fl->body().exprs()) {
     if (ir_utils::isTVOp(expr)) {
-      // Predicate determining op for unroll
-      out = ir_utils::asTV(expr->output(0));
-      has_global = has_global || out->getMemoryType() == MemoryType::Global;
-      for (auto inp : expr->inputs())
-        if (ir_utils::isTV(inp))
-          has_global = has_global ||
-              ir_utils::asTV(inp)->getMemoryType() == MemoryType::Global;
+      // Predicate determining ops for unroll
+      tv_ops.push_back(expr);
     }
+  }
 
-  bool has_TV_op = out != nullptr;
+  bool has_TV_op = !tv_ops.empty();
 
   if (within_unroll && has_TV_op) {
     // Setup unrolled loop information:
@@ -152,8 +195,10 @@ void UnrollPass::handle(kir::ForLoop* fl) {
     }
 
     // Make predicates for the unrolling, and the epilogue
-    Bool* unroll_predicate =
-        getPredicate(out, unroll_pred_inds, getThreadPredicate(out));
+    Bool* unroll_predicate = getPredicate(
+        tv_ops,
+        unroll_pred_inds,
+        getThreadPredicate(ir_utils::getTVOutput(tv_ops[0])));
     // Make the IfThenElse controlling the unrolling
     kir::IfThenElse* unroll_ite = new kir::IfThenElse(
         unroll_predicate, {}, {}, first_unroll->parentScope());
@@ -180,7 +225,9 @@ void UnrollPass::handle(kir::ForLoop* fl) {
 
       // Setup the expressions that need predicates around them.
       Bool* inline_predicate = getPredicate(
-          out, ir_utils::indices(for_loops), getThreadPredicate(out));
+          {expr},
+          ir_utils::indices(for_loops),
+          getThreadPredicate(ir_utils::getTVOutput(expr)));
 
       kir::IfThenElse* inline_ite = new kir::IfThenElse(
           inline_predicate, {expr}, {}, inner_most_inlined_loop);
@@ -201,7 +248,9 @@ void UnrollPass::handle(kir::ForLoop* fl) {
       TensorView* out = ir_utils::asTV(ir_utils::asExpr(expr)->outputs()[0]);
 
       Bool* pred = getPredicate(
-          out, ir_utils::indices(for_loops), getThreadPredicate(out));
+          {expr},
+          ir_utils::indices(for_loops),
+          getThreadPredicate(ir_utils::getTVOutput(expr)));
 
       // If we need a predicate, put expr inside an if then else
       if (!(pred->isConst()) || !(pred->isConst() && pred->value().value())) {

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -422,6 +422,15 @@ bool isTVOp(const Expr* expr) {
   return false;
 }
 
+TensorView* getTVOutput(const Expr* expr) {
+  for (auto out : expr->outputs()) {
+    if (out->getValType().value() == ValType::TensorView) {
+      return out->as<TensorView>();
+    }
+  }
+  return nullptr;
+}
+
 bool isScalarOp(const Expr* expr) {
   for (auto out : expr->outputs())
     if (!out->isScalar())

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -389,6 +389,18 @@ Expr* firstInnerMostScope(Expr* scope) {
 
 namespace ir_utils {
 
+std::vector<IterDomain*> iterDomainInputsOf(
+    const std::vector<IterDomain*>& input_ids) {
+  auto inputs = IterVisitor::getInputsTo({input_ids.begin(), input_ids.end()});
+  std::vector<IterDomain*> id_inputs;
+  for (auto inp : inputs) {
+    if (inp->getValType() == ValType::IterDomain) {
+      id_inputs.push_back(inp->as<IterDomain>());
+    }
+  }
+  return id_inputs;
+}
+
 std::vector<Val*> indices(std::vector<kir::ForLoop*> loops) {
   std::vector<Val*> inds(loops.size());
   std::transform(

--- a/torch/csrc/jit/codegen/cuda/lower_utils.h
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.h
@@ -55,6 +55,9 @@ Expr* firstInnerMostScope(Expr* scope);
 
 namespace ir_utils {
 
+// Return inputs of provided IterDomains that are IterDomains
+std::vector<IterDomain*> iterDomainInputsOf(const std::vector<IterDomain*>&);
+
 std::vector<Val*> indices(std::vector<kir::ForLoop*>);
 
 std::vector<IterDomain*> iterDomains(std::vector<kir::ForLoop*>);
@@ -73,11 +76,14 @@ bool isScope(const Expr*);
 
 Expr* asExpr(Statement*);
 
+// TODO: Remove in favor of ->as<TensorView>()
 TensorView* asTV(Val*);
 
+// TODO: Remove in favor of ->as<ForLoop>()
 kir::ForLoop* asForLoop(Statement*);
 
-const TensorView* asConstTV(const Val* const);
+// TODO: Remove in favor of ->as<TensorView>()
+const TensorView* asConstTV(const Val*);
 
 bool isUnrolledFor(const Expr*);
 

--- a/torch/csrc/jit/codegen/cuda/lower_utils.h
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.h
@@ -63,6 +63,8 @@ bool isTV(const Val* const);
 
 bool isTVOp(const Expr*);
 
+TensorView* getTVOutput(const Expr*);
+
 bool isScalarOp(const Expr*);
 
 void ASSERT_EXPR(Statement*);

--- a/torch/csrc/jit/codegen/cuda/lower_validation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_validation.cpp
@@ -9,19 +9,56 @@ namespace fuser {
 
 // Some pre-compilation checks
 static void IrValidate(Fusion* fusion) {
-  fusion->validateInputs();
-  for (Val* val : fusion->vals()) {
-    if (ir_utils::isTV(val)) {
-      TensorView* tv = ir_utils::asTV(val);
-      for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
-        IterDomain* id = tv->getComputeAtAxis(i).first;
+  FusionGuard fg(fusion);
+  auto used_vals = DependencyCheck::getAllValsBetween(
+      {fusion->outputs().begin(), fusion->outputs().end()}, fusion->inputs());
 
-        if (id->isBlockDim()) {
-          TORCH_CHECK(
-              !id->isBroadcast(),
-              "Parallelization across blocks on broadcast axes is not supported, but found on, ",
-              tv,
-              ".");
+  std::unordered_set<TensorView*> used_tvs;
+
+  for (auto val : used_vals) {
+    if (ir_utils::isTV(val)) {
+      used_tvs.emplace(val->as<TensorView>());
+    }
+  }
+
+  fusion->validateInputs();
+
+  for (auto tv : used_tvs) {
+    for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
+      IterDomain* id = tv->getComputeAtAxis(i).first;
+
+      if (id->isBlockDim()) {
+        TORCH_CHECK(
+            !id->isBroadcast(),
+            "Parallelization across blocks on broadcast axes is not supported, but found on, ",
+            tv,
+            ".");
+      }
+      if (tv->hasBroadcast() && tv->getMemoryType() != MemoryType::Global) {
+        auto td = tv->domain()->domain();
+        auto ca_inputs = ir_utils::iterDomainInputsOf(
+            {td.begin(), td.begin() + tv->getThisComputeAtAxis()});
+        auto non_ca_inputs = ir_utils::iterDomainInputsOf(
+            {td.begin() + tv->getThisComputeAtAxis(), td.end()});
+
+        std::unordered_set<IterDomain*> ca_inputs_set(
+            ca_inputs.begin(), ca_inputs.end());
+        std::unordered_set<IterDomain*> non_ca_inputs_set(
+            non_ca_inputs.begin(), non_ca_inputs.end());
+
+        for (auto id : tv->getRootDomain()) {
+          if (id->isBroadcast()) {
+            // If a broadcast dimension is an input to both an axis within the
+            // computeAt point and outside the compute at point we would have to
+            // look at consumers to figure out what that axis will be
+            // broadcasted to, because we would have to generate everything the
+            // consumer could need on that axis. This could be supported but is
+            // not at this point.
+            TORCH_INTERNAL_ASSERT(
+                !(ca_inputs_set.find(id) != ca_inputs_set.end() &&
+                  non_ca_inputs_set.find(id) != non_ca_inputs_set.end()),
+                "Cannot generate a kernel where a root broadcast dimension is input to both IterDomains outside and within the computeAt point.");
+          }
         }
       }
     }
@@ -33,6 +70,8 @@ void IrBuildSizesMap(Fusion* fusion) {
   std::unordered_map<Val*, Val*> size_map;
 
   // Grab inputs and outputs
+  // TODO: Only run through inputs for the size map, outputs don't actually set
+  // any sizes of the problem.
   std::vector<TensorView*> inputs_and_outputs;
   for (auto val : fusion->inputs()) {
     if (ir_utils::isTV(val)) {

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -51,7 +51,8 @@ Statement* OptOutMutator::mutate(TensorDomain* td) {
   }
 
   if (mutated) {
-    Val* mutated_val = new TensorDomain(dom);
+    Val* mutated_val = new TensorDomain(
+        td->rootDomain(), td->rfactorDomain(), dom, td->contiguity());
     registerMutation(td, mutated_val);
     return mutated_val;
   }

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -31,22 +31,39 @@ std::vector<Bool*> PredicateCompute::computePredicates(
   if (no_pred_needed)
     return preds;
 
-  TORCH_INTERNAL_ASSERT(root.size() == ti->nDims());
-  for (decltype(ti->nDims()) i{0}; i < ti->nDims(); i++)
+  TORCH_INTERNAL_ASSERT(
+      root.size() == ti->nDims(),
+      "Predicate compute received mismatched TensorView and TensorIndex.");
 
-    // I believe the second part of this check is redundant, but it doesn't
-    // hurt.
-    if (FusionGuard::getCurFusion()->origin(ti->index(i)) != nullptr &&
-        !root[i]->isBroadcast()) {
-      Val* pred = lt(ti->index(i), root[i]->extent());
+  Val* extent = nullptr;
+
+  for (size_t i = 0; i < ti->nDims(); i++) {
+    bool zero_ind = ti->index(i)->isZeroInt();
+    bool simple_ind = ti->index(i)->getOrigin() == nullptr;
+
+    if (root[i]->isBroadcast()) {
+      preds.push_back(new Bool(true));
+    } else if (simple_ind && !zero_ind) {
+      preds.push_back(new Bool(true));
+    } else if (zero_ind) {
+      if (extent == nullptr) {
+        extent = root[i]->extent();
+      } else {
+        extent = mul(extent, root[i]->extent());
+      }
+    } else {
+      auto local_extent = root[i]->extent();
+      if (extent != nullptr) {
+        local_extent = mul(extent, local_extent);
+      }
+      Val* pred = lt(ti->index(i), local_extent);
+      extent = nullptr;
       TORCH_INTERNAL_ASSERT(
           pred->getValType().value() == ValType::Scalar &&
           pred->getDataType().value() == DataType::Bool);
       preds.push_back(pred->as<Bool>());
-    } else {
-      preds.push_back(new Bool(true));
     }
-
+  }
   return preds;
 }
 

--- a/torch/csrc/jit/codegen/cuda/transform_replay.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.cpp
@@ -168,7 +168,8 @@ TensorDomain* TransformReplay::fullSelfReplay(
     }
   }
 
-  return new TensorDomain(new_self_root->domain(), new_domain);
+  return new TensorDomain(
+      new_self_root->domain(), new_domain, self->contiguity());
 }
 
 // Producer could have rfactor axes which consumer may want replayed. We can
@@ -365,7 +366,10 @@ std::pair<TensorDomain*, unsigned int> TransformReplay::replayPasC(
       new_IDs.push_back(id);
 
   TensorDomain* replayed = new TensorDomain(
-      producer->rootDomain(), producer->rfactorDomain(), new_IDs);
+      producer->rootDomain(),
+      producer->rfactorDomain(),
+      new_IDs,
+      producer->contiguity());
   return {replayed, producer_compute_at_axis};
 }
 
@@ -567,7 +571,10 @@ std::pair<TensorDomain*, unsigned int> TransformReplay::replayCasP(
       new_IDs.push_back(id);
 
   TensorDomain* replayed = new TensorDomain(
-      consumer->rootDomain(), consumer->rfactorDomain(), new_IDs);
+      consumer->rootDomain(),
+      consumer->rfactorDomain(),
+      new_IDs,
+      consumer->contiguity());
 
   return {replayed, producer_CA_ids.size()};
 }

--- a/torch/csrc/jit/codegen/cuda/transform_replay.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.cpp
@@ -171,85 +171,6 @@ TensorDomain* TransformReplay::fullSelfReplay(
   return new TensorDomain(new_self_root->domain(), new_domain);
 }
 
-namespace {
-
-// consumer->rootDomain()[i] = producer->rootDomain()[result_vector[i]] if there
-// is a mapping from consumer->rootDomain()[i] to the producer->rootDomain().
-// Else if axis exists in consumer (broadcast) but not in producer,
-// result_vector[i] = -1. If producer has rfactorDomain then the map is actually
-// consumer->rootDomain()[i] = producer->rfactorDomain()[result_vector[i]]
-std::vector<int64_t> rootCtoPMap(
-    const TensorDomain* consumer,
-    const TensorDomain* producer) {
-  // Grab root domains of producer and consumer
-  std::vector<IterDomain*> consumer_root = consumer->rootDomain();
-  std::vector<IterDomain*> producer_root = producer->rootDomain();
-
-  // If producer has an rfactor root, that's what will match with consumer,
-  // as it means the consumer was a result of the rfactor operation.
-  if (producer->hasRFactor()) {
-    producer_root = producer->rfactorDomain();
-  }
-
-  std::vector<int64_t> consumer_to_producer(consumer_root.size(), -1);
-
-  size_t itc = 0, itp = 0;
-  while (itc < consumer_root.size() && itp < producer_root.size()) {
-    if (itc < consumer_root.size() && consumer_root[itc]->isBroadcast() &&
-        !producer_root[itp]->isBroadcast()) {
-      itc++;
-      continue;
-    }
-    if (itp < producer_root.size() && producer_root[itp]->isReduction()) {
-      itp++;
-      continue;
-    }
-    TORCH_INTERNAL_ASSERT(
-        itc < consumer_root.size() && itp < producer_root.size(),
-        "Error during replay, wanted to keep going, but ran out of root dimensions.");
-
-    consumer_to_producer[itc] = itp;
-    itc++;
-    itp++;
-  }
-  return consumer_to_producer;
-}
-
-// Create a map from consumer root IterDomains -> producer root IterDomains.
-// Constrain will restrict which consumer root IterDomains we map to the
-// producer IterDomains. Only those root consumer IDs present in the provided
-// unordered_set will be attempted to map to their corresponding producer IDs.
-std::unordered_map<IterDomain*, IterDomain*> mapRootConsumerToProducer(
-    const TensorDomain* consumer,
-    const TensorDomain* producer,
-    bool constrain = false,
-    std::unordered_set<IterDomain*> consumer_root_dims_to_map =
-        std::unordered_set<IterDomain*>()) {
-  auto c_to_p = rootCtoPMap(consumer, producer);
-
-  auto consumer_root = consumer->rootDomain();
-  auto producer_root = producer->hasRFactor() ? producer->rfactorDomain()
-                                              : producer->rootDomain();
-
-  std::unordered_map<IterDomain*, IterDomain*> root_id_map;
-
-  for (int64_t itc = 0; itc < c_to_p.size(); itc++) {
-    int64_t itp = c_to_p[itc];
-    if (itp == -1)
-      continue;
-
-    if (!constrain ||
-        (constrain &&
-         consumer_root_dims_to_map.find(consumer_root[itc]) !=
-             consumer_root_dims_to_map.end())) {
-      root_id_map[consumer_root[itc]] = producer_root[itp];
-    }
-  }
-  return root_id_map;
-}
-
-} // namespace
-
 // Producer could have rfactor axes which consumer may want replayed. We can
 // "replay" them as long as it doesn't modify the root rfactor axes. What we
 // really want to do is validate if we replayed these axes to the ones they
@@ -284,7 +205,7 @@ std::pair<TensorDomain*, unsigned int> TransformReplay::replayPasC(
 
   // Map of consumer_CA_root_ids to related producer_CA_ids
   auto replay_root_map =
-      mapRootConsumerToProducer(consumer, producer, true, consumer_CA_root_ids);
+      TensorDomain::mapRootCtoP(consumer, producer, true, consumer_CA_root_ids);
 
   // Track which root axes in producer we will send to replay
   std::unordered_set<IterDomain*> producer_roots4replay;
@@ -450,59 +371,35 @@ std::pair<TensorDomain*, unsigned int> TransformReplay::replayCasP(
     }
   }
 
-  // Map of producer_CA_root_ids to related producer_CA_ids
-  id_map replay_root_map;
-
-  // Grab root domains of producer and consumer
-  std::vector<IterDomain*> consumer_root = consumer->rootDomain();
-  std::vector<IterDomain*> producer_root = producer->rootDomain();
-
-  // If producer has an rfactor root, that's the one that will match the
-  // consumer
-  if (producer->hasRFactor())
-    producer_root = producer->rfactorDomain();
-
   // Figure out all inputs required to generate the compute_at dimensions
   std::unordered_set<Val*> all_CA_id_deps = DependencyCheck::getAllValsBetween(
       std::unordered_set<Val*>(
           producer->rootDomain().begin(), producer->rootDomain().end()),
       std::vector<Val*>(producer_CA_ids.begin(), producer_CA_ids.end()));
 
+  // Grab root domains of producer and consumer
+  std::vector<IterDomain*> consumer_root = consumer->rootDomain();
+
+  // If producer has an rfactor root, that's the one that will match the
+  // consumer
+  std::vector<IterDomain*> producer_root = producer->hasRFactor()
+      ? producer->rfactorDomain()
+      : producer->rootDomain();
+
   // Figure out which root IDs we need:
-  std::unordered_set<Val*> producer_CA_root_ids;
-  for (Val* val : producer_root) {
-    if (all_CA_id_deps.find(val) != all_CA_id_deps.end())
-      producer_CA_root_ids.emplace(val);
+  std::unordered_set<IterDomain*> producer_CA_root_ids;
+  for (IterDomain* id : producer_root) {
+    if (all_CA_id_deps.find(id) != all_CA_id_deps.end())
+      producer_CA_root_ids.emplace(id);
   }
 
-  // Track which root axes in consumer we send to replay
-  std::unordered_set<IterDomain*> consumer_roots4replay;
-  // Map related axes from producer and consumer roots. Make sure we go to the
-  // end of both.
-  {
-    size_t itc = 0, itp = 0;
-    while (itc < consumer_root.size() || itp < producer_root.size()) {
-      if (itc < consumer_root.size() && consumer_root[itc]->isBroadcast() &&
-          (itp >= producer_root.size() || !producer_root[itp]->isBroadcast())) {
-        itc++;
-        continue;
-      }
-      if (itp < producer_root.size() && producer_root[itp]->isReduction()) {
-        itp++;
-        continue;
-      }
-      TORCH_INTERNAL_ASSERT(
-          itc < consumer_root.size() && itp < producer_root.size(),
-          "Error during replay, wanted to keep going, but ran out of root dimensions.");
+  auto replay_root_map =
+      TensorDomain::mapRootPtoC(producer, consumer, true, producer_CA_root_ids);
 
-      if (producer_CA_root_ids.find(producer_root[itp]) !=
-          producer_CA_root_ids.end()) {
-        replay_root_map[producer_root[itp]] = consumer_root[itc];
-        consumer_roots4replay.emplace(consumer_root[itc]);
-      }
-      itc++;
-      itp++;
-    }
+  // Track which root axes in producer we will send to replay
+  std::unordered_set<IterDomain*> consumer_roots4replay;
+  for (auto entry : replay_root_map) {
+    consumer_roots4replay.emplace(entry.second);
   }
 
   // Instead of replaying from the root, lets try to forward the history of

--- a/torch/csrc/jit/codegen/cuda/transform_rfactor.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_rfactor.cpp
@@ -288,7 +288,11 @@ TensorDomain* TransformRFactor::runReplay(
     if (dom->isRFactorProduct())
       rfactor_root.push_back(dom);
 
-  return new TensorDomain(new_root, rfactor_root, new_domain);
+  return new TensorDomain(
+      new_root,
+      rfactor_root,
+      new_domain,
+      std::vector<bool>(new_root.size(), true));
 }
 
 // We want to take any axes marked in axes and remove them from the TensorDomain
@@ -380,7 +384,8 @@ TensorDomain* TransformRFactor::runReplay2(
     }
   }
 
-  return new TensorDomain(new_root, new_domain);
+  return new TensorDomain(
+      new_root, new_domain, std::vector<bool>(new_root.size(), true));
 }
 
 } // namespace fuser


### PR DESCRIPTION
Create an interface to allow specifying contiguity information of inputs at compile-time. Simplify index and predicate math based on contiguity information.

Remaining issues:

- [ ] Broadcast indexing can be incorrect when consumer has a broadcast dim outside the computeAt of a producer that doesn't have that broadcast dim
- [ ] Unroll predicate can be wrong if consumers don't have the same broadcast patterns when they're in the same unroll loop.
- [ ] Split TensorView/TensorDomain into its own .cpp/.h file.