### PR TITLE
disable failing tests

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -182,7 +182,6 @@ namespace jit {
   _(GPU_FusionCacheMultiConsumer)                   \
   _(GPU_FusionSmem)                                 \
   _(GPU_FusionSmemReduce)                           \
-  _(GPU_FusionSmemBlockGemm)                        \
   _(GPU_FusionSmemBlockGemmCache)                   \
   _(GPU_FusionConstCheck)                           \
   _(GPU_FusionSymbolicReduction)                    \


### PR DESCRIPTION
Failing test was put into CI. Disabling it to avoid confusion while we work on the fix.