### PR TITLE
Create allocate nodes for grid reduction flags

### DIFF
--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -114,22 +114,25 @@ bool Val::isConstScalar() const {
   return ConstCheck::isConst(this);
 }
 
+c10::optional<int64_t> Val::getInt() const {
+  if (isConstScalar() && isAnInt()) {
+    if (this->getValType() == ValType::Scalar) {
+      return this->as<Int>()->value();
+    } else if (this->getValType() == ValType::KirScalar) {
+      return this->as<kir::Int>()->value();
+    }
+  }
+  return c10::optional<int64_t>();
+}
+
 bool Val::isZeroInt() const {
-  if (isConstScalar() && getValType().value() == ValType::Scalar &&
-      getDataType().value() == DataType::Int &&
-      this->as<Int>()->value().has_value() &&
-      this->as<Int>()->value() == Int::ScalarType(0))
-    return true;
-  return false;
+  auto int_val = getInt();
+  return int_val.has_value() && int_val.value() == 0;
 }
 
 bool Val::isOneInt() const {
-  if (isConstScalar() && getValType().value() == ValType::Scalar &&
-      getDataType().value() == DataType::Int &&
-      this->as<Int>()->value().has_value() &&
-      this->as<Int>()->value() == Int::ScalarType(1))
-    return true;
-  return false;
+  auto int_val = getInt();
+  return int_val.has_value() && int_val.value() == 1;
 }
 
 c10::optional<DataType> Val::getDataType() const {

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.h
@@ -228,6 +228,8 @@ class TORCH_CUDA_API Val : public Statement {
     return isScalar() && dtype_ == DataType::Int;
   }
 
+  c10::optional<int64_t> getInt() const;
+
   bool isZeroInt() const;
   bool isOneInt() const;
 

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -698,7 +698,7 @@ void IRPrinter::handle(const kir::GridReduction* gr) {
   indent();
   // Since block-level reduction is already done, those dimensions
   // with tidx/y/z being true do not participate in the grid reduction.
-  os << kir::getPredicateFlagName(out->view()) << " = "
+  os << kir::GridReduction::getPredicateFlagName(out->view()) << " = "
      << "reduction::gridReduce< " << (bidx ? "true" : "false") << ", "
      << (bidy ? "true" : "false") << ", " << (bidz ? "true" : "false") << ", "
      << (!tidx ? "true" : "false") << ", " << (!tidy ? "true" : "false") << ", "

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -698,7 +698,7 @@ void IRPrinter::handle(const kir::GridReduction* gr) {
   indent();
   // Since block-level reduction is already done, those dimensions
   // with tidx/y/z being true do not participate in the grid reduction.
-  os << "bool " << kir::getPredicateFlagName(out->view()) << " = "
+  os << kir::getPredicateFlagName(out->view()) << " = "
      << "reduction::gridReduce< " << (bidx ? "true" : "false") << ", "
      << (bidy ? "true" : "false") << ", " << (bidz ? "true" : "false") << ", "
      << (!tidx ? "true" : "false") << ", " << (!tidy ? "true" : "false") << ", "

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -361,7 +361,7 @@ GridReduction::GridReduction(const GridReduction* src, IrCloner* ir_cloner)
       reduction_buffer_(ir_cloner->clone(src->reduction_buffer_)),
       sync_buffer_(ir_cloner->clone(src->sync_buffer_)) {}
 
-std::string getPredicateFlagName(const TensorView* val) {
+std::string GridReduction::getPredicateFlagName(const TensorView* val) {
   std::stringstream ss;
   ss << "T" << val->name() << "pred";
   return ss.str();

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -529,6 +529,8 @@ class TORCH_CUDA_API GridReduction : public Expr {
     return sync_buffer_;
   }
 
+  static std::string getPredicateFlagName(const TensorView* val);
+
  private:
   ReductionOp* reduction_op_ = nullptr;
   Allocate* reduction_buffer_ = nullptr;

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -137,10 +137,23 @@ void IndexLowering::handle(TernaryOp* top) {
 
 namespace {
 
-kir::Allocate* allocateGridReductionFlag(TensorView* out_tv) {
+void allocateGridReductionFlag(TensorView* out_tv, Expr* current_scope_expr) {
   auto flag_name = kir::GridReduction::getPredicateFlagName(out_tv);
-  auto flag_var = new kir::NamedScalar(flag_name, DataType::Bool);
-  return new kir::Allocate(flag_var, MemoryType::Local, new kir::Int(1));
+  auto flag_var = new kir::Allocate(
+      new kir::NamedScalar(flag_name, DataType::Bool),
+      MemoryType::Local,
+      new kir::Int(1));
+  // When enclosed by IfThenElse, place the variable outside of the
+  // IfThenElse. This IfThenElse is assumed to be the prediate for
+  // this grid reduction expression.
+  if (current_scope_expr->getExprType() == ExprType::IfThenElse) {
+    scope_utils::insertBefore(
+        scope_utils::getParent(current_scope_expr),
+        current_scope_expr,
+        flag_var);
+  } else {
+    scope_utils::pushBack(current_scope_expr, flag_var);
+  }
 }
 
 } // namespace
@@ -185,6 +198,10 @@ void IndexLowering::handle(ReductionOp* rop) {
   }
 
   if (is_grid_reduce) {
+    // First, declare a boolean flag variable storing the return value
+    // of gridReduce.
+    allocateGridReductionFlag(out_tv, active_scope_expr);
+
     std::vector<IterDomain*> buffer_ids(out_tv->domain()->domain());
     buffer_ids.erase(
         std::remove_if(
@@ -230,7 +247,6 @@ void IndexLowering::handle(ReductionOp* rop) {
 
     pushBack(reduce_buffer);
     pushBack(sync_buffer);
-    pushBack(allocateGridReductionFlag(out_tv));
     pushBack(new kir::GridReduction(
         block_reduction == nullptr
             ? new kir::ReductionOp(

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -138,7 +138,7 @@ void IndexLowering::handle(TernaryOp* top) {
 namespace {
 
 kir::Allocate* allocateGridReductionFlag(TensorView* out_tv) {
-  auto flag_name = kir::getPredicateFlagName(out_tv);
+  auto flag_name = kir::GridReduction::getPredicateFlagName(out_tv);
   auto flag_var = new kir::NamedScalar(flag_name, DataType::Bool);
   return new kir::Allocate(flag_var, MemoryType::Local, new kir::Int(1));
 }

--- a/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
@@ -18,7 +18,7 @@ Val* getPredicatePerParallelType(
     TORCH_INTERNAL_ASSERT(!sources.empty(), "No predicate source found");
     TORCH_INTERNAL_ASSERT(sources.size() == 1, "Multiple sources detected");
     auto src = *sources.begin();
-    auto flag_name = kir::getPredicateFlagName(src);
+    auto flag_name = kir::GridReduction::getPredicateFlagName(src);
     return new kir::NamedScalar(flag_name, DataType::Bool);
   } else {
     return kir::eqExpr(kir::NamedScalar::getParallelIndex(pt), new kir::Int(0));


### PR DESCRIPTION
This is to fix #244.

Inserts scalar value allocation nodes before grid reduction nodes. 

Additionally, refactors several `Val` functions to handle `kir::Int` types.