### PR TITLE
Do not predicate initializations of reduction buffers

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2707,7 +2707,7 @@ void testGPU_FusionReduction5() {
 
   int numel_x = 650;
   int numel_y = 1000;
-  int numel_z = 1000;
+  int numel_z = 4;
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input = at::rand({numel_x, numel_y, numel_z}, options);

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -78,10 +78,10 @@ void GPULower::lower() {
   // Compute thread predicates
   ThreadPredicateMap preds(fusion_);
 
-  // Run our passes keeping the lowered expressions and forwarding them.
-  const auto loop_nests =
-      LoopNestGenerator::getLoopNest(fusion_, fusion_->exprs(true), preds);
-  const auto unrolled_loops = UnrollPass::runPass(fusion_, loop_nests, preds);
+  // Run our passes keeping the lowered expressions and forwarding
+  // them.
+  LoopNestGenerator lng(fusion_, preds, fusion_->exprs(true));
+  const auto unrolled_loops = UnrollPass::runPass(fusion_, lng.loweredExprs(), lng.initExprs(), preds);
   const auto indexed_loops =
       IndexLowering::getIndexedExprs(fusion_, unrolled_loops);
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -81,7 +81,8 @@ void GPULower::lower() {
   // Run our passes keeping the lowered expressions and forwarding
   // them.
   LoopNestGenerator lng(fusion_, preds, fusion_->exprs(true));
-  const auto unrolled_loops = UnrollPass::runPass(fusion_, lng.loweredExprs(), lng.initExprs(), preds);
+  const auto unrolled_loops =
+      UnrollPass::runPass(fusion_, lng.loweredExprs(), lng.initExprs(), preds);
   const auto indexed_loops =
       IndexLowering::getIndexedExprs(fusion_, unrolled_loops);
 

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -218,18 +218,12 @@ void LoopNestGenerator::initReduction(
     // If we allocate at the root, look for the provided allocatoin if it
     // exists, and place after it.
     if (alloc_expr != nullptr) {
-      bool found = false;
-      for (auto it = lowered_exprs.begin(); it != lowered_exprs.end(); it++) {
-        if ((*it) == alloc_expr) {
-          lowered_exprs.insert(it + 1, init_loop_nest);
-          found = true;
-          break;
-        }
-      }
+      auto it = std::find(lowered_exprs.begin(), lowered_exprs.end(), alloc_expr);
       TORCH_INTERNAL_ASSERT(
-          found,
+          it != lowered_exprs.end(),
           "Could not figure out where to initialize the buffer for ",
           tv);
+      lowered_exprs.insert(it + 1, init_loop_nest);
     } else {
       lowered_exprs.insert(lowered_exprs.begin(), init_loop_nest);
     }

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -213,6 +213,8 @@ void LoopNestGenerator::initReduction(
     inner_fl->body().push_back(init_stmt);
   }
 
+  init_exprs_.insert(init_stmt);
+
   // Place the allocation
   if (alloc_pos == 0) {
     // If we allocate at the root, look for the provided allocatoin if it

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -220,7 +220,8 @@ void LoopNestGenerator::initReduction(
     // If we allocate at the root, look for the provided allocatoin if it
     // exists, and place after it.
     if (alloc_expr != nullptr) {
-      auto it = std::find(lowered_exprs.begin(), lowered_exprs.end(), alloc_expr);
+      auto it =
+          std::find(lowered_exprs.begin(), lowered_exprs.end(), alloc_expr);
       TORCH_INTERNAL_ASSERT(
           it != lowered_exprs.end(),
           "Could not figure out where to initialize the buffer for ",

--- a/torch/csrc/jit/codegen/cuda/lower_loops.h
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.h
@@ -40,6 +40,10 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   // Track the active computeAt scope, and what view we're "computeAt-ing" into
   std::vector<std::pair<IterDomain*, TensorView*>> compute_at_scope;
 
+  // Track the array initialization expressions as they need be
+  // treated differently when adding predicatation.
+  std::unordered_set<Expr*> init_exprs_;
+
   // Predicates from ThreadPredicates that we will extend to reduction buffer
   // initialization
   ThreadPredicateMap& thread_predicates_;
@@ -87,18 +91,19 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   // Run the pass and accumulate output in lowered_exprs
   void generate(const std::vector<Expr*>& exprs);
 
-  LoopNestGenerator(Fusion* _fusion, ThreadPredicateMap& _thread_predicates)
-      : fusion_(_fusion), thread_predicates_(_thread_predicates) {}
-
  public:
-  static std::vector<Expr*> getLoopNest(
-      Fusion* fusion,
-      std::vector<Expr*> exprs,
-      ThreadPredicateMap& thread_predicates) {
-    FusionGuard fg(fusion);
-    LoopNestGenerator lng(fusion, thread_predicates);
-    lng.generate(exprs);
-    return lng.lowered_exprs;
+  LoopNestGenerator(Fusion* _fusion, ThreadPredicateMap& _thread_predicates,
+                    const std::vector<Expr*> &exprs)
+      : fusion_(_fusion), thread_predicates_(_thread_predicates) {
+    generate(exprs);
+  }
+
+  const auto& loweredExprs() const {
+    return lowered_exprs;
+  }
+
+  const auto& initExprs() const {
+    return init_exprs_;
   }
 };
 

--- a/torch/csrc/jit/codegen/cuda/lower_loops.h
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.h
@@ -92,8 +92,10 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   void generate(const std::vector<Expr*>& exprs);
 
  public:
-  LoopNestGenerator(Fusion* _fusion, ThreadPredicateMap& _thread_predicates,
-                    const std::vector<Expr*> &exprs)
+  LoopNestGenerator(
+      Fusion* _fusion,
+      ThreadPredicateMap& _thread_predicates,
+      const std::vector<Expr*>& exprs)
       : fusion_(_fusion), thread_predicates_(_thread_predicates) {
     generate(exprs);
   }

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
@@ -32,81 +32,87 @@ void UnrollPass::handle(Expr* expr) {
 namespace {
 
 kir::Bool* getPredicate(
-    std::vector<Expr*> tv_ops,
-    std::vector<Val*> inds_,
-    kir::Bool* thread_pred) {
+    const std::vector<Expr*>& tv_ops,
+    const std::vector<Val*>& inds_,
+    kir::Bool* thread_pred,
+    const std::unordered_set<Expr*>& init_exprs) {
   TORCH_INTERNAL_ASSERT(
       !tv_ops.empty() && !inds_.empty(),
       "Provided empty values to getPredicate.");
 
-  // Need to start with an output to (effectively) grab its root domain size
-  std::vector<bool> overall_contiguity =
-      ir_utils::getTVOutput(tv_ops[0])->domain()->contiguity();
+  std::vector<kir::Bool*> all_preds;
 
-  // We want to get all the contiguity information from all TensorViews in the
-  // exprs provided we need to support checking the predicate with the worst
-  // case contiguity information across these TVs.
-  for (auto tv_op : tv_ops) {
-    TensorView* consumer_tv = nullptr;
+  if (std::find(init_exprs.begin(), init_exprs.end(), tv_ops[0])
+      == init_exprs.end()) {
+    // Need to start with an output to (effectively) grab its root domain size
+    std::vector<bool> overall_contiguity =
+        ir_utils::getTVOutput(tv_ops[0])->domain()->contiguity();
 
-    for (auto out : tv_op->outputs()) {
-      if (!ir_utils::isTV(out))
-        continue;
-      consumer_tv = out->as<TensorView>();
+    // We want to get all the contiguity information from all TensorViews in the
+    // exprs provided we need to support checking the predicate with the worst
+    // case contiguity information across these TVs.
+    for (auto tv_op : tv_ops) {
+      TensorView* consumer_tv = nullptr;
 
-      TORCH_INTERNAL_ASSERT(
-          inds_.size() == consumer_tv->nDims() ||
-              inds_.size() == consumer_tv->domain()->noReductions().size(),
-          "Invalid indices vector provided for getPredicate");
+      for (auto out : tv_op->outputs()) {
+        if (!ir_utils::isTV(out))
+          continue;
+        consumer_tv = out->as<TensorView>();
 
-      TORCH_INTERNAL_ASSERT(
-          consumer_tv->domain()->contiguity().size() ==
-              overall_contiguity.size(),
-          "Invalid expressions in getPredicate, their out domains don't match up,",
-          " they shouldn't be in the same loop nest together.");
-
-      overall_contiguity = IndexCompute::contiguityAnd(
-          overall_contiguity, consumer_tv->domain()->contiguity());
-    }
-
-    for (auto inp : tv_op->inputs()) {
-      if (!ir_utils::isTV(inp))
-        continue;
-      overall_contiguity = IndexCompute::contiguityAnd(
-          overall_contiguity,
-          IndexCompute::contiguityPasC(
-              inp->as<TensorView>()->domain(), consumer_tv->domain()));
-    }
-  }
-
-  // Need a tv to base the indexing on, just grab the first.
-  auto consumer_tv = ir_utils::getTVOutput(tv_ops[0]);
-
-  // Do we need to adjust for reduction axes?
-  const bool reductions = inds_.size() != consumer_tv->nDims();
-
-  // Sanitize the indices
-  std::vector<Val*> inds;
-  if (reductions) {
-    for (size_t ind_i = 0, consumer_tv_i = 0;
-         consumer_tv_i < consumer_tv->nDims();) {
-      if (consumer_tv->axis(consumer_tv_i++)->isReduction()) {
-        inds.push_back(new Int(0));
-      } else {
         TORCH_INTERNAL_ASSERT(
-            ind_i < inds_.size(), "Ran out of indices to generate predicate.");
-        inds.push_back(inds_[ind_i++]);
+            inds_.size() == consumer_tv->nDims() ||
+            inds_.size() == consumer_tv->domain()->noReductions().size(),
+            "Invalid indices vector provided for getPredicate");
+
+        TORCH_INTERNAL_ASSERT(
+            consumer_tv->domain()->contiguity().size() ==
+            overall_contiguity.size(),
+            "Invalid expressions in getPredicate, their out domains don't match up,",
+            " they shouldn't be in the same loop nest together.");
+
+        overall_contiguity = IndexCompute::contiguityAnd(
+            overall_contiguity, consumer_tv->domain()->contiguity());
+      }
+
+      for (auto inp : tv_op->inputs()) {
+        if (!ir_utils::isTV(inp))
+          continue;
+        overall_contiguity = IndexCompute::contiguityAnd(
+            overall_contiguity,
+            IndexCompute::contiguityPasC(
+                inp->as<TensorView>()->domain(), consumer_tv->domain()));
       }
     }
-  } else {
-    inds = inds_;
-  }
 
-  // Compute indices based on consumer_tv and all contiguity information
-  // combined
-  auto all_preds = PredicateCompute::computePredicates(new kir::TensorIndex(
-      consumer_tv,
-      IndexCompute::get(consumer_tv->domain(), inds, overall_contiguity)));
+    // Need a tv to base the indexing on, just grab the first.
+    auto consumer_tv = ir_utils::getTVOutput(tv_ops[0]);
+
+    // Do we need to adjust for reduction axes?
+    const bool reductions = inds_.size() != consumer_tv->nDims();
+
+    // Sanitize the indices
+    std::vector<Val*> inds;
+    if (reductions) {
+      for (size_t ind_i = 0, consumer_tv_i = 0;
+           consumer_tv_i < consumer_tv->nDims();) {
+        if (consumer_tv->axis(consumer_tv_i++)->isReduction()) {
+          inds.push_back(new Int(0));
+        } else {
+          TORCH_INTERNAL_ASSERT(
+              ind_i < inds_.size(), "Ran out of indices to generate predicate.");
+          inds.push_back(inds_[ind_i++]);
+        }
+      }
+    } else {
+      inds = inds_;
+    }
+
+    // Compute indices based on consumer_tv and all contiguity information
+    // combined
+    all_preds = PredicateCompute::computePredicates(new kir::TensorIndex(
+        consumer_tv,
+        IndexCompute::get(consumer_tv->domain(), inds, overall_contiguity)));
+  }
 
   // If we have thread predicates, add those
   if (thread_pred != nullptr) {
@@ -119,8 +125,9 @@ kir::Bool* getPredicate(
     if (!(pred->isConst()) || !(pred->isConst() && pred->value().value()))
       preds.push_back(pred);
 
-  if (preds.size() == 0)
+  if (preds.empty()) {
     return new kir::Bool(true);
+  }
 
   Val* cond = preds[0];
 
@@ -198,7 +205,8 @@ void UnrollPass::handle(kir::ForLoop* fl) {
     kir::Bool* unroll_predicate = getPredicate(
         tv_ops,
         unroll_pred_inds,
-        getThreadPredicate(ir_utils::getTVOutput(tv_ops[0])));
+        getThreadPredicate(ir_utils::getTVOutput(tv_ops[0])),
+        incoming_init_exprs_);
 
     // Make the IfThenElse controlling the unrolling
     kir::IfThenElse* unroll_ite = new kir::IfThenElse(
@@ -228,7 +236,8 @@ void UnrollPass::handle(kir::ForLoop* fl) {
       auto inline_predicate = getPredicate(
           {expr},
           ir_utils::indices(for_loops),
-          getThreadPredicate(ir_utils::getTVOutput(expr)));
+          getThreadPredicate(ir_utils::getTVOutput(expr)),
+          incoming_init_exprs_);
 
       kir::IfThenElse* inline_ite = new kir::IfThenElse(
           inline_predicate, {expr}, {}, inner_most_inlined_loop);
@@ -251,7 +260,8 @@ void UnrollPass::handle(kir::ForLoop* fl) {
       auto pred = getPredicate(
           {expr},
           ir_utils::indices(for_loops),
-          getThreadPredicate(ir_utils::getTVOutput(expr)));
+          getThreadPredicate(ir_utils::getTVOutput(expr)),
+          incoming_init_exprs_);
 
       // If we need a predicate, put expr inside an if then else
       if (!(pred->isConst()) || !(pred->isConst() && pred->value().value())) {
@@ -280,9 +290,10 @@ void UnrollPass::computeMap() {
 std::vector<Expr*> UnrollPass::runPass(
     Fusion* fusion,
     const std::vector<Expr*>& exprs,
+    const std::unordered_set<Expr*>& init_exprs,
     const ThreadPredicateMap& thread_predicates) {
   FusionGuard fg(fusion);
-  UnrollPass up(fusion, exprs, thread_predicates);
+  UnrollPass up(fusion, exprs, init_exprs, thread_predicates);
   up.computeMap();
   std::vector<Expr*> mutated_exprs;
   for (Expr* expr : exprs) {

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
@@ -42,8 +42,8 @@ kir::Bool* getPredicate(
 
   std::vector<kir::Bool*> all_preds;
 
-  if (std::find(init_exprs.begin(), init_exprs.end(), tv_ops[0])
-      == init_exprs.end()) {
+  if (std::find(init_exprs.begin(), init_exprs.end(), tv_ops[0]) ==
+      init_exprs.end()) {
     // Need to start with an output to (effectively) grab its root domain size
     std::vector<bool> overall_contiguity =
         ir_utils::getTVOutput(tv_ops[0])->domain()->contiguity();
@@ -61,12 +61,12 @@ kir::Bool* getPredicate(
 
         TORCH_INTERNAL_ASSERT(
             inds_.size() == consumer_tv->nDims() ||
-            inds_.size() == consumer_tv->domain()->noReductions().size(),
+                inds_.size() == consumer_tv->domain()->noReductions().size(),
             "Invalid indices vector provided for getPredicate");
 
         TORCH_INTERNAL_ASSERT(
             consumer_tv->domain()->contiguity().size() ==
-            overall_contiguity.size(),
+                overall_contiguity.size(),
             "Invalid expressions in getPredicate, their out domains don't match up,",
             " they shouldn't be in the same loop nest together.");
 
@@ -99,7 +99,8 @@ kir::Bool* getPredicate(
           inds.push_back(new Int(0));
         } else {
           TORCH_INTERNAL_ASSERT(
-              ind_i < inds_.size(), "Ran out of indices to generate predicate.");
+              ind_i < inds_.size(),
+              "Ran out of indices to generate predicate.");
           inds.push_back(inds_[ind_i++]);
         }
       }

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
@@ -42,8 +42,7 @@ kir::Bool* getPredicate(
 
   std::vector<kir::Bool*> all_preds;
 
-  if (std::find(init_exprs.begin(), init_exprs.end(), tv_ops[0]) ==
-      init_exprs.end()) {
+  if (init_exprs.find(tv_ops[0]) == init_exprs.end()) {
     // Need to start with an output to (effectively) grab its root domain size
     std::vector<bool> overall_contiguity =
         ir_utils::getTVOutput(tv_ops[0])->domain()->contiguity();

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.h
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.h
@@ -60,6 +60,8 @@ class TORCH_CUDA_API UnrollPass : public OptOutDispatch {
   // Hold on to the incoming exprs, but don't modify them. We don't set the
   // Expr* to be const as Exprs' are const by virtue of their interface design
   const std::vector<Expr*>& incoming_exprs_;
+  // Hold on to the incoming initialization exprs
+  const std::unordered_set<Expr*>& incoming_init_exprs_;
 
   // Keep all for loops conveniently to make unrolling easier
   std::vector<kir::ForLoop*> for_loops;
@@ -80,9 +82,11 @@ class TORCH_CUDA_API UnrollPass : public OptOutDispatch {
   UnrollPass(
       Fusion* _fusion,
       const std::vector<Expr*>& _incoming_exprs,
+      const std::unordered_set<Expr*>& _incoming_init_exprs,
       const ThreadPredicateMap& _thread_predicates)
       : fusion_(_fusion),
         incoming_exprs_(_incoming_exprs),
+        incoming_init_exprs_(_incoming_init_exprs),
         thread_predicates_(_thread_predicates) {}
 
   // Generate the for Expr replacement map
@@ -94,6 +98,7 @@ class TORCH_CUDA_API UnrollPass : public OptOutDispatch {
   static std::vector<Expr*> runPass(
       Fusion* fusion,
       const std::vector<Expr*>& exprs,
+      const std::unordered_set<Expr*>& init_exprs,
       const ThreadPredicateMap& thread_predicates);
 };
 


### PR DESCRIPTION
This is to fix #64. Reduction buffers do not need to be predicated when initialized to 0. This PR tracks which expressions are initialization expressions and skips generating predicates for them.

For example, here's the kernel code of test fusion5 before this PR:

```
__global__ void kernel1(Tensor<float, 3> T0, Tensor<float, 1> T1){
  __shared__ float shared_mem[1024];
  T1[ ( blockIdx.x * T1.stride[0] ) ]
     = float(0);
  float T3[1];
  if ( ( ( ( 0 * 8 ) + threadIdx.y ) < T0.size[1] ) ) {
    T3[ 0 ]
       = float(0);
  }
  for(size_t i27 = 0; i27 < ( ceilDiv(T0.size[1], 8) ); ++i27 ) {
    float T2[1];
    if ( ( ( ( ( i27 * 8 ) + threadIdx.y ) < T0.size[1] ) && ( ( ( 0 * 64 ) + threadIdx.x ) < T0.size[2] ) ) ) {
      T2[ 0 ]
         = float(0);
    }
    for(size_t i29 = 0; i29 < ( ceilDiv(T0.size[2], 64) ); ++i29 ) {
      if ( ( ( ( ( i27 * 8 ) + threadIdx.y ) < T0.size[1] ) && ( ( ( i29 * 64 ) + threadIdx.x ) < T0.size[2] ) ) ) {
        T2[ 0 ]
           = T2[ 0 ]
           + T0[ ( blockIdx.x * T0.stride[0] ) + ( ( ( i27 * 8 ) + threadIdx.y ) * T0.stride[1] ) + ( ( ( i29 * 64 ) + threadIdx.x ) * T0.stride[2] ) ];
      }
    }
    if ( ( ( ( i27 * 8 ) + threadIdx.y ) < T0.size[1] ) ) {
      T3[ 0 ]
         = T3[ 0 ]
         + T2[ 0 ];
    }
  }
  blockReduce< true, true, false > ( T1[ ( blockIdx.x * T1.stride[0] ) ], T3[ 0 ], reduction_add_float, threadIdx, blockDim, reinterpret_cast<float*>(shared_mem));
}
```

With this fix:
```
__global__ void kernel1(Tensor<float, 3> T0, Tensor<float, 1> T1){
  __shared__ float shared_mem[1024];
  T1[ ( blockIdx.x * T1.stride[0] ) ]
     = float(0);
  float T3[1];
  T3[ 0 ]
     = float(0);
  for(size_t i27 = 0; i27 < ( ceilDiv(T0.size[1], 8) ); ++i27 ) {
    float T2[1];
    T2[ 0 ]
       = float(0);
    for(size_t i29 = 0; i29 < ( ceilDiv(T0.size[2], 64) ); ++i29 ) {
      if ( ( ( ( ( i27 * 8 ) + threadIdx.y ) < T0.size[1] ) && ( ( ( i29 * 64 ) + threadIdx.x ) < T0.size[2] ) ) ) {
        T2[ 0 ]
           = T2[ 0 ]
           + T0[ ( blockIdx.x * T0.stride[0] ) + ( ( ( i27 * 8 ) + threadIdx.y ) * T0.stride[1] ) + ( ( ( i29 * 64 ) + threadIdx.x ) * T0.stride[2] ) ];
      }
    }
    if ( ( ( ( i27 * 8 ) + threadIdx.y ) < T0.size[1] ) ) {
      T3[ 0 ]
         = T3[ 0 ]
         + T2[ 0 ];
    }
  }
  blockReduce< true, true, false > ( T1[ ( blockIdx.x * T1.stride[0] ) ], T3[ 0 ], reduction_add_float, threadIdx, blockDim, reinterpret_cast<float*>(shared_mem));
}
```

Notice that the initialization statements for `T3` and `T2` are no longer predicated.

I also changed one of the tensor dimensions of the test, which caused a validation error to happen. The test passes again with this PR.

- [x] Make sure the Python tests pass
