### PR TITLE
Revert "Reworking loop nests, making sure we get broadcast dims."

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -51,17 +51,6 @@ TensorView* makeDummyTensor(int nDims, DataType dtype = DataType::Float) {
   return new TensorView(new TensorDomain(dom), dtype);
 }
 
-TensorView* makeConcreteTensor(
-    std::vector<int> sizes,
-    DataType dtype = DataType::Float) {
-  // We can uncomment the below statement to test all tests with contiguous
-  // tensors. return makeContigTensor(nDims, dtype);
-  std::vector<IterDomain*> dom;
-  for (int i = 0; i < sizes.size(); i++)
-    dom.push_back(new IterDomain(new Int(0), new Int(sizes[i])));
-  return new TensorView(new TensorDomain(dom), dtype);
-}
-
 TensorView* makeTensorWithContig(
     int nDims,
     std::vector<bool> contig_info,
@@ -3047,53 +3036,6 @@ void testGPU_FusionSimpleBCast() {
     TORCH_CHECK(t4.allclose(cg_output));
   }
 #endif
-}
-
-void testGPU_FusionComplexBCast() {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  int x = 2, y = 3, z = 4;
-
-  auto tv0 = makeConcreteTensor({y});
-  auto tv1 = broadcast(tv0, {false, true});
-  auto tv2 = makeConcreteTensor({y, z});
-  auto tv3 = mul(tv1, tv2);
-  auto tv4 = broadcast(tv3, {true, false, false});
-  auto tv5 = makeConcreteTensor({x, y, z});
-  auto tv6 = add(tv4, tv5);
-
-  // tv0[    i1    ]
-  // tv1[    i1, b2]
-  // tv2[    i1, i2]
-  // tv3[    i1, i2]
-  // tv4[b0, i1, i2]
-  // tv5[i0, i1, i2]
-  // tv6[i0, i1, i2]
-
-  // tv3 = bcast(tv0) * tv2
-  // tv6 = bcast(tv3) + tv5
-
-  fusion.addInput(tv0);
-  fusion.addInput(tv2);
-  fusion.addInput(tv5);
-
-  fusion.addOutput(tv6);
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-
-  at::Tensor t0 = at::randn({y}, options);
-  at::Tensor t2 = at::randn({y, z}, options);
-  at::Tensor t5 = at::randn({x, y, z}, options);
-
-  auto t3 = t0.unsqueeze(-1).expand({y, z}) * t2;
-  auto t6 = t3.unsqueeze(0).expand({x, y, z}) + t5;
-
-  torch::jit::fuser::cuda::FusionExecutor fe;
-  fe.compileFusion(&fusion);
-  auto outputs = fe.runFusion({t0, t2, t5});
-
-  TORCH_CHECK(t6.allclose(outputs[0]));
 }
 
 // Test a simple Gemm but also play around with fusion executor features

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -147,7 +147,6 @@ namespace jit {
   _(GPU_FusionReduction5)                           \
   _(GPU_FusionReductionTFT)                         \
   _(GPU_FusionSimpleBCast)                          \
-  _(GPU_FusionComplexBCast)                         \
   _(GPU_FusionSimpleGemm)                           \
   _(GPU_FusionSoftmax1D)                            \
   _(GPU_FusionSoftmax1DNormalized)                  \

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -610,7 +610,6 @@ void IRPrinter::handle(const kir::TernaryOp* top) {
 
 void IRPrinter::handle(const ReductionOp* rop) {
   TORCH_CHECK(rop->out()->getValType() != ValType::TensorIndex);
-  indent();
   os << rop->out() << " = reduction( " << rop->in()
      << ", op = " << rop->getReductionOpType()
      << ", initial value = " << rop->init() << " )\n";
@@ -722,7 +721,6 @@ void IRPrinter::handle(const kir::GridReduction* gr) {
 
 void IRPrinter::handle(const BroadcastOp* bop) {
   TORCH_CHECK(bop->out()->getValType() != ValType::TensorIndex);
-  indent();
   os << bop->out() << " = broadcast( " << bop->in() << " )\n";
 }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -372,12 +372,12 @@ class TORCH_CUDA_API Scope {
     exprs_.push_back(e);
   }
 
-  void insert(size_t pos, Expr* expr) {
-    exprs_.insert(exprs_.begin() + pos, expr);
+  void insert(std::vector<Expr*>::iterator it, Expr* expr) {
+    exprs_.insert(it, expr);
   }
 
-  void erase(size_t pos) {
-    exprs_.erase(exprs_.begin() + pos);
+  void erase(std::vector<Expr*>::iterator it) {
+    exprs_.erase(it);
   }
 
   bool empty() const {

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -11,27 +11,31 @@ namespace jit {
 namespace fuser {
 
 // Create, place, and return the allocation for tv
-Expr* LoopNestGenerator::pushAlloc(TensorView* tv, IterDomain* alloc_id) {
+Expr* LoopNestGenerator::pushAlloc(TensorView* tv) {
   TORCH_INTERNAL_ASSERT(
       !(FusionGuard::getCurFusion()->hasInput(tv) ||
         FusionGuard::getCurFusion()->hasOutput(tv)),
       "Tried to allocate an input or output tensor.");
 
-  // Alloc id is the iteration domain associated with the allocation point of
-  // tv, figure out which local axis it is so we can determine the allocation
-  // size.
+  // First figure out which loop nest this allocation needs to be placed in
+  // Do we need to place the allocation at the root?
   size_t alloc_pos = 0;
-
-  if (alloc_id != nullptr) {
-    for (auto tv_i = alloc_pos; tv_i < tv->nDims(); tv_i++) {
-      if (alloc_id == tv->getComputeAtAxis(tv_i).first) {
-        alloc_pos = tv_i + 1;
-        break;
-      }
+  // If there's no computeAt, then we want to be allocated at the root
+  while (alloc_pos <= tv->nDims() && tv->hasComputeAt()) {
+    // If we have a computeAt and we reached computeAt pos that's where it goes
+    if (tv->hasComputeAt() && alloc_pos == tv->getThisComputeAtAxis()) {
+      break;
     }
+    // If we found an unroll, we want to place the allocation outside the unroll
+    if (alloc_pos < tv->nDims() &&
+        tv->getComputeAtAxis(alloc_pos).first->getParallelType() ==
+            ParallelType::Unroll) {
+      break;
+    }
+    alloc_pos++;
   }
 
-  // Grab the dimensions the allocation will be based on to compute a size
+  // Grab the dimensions the allocation will be based on
   std::vector<Val*> alloc_dims;
   for (auto i = alloc_pos; i < tv->nDims(); i++) {
     IterDomain* compute_at_dim = tv->getComputeAtAxis(i).first;
@@ -68,18 +72,19 @@ Expr* LoopNestGenerator::pushAlloc(TensorView* tv, IterDomain* alloc_id) {
   // Create the allocation node
   kir::Allocate* alloc = new kir::Allocate(tv, tv->getMemoryType(), size);
 
-  // Find which for loop we need to place this allocation
-  bool inserted = false;
-  for (auto loop : for_loops) {
-    if (loop->iter_domain() == alloc_id) {
-      loop->body().insert(0, alloc);
-      inserted = true;
-      break;
-    }
-  }
-
-  if (!inserted) {
+  // Place the allocation
+  if (alloc_pos == 0) {
+    // If we allocate at the root, insert at the begining of the lowered
+    // expressions
     lowered_exprs.insert(lowered_exprs.begin(), alloc);
+  } else if (alloc_pos == for_loops.size()) {
+    // If we allocate inline, push to the back of the last for loop
+    scope_utils::pushBack(for_loops.back(), alloc);
+  } else {
+    // Otherwise we allocate in some loop nest that is not inline, or root, so
+    // insert right before the loop we're just outside of
+    scope_utils::insertBefore(
+        for_loops[alloc_pos - 1], for_loops[alloc_pos], alloc);
   }
 
   return alloc;
@@ -118,21 +123,27 @@ void LoopNestGenerator::pushBack(Expr* expr) {
 void LoopNestGenerator::initReduction(
     TensorView* tv,
     Val* init_val,
-    IterDomain* alloc_id,
     Expr* alloc_expr) {
   // This logic was taken from pushAlloc, as the initialization loop nest will
   // go at the same place.
-  size_t alloc_pos = 0;
 
-  // Allocation id is the iteration domain associated with the for loop which we
-  // will place this initialization loop nest in
-  if (alloc_id != nullptr) {
-    for (auto tv_i = alloc_pos; tv_i < tv->nDims(); tv_i++) {
-      if (alloc_id == tv->getComputeAtAxis(tv_i).first) {
-        alloc_pos = tv_i + 1;
-        break;
-      }
+  // First figure out which loop nest this allocation needs to be placed in
+  // Do we need to place the allocation at the root?
+  size_t alloc_pos = 0;
+  // If there's no computeAt, then we want to be allocated at the root
+  while (alloc_pos <= tv->nDims() && tv->hasComputeAt()) {
+    // If we have a computeAt and we reached computeAt pos that's where it  goes
+    if (tv->hasComputeAt() && alloc_pos == tv->getThisComputeAtAxis()) {
+      break;
     }
+
+    // If we found an unroll, we want to place the allocation outside the unroll
+    if (alloc_pos < tv->nDims() &&
+        tv->getComputeAtAxis(alloc_pos).first->getParallelType() ==
+            ParallelType::Unroll) {
+      break;
+    }
+    alloc_pos++;
   }
 
   // Grab the IDs that will be involved in the initialization, ignore reduction
@@ -154,10 +165,6 @@ void LoopNestGenerator::initReduction(
   // The initilization stmt that will be located inside the loop nest (if there
   // is one)
   auto init_stmt = new UnaryOp(UnaryOpType::Set, clone, init_val);
-
-  // Track that this is the init statement so we can process differently for
-  // predicate generation
-  init_exprs_.insert(init_stmt);
 
   // Init a pointer that will become the entirety of the initialization
   Expr* init_loop_nest = nullptr;
@@ -206,17 +213,12 @@ void LoopNestGenerator::initReduction(
     inner_fl->body().push_back(init_stmt);
   }
 
-  // Figure out which loop we need to place this initialization loop in.
-  kir::ForLoop* insert_loop = nullptr;
-  for (auto loop : for_loops) {
-    if (loop->iter_domain() == alloc_id) {
-      insert_loop = loop;
-      break;
-    }
-  }
+  init_exprs_.insert(init_stmt);
 
-  // If we don't find an insertion loop it means it needs to go in lowered_exprs
-  if (insert_loop == nullptr) {
+  // Place the allocation
+  if (alloc_pos == 0) {
+    // If we allocate at the root, look for the provided allocatoin if it
+    // exists, and place after it.
     if (alloc_expr != nullptr) {
       auto it =
           std::find(lowered_exprs.begin(), lowered_exprs.end(), alloc_expr);
@@ -228,21 +230,31 @@ void LoopNestGenerator::initReduction(
     } else {
       lowered_exprs.insert(lowered_exprs.begin(), init_loop_nest);
     }
+  } else if (alloc_pos == for_loops.size()) {
+    // If we allocate inline, push to the back of the last for loop
+    scope_utils::pushBack(for_loops[for_loops.size() - 1], init_loop_nest);
   } else {
-    if (alloc_expr != nullptr) {
-      // If there is an allocation for this tensor view place this loop nest
-      // after it
-      insert_loop->body().insert_after(alloc_expr, init_loop_nest);
-    } else {
-      // Otherwise we're allocating a global value
-      insert_loop->body().insert(0, init_loop_nest);
-    }
+    // Otherwise we allocate in some loop nest that is not inline, or root, so
+    // insert right before the loop we're just outside of
+    scope_utils::insertBefore(
+        for_loops[alloc_pos - 1], for_loops[alloc_pos], init_loop_nest);
   }
 }
 
+/*
+ *  This is one of the most complex parts of the code lowering logic. what we
+ * need to do is:
+ *  1) Reduce loop structure if needed
+ *  2) Open to compute At
+ *    - If there is a computeAt set for this TV
+ *  3) Allocate the output.
+ *  4) If this is a reduction, initialize the output (open for loops to inner
+ *       most, predicate, initialize, close predicate, close to computeAt)
+ *  5) Open to inner most loop
+ *  6) Run operation
+ *  7) Close to computeAt
+ */
 void LoopNestGenerator::handle(Expr* expr) {
-  // Check if it's a tensor view expression we need to place in the loop nest
-  // structure
   if (!ir_utils::isTVOp(expr)) {
     for (auto out : expr->outputs()) {
       TORCH_INTERNAL_ASSERT(
@@ -270,133 +282,46 @@ void LoopNestGenerator::handle(Expr* expr) {
   }
 
   TensorView* out = expr->output(0)->as<TensorView>();
-
-  // Figure out what the entire loop structure should look like.
-  std::deque<
-      std::pair<torch::jit::fuser::IterDomain*, torch::jit::fuser::TensorView*>>
-      loop_structure;
-
-  // As we go through iteration domains track the previous view
-  TensorView* last_ca_view = nullptr;
-  // Check where in the previous view our last axis was in that view
-  int64_t last_ca_view_ind = 0;
-
-  // Look at each axis individually in out's domain
-  for (int64_t out_i = 0; out_i < (int64_t)out->getThisComputeAtAxis();
-       out_i++) {
-    // Grab the axis information
-    auto ca_point = out->getComputeAtAxis(out_i);
-    auto ca_view = ca_point.second;
-    auto ca_id = ca_point.first;
-
-    // Figure out if there are axes in the compute at tensor view that aren't
-    // in out, make sure to also open them. Check where to start looking for
-    // them in the compute at view.
-    size_t start = 0;
-    if (last_ca_view == nullptr) {
-      // Start at the begining, we haven't processed any axes yet.
-      start = 0;
-    } else if (last_ca_view == ca_view) {
-      // This view is the same as the last axis, so start where we left off.
-      start = last_ca_view_ind + 1;
-    } else {
-      // This is a new view, figure out where we are in it, and start from there
-      for (start = 0; start < ca_view->nDims(); start++) {
-        if (loop_structure.back() == ca_view->getComputeAtAxis(start)) {
-          break;
-        }
-      }
-      start++;
-    }
-
-    // Go from start, and open all loops in the computeAt view until we hit the
-    // one associated with out->getComputeAtAxis(out_i)
-    for (size_t ca_i = start; ca_i < ca_view->nDims(); ca_i++) {
-      loop_structure.push_back(ca_view->getComputeAtAxis(ca_i));
-
-      // Update the last view processed
-      last_ca_view_ind = ca_i;
-      last_ca_view = ca_view;
-      if (ca_view->getComputeAtAxis(ca_i).first == ca_id) {
-        break;
-      }
-    }
-
-    // Shouldn't ever hit this, but make sure we hit the break above, meaning we
-    // added all necessary axes from the compute at view.
-    TORCH_INTERNAL_ASSERT(
-        ca_view->getComputeAtAxis(last_ca_view_ind).first == ca_id);
+  // 1) Reduce loop structure
+  while (compute_at_scope.size() > out->getThisComputeAtAxis() &&
+         compute_at_scope.back().second != out &&
+         compute_at_scope.back() !=
+             out->getComputeAtAxis((int)compute_at_scope.size() - 1)) {
+    popFor();
   }
 
-  // We're up to the compute at point in loop_structure, grab the remaining
-  // axes.
-  for (int64_t out_i = (int64_t)out->getThisComputeAtAxis();
-       out_i < (int64_t)out->nDims();
-       out_i++) {
-    // It's actually local, but getComputeAtAxis returns a std::pair, axis
-    // doesn't
-    loop_structure.push_back(out->getComputeAtAxis(out_i));
+  // 2) Open back up to computeAt
+  while (compute_at_scope.size() < out->getThisComputeAtAxis()) {
+    openFor(out->getComputeAtAxis((int)compute_at_scope.size()));
   }
 
-  // At this point loop_structure contains our overal target loop nest structure
-  // Lets get a copy of the loop structure, and figure out which loops we need
-  // to open.
-  decltype(loop_structure) loops_to_open(loop_structure);
-  std::deque<kir::ForLoop*> for_copy(for_loops.begin(), for_loops.end());
-  while (!loops_to_open.empty() && !for_copy.empty()) {
-    if (loops_to_open.front().first == for_copy.front()->iter_domain()) {
-      loops_to_open.pop_front();
-    }
-    for_copy.pop_front();
-  }
-
-  // At this point for_loops + loops_to_open contains our overal target loop
-  // nest structure. Open loops in "loops_to_open".
-  while (!loops_to_open.empty()) {
-    openFor(loops_to_open.front());
-    loops_to_open.pop_front();
-  }
-
-  // Figure out where we want to place alloc/reduction initialization
-  IterDomain* alloc_id = nullptr;
-  for (size_t out_i = 0; out_i < out->getThisComputeAtAxis(); out_i++) {
-    auto ca_id = out->getComputeAtAxis(out_i).first;
-    if (ca_id->getParallelType() == ParallelType::Unroll)
-      break;
-    alloc_id = ca_id;
-  }
-
-  Expr* alloc_expr = nullptr;
-  // Place the allocation for out
+  Expr* alloc_stmt = nullptr;
+  //  3) Allocate the output.
   if (!FusionGuard::getCurFusion()->hasInput(out) &&
       !FusionGuard::getCurFusion()->hasOutput(out)) {
-    alloc_expr = pushAlloc(out, alloc_id);
+    alloc_stmt = pushAlloc(out);
   }
 
-  //  If this is a reduction, initialize the output (open for loops to inner
+  //  4) If this is a reduction, initialize the output (open for loops to inner
   //  most, predicate, initialize, place next after allocation if exists, close
   //  to computeAt)
   if (out->hasReduction())
-    initReduction(out, expr->as<ReductionOp>()->init(), alloc_id, alloc_expr);
+    initReduction(out, expr->as<ReductionOp>()->init(), alloc_stmt);
 
-  //  Place the expression
+  //  5) Open to inner most loop
+  for (decltype(out->nDims()) i = for_loops.size(); i < out->nDims(); i++)
+    openFor(out->getComputeAtAxis(i));
+
+  //  6) Run expression
   pushBack(expr);
 
   // If output is a shared memory buffer, set modified status
   modifySharedMemory(out);
 
-  // Reduce the loop nest structure back to computeAt
-  if (out->getThisComputeAtAxis() == 0) {
-    while (!for_loops.empty())
-      popFor();
-  } else {
-    auto ca_axis = out->getThisComputeAtAxis() - 1;
-    while (for_loops.size() > 0 &&
-           for_loops.back()->iter_domain() !=
-               out->getComputeAtAxis(ca_axis).first) {
-      popFor();
-    }
-  }
+  // 7) Reduce loop structure back to computeAt
+  while (!compute_at_scope.empty() &&
+         compute_at_scope.size() > out->getThisComputeAtAxis())
+    popFor();
 }
 
 namespace {

--- a/torch/csrc/jit/codegen/cuda/lower_loops.h
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.h
@@ -48,10 +48,6 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   // initialization
   ThreadPredicateMap& thread_predicates_;
 
-  // Create the allocation for tv, place it inside the loop associated with
-  // alloc_id, return the node
-  Expr* pushAlloc(TensorView*, IterDomain* alloc_id);
-
   // Fusion shared_memory values
   // Tracks if shared memory is modified
   std::unordered_map<Val*, bool> smem_;
@@ -65,6 +61,9 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   // Return the status of the shared memory buffer
   // False if TensorView is not shared memory buffer
   bool isModifiedSharedMemory(Val* key) const;
+
+  // Create, place, and return the allocation for tv
+  Expr* pushAlloc(TensorView*);
 
   // Open a new inner most for loop, track which TV it was constructed from
   // according to the computeAt chain.
@@ -83,12 +82,8 @@ class TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
 
   // Initialize a buffer to init_val. If this buffer is in smem or registers,
   // pass in its allocation statement so we can make sure that we insert this
-  // initialization after the allocation.
-  void initReduction(
-      TensorView* tv,
-      Val* init_val,
-      IterDomain* alloc_id,
-      Expr* alloc_expr = nullptr);
+  // initialization comes after the allocation.
+  void initReduction(TensorView* tv, Val* init_val, Expr* alloc_expr = nullptr);
 
   // Check if expr is a TV op and handle accordingly.
   void handle(Expr*) final;

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -389,18 +389,6 @@ Expr* firstInnerMostScope(Expr* scope) {
 
 namespace ir_utils {
 
-std::vector<IterDomain*> iterDomainInputsOf(
-    const std::vector<IterDomain*>& input_ids) {
-  auto inputs = IterVisitor::getInputsTo({input_ids.begin(), input_ids.end()});
-  std::vector<IterDomain*> id_inputs;
-  for (auto inp : inputs) {
-    if (inp->getValType() == ValType::IterDomain) {
-      id_inputs.push_back(inp->as<IterDomain>());
-    }
-  }
-  return id_inputs;
-}
-
 std::vector<Val*> indices(std::vector<kir::ForLoop*> loops) {
   std::vector<Val*> inds(loops.size());
   std::transform(

--- a/torch/csrc/jit/codegen/cuda/lower_utils.h
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.h
@@ -55,9 +55,6 @@ Expr* firstInnerMostScope(Expr* scope);
 
 namespace ir_utils {
 
-// Return inputs of provided IterDomains that are IterDomains
-std::vector<IterDomain*> iterDomainInputsOf(const std::vector<IterDomain*>&);
-
 std::vector<Val*> indices(std::vector<kir::ForLoop*>);
 
 std::vector<IterDomain*> iterDomains(std::vector<kir::ForLoop*>);
@@ -76,14 +73,11 @@ bool isScope(const Expr*);
 
 Expr* asExpr(Statement*);
 
-// TODO: Remove in favor of ->as<TensorView>()
 TensorView* asTV(Val*);
 
-// TODO: Remove in favor of ->as<ForLoop>()
 kir::ForLoop* asForLoop(Statement*);
 
-// TODO: Remove in favor of ->as<TensorView>()
-const TensorView* asConstTV(const Val*);
+const TensorView* asConstTV(const Val* const);
 
 bool isUnrolledFor(const Expr*);
 

--- a/torch/csrc/jit/codegen/cuda/lower_validation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_validation.cpp
@@ -9,56 +9,19 @@ namespace fuser {
 
 // Some pre-compilation checks
 static void IrValidate(Fusion* fusion) {
-  FusionGuard fg(fusion);
-  auto used_vals = DependencyCheck::getAllValsBetween(
-      {fusion->outputs().begin(), fusion->outputs().end()}, fusion->inputs());
-
-  std::unordered_set<TensorView*> used_tvs;
-
-  for (auto val : used_vals) {
-    if (ir_utils::isTV(val)) {
-      used_tvs.emplace(val->as<TensorView>());
-    }
-  }
-
   fusion->validateInputs();
+  for (Val* val : fusion->vals()) {
+    if (ir_utils::isTV(val)) {
+      TensorView* tv = ir_utils::asTV(val);
+      for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
+        IterDomain* id = tv->getComputeAtAxis(i).first;
 
-  for (auto tv : used_tvs) {
-    for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
-      IterDomain* id = tv->getComputeAtAxis(i).first;
-
-      if (id->isBlockDim()) {
-        TORCH_CHECK(
-            !id->isBroadcast(),
-            "Parallelization across blocks on broadcast axes is not supported, but found on, ",
-            tv,
-            ".");
-      }
-      if (tv->hasBroadcast() && tv->getMemoryType() != MemoryType::Global) {
-        auto td = tv->domain()->domain();
-        auto ca_inputs = ir_utils::iterDomainInputsOf(
-            {td.begin(), td.begin() + tv->getThisComputeAtAxis()});
-        auto non_ca_inputs = ir_utils::iterDomainInputsOf(
-            {td.begin() + tv->getThisComputeAtAxis(), td.end()});
-
-        std::unordered_set<IterDomain*> ca_inputs_set(
-            ca_inputs.begin(), ca_inputs.end());
-        std::unordered_set<IterDomain*> non_ca_inputs_set(
-            non_ca_inputs.begin(), non_ca_inputs.end());
-
-        for (auto id : tv->getRootDomain()) {
-          if (id->isBroadcast()) {
-            // If a broadcast dimension is an input to both an axis within the
-            // computeAt point and outside the compute at point we would have to
-            // look at consumers to figure out what that axis will be
-            // broadcasted to, because we would have to generate everything the
-            // consumer could need on that axis. This could be supported but is
-            // not at this point.
-            TORCH_INTERNAL_ASSERT(
-                !(ca_inputs_set.find(id) != ca_inputs_set.end() &&
-                  non_ca_inputs_set.find(id) != non_ca_inputs_set.end()),
-                "Cannot generate a kernel where a root broadcast dimension is input to both IterDomains outside and within the computeAt point.");
-          }
+        if (id->isBlockDim()) {
+          TORCH_CHECK(
+              !id->isBroadcast(),
+              "Parallelization across blocks on broadcast axes is not supported, but found on, ",
+              tv,
+              ".");
         }
       }
     }
@@ -70,8 +33,6 @@ void IrBuildSizesMap(Fusion* fusion) {
   std::unordered_map<Val*, Val*> size_map;
 
   // Grab inputs and outputs
-  // TODO: Only run through inputs for the size map, outputs don't actually set
-  // any sizes of the problem.
   std::vector<TensorView*> inputs_and_outputs;
   for (auto val : fusion->inputs()) {
     if (ir_utils::isTV(val)) {


### PR DESCRIPTION
Reverts csarofeen/pytorch#256

#256 causes an error as shown below:

```
test_addcmul_ops (__main__.TestCudaFuser) ... ok
test_binary_ops (__main__.TestCudaFuser) ... ok
test_broadcasting (__main__.TestCudaFuser) ... expected failure
test_broadcasting_multiple_output (__main__.TestCudaFuser) ... skipped 'real broadcast with different output not supported yet'
test_broadcasting_multiple_output_shape (__main__.TestCudaFuser) ... skipped 'Broadcast with different output not supported yet'
test_chunk (__main__.TestCudaFuser) ... ok
test_const (__main__.TestCudaFuser) ... ok
test_dynamic_size (__main__.TestCudaFuser) ... FAIL
======================================================================
FAIL: test_dynamic_size (__main__.TestCudaFuser)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nmaruyama/pytorch/release/src1/torch/testing/_internal/common_utils.py", line 777, in wrapper
    method(*args, **kwargs)
  File "test/test_jit_cuda_fuser.py", line 401, in test_dynamic_size
    self.assertEqual(o, jit_o)
  File "/home/nmaruyama/pytorch/release/src1/torch/testing/_internal/common_utils.py", line 1085, in assertEqual
    self.assertTrue(result, msg=msg)
AssertionError: False is not true : Tensors failed to compare as equal! With rtol=1.3e-06 and atol=1e-05, found 31744 element(s) (out of 32768) whose difference(s) exceeded the margin of error (including 0 nan comparisons). The greatest difference was 4.324123978614807 (4.439993858337402 vs. 0.11586987972259521), which occurred at index (0, 1, 28, 26).
----------------------------------------------------------------------
```