### PR TITLE
Fix expr ordering for loop-nest generation

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2843,11 +2843,10 @@ void testGPU_FusionBranches() {
   at::Tensor t2 = at::randn({x, y}, options);
 
   torch::jit::fuser::cuda::FusionExecutor fe;
-  //fuser::cuda::scheduleFusion(&fusion, {t0, t1, t2});
   tv6->merge(0);
   tv6->split(0, 128);
   tv6->split(0, 4);
-  
+
   tv6->axis(0)->parallelize(ParallelType::BIDx);
 
   tv0->computeAt(tv6, 1);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2860,6 +2860,7 @@ void testGPU_FusionBranches() {
   tv4->axis(-1)->parallelize(ParallelType::TIDx);
   tv5->axis(-2)->parallelize(ParallelType::Unroll);
   tv5->axis(-1)->parallelize(ParallelType::TIDx);
+  tv6->axis(-1)->parallelize(ParallelType::TIDx);
 
   fe.compileFusion(&fusion);
   auto outputs = fe.runFusion({t0, t1, t2});
@@ -2869,7 +2870,7 @@ void testGPU_FusionBranches() {
   auto t5 = t3.add(t2);
   auto t6 = t4.add(t5);
 
-  TORCH_CHECK(t4.allclose(outputs[0]));
+  TORCH_CHECK(t6.allclose(outputs[0]));
 }
 
 void testGPU_FusionSimpleBCast() {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2815,6 +2815,63 @@ void testGPU_FusionReductionTFT() {
   TORCH_CHECK(aten_output.allclose(cg_output));
 }
 
+void testGPU_FusionBranches() {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeDummyTensor(2);
+  TensorView* tv1 = makeDummyTensor(2);
+  TensorView* tv2 = makeDummyTensor(2);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  fusion.addInput(tv2);
+
+  auto tv3 = add(tv0, new Float(1.0));
+  auto tv4 = add(tv3, tv1);
+  auto tv5 = add(tv3, tv2);
+  auto tv6 = add(tv4, tv5);
+
+  fusion.addOutput(tv6);
+
+  constexpr int x = 63, y = 33;
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  at::Tensor t0 = at::randn({x, y}, options);
+  at::Tensor t1 = at::randn({x, y}, options);
+  at::Tensor t2 = at::randn({x, y}, options);
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  //fuser::cuda::scheduleFusion(&fusion, {t0, t1, t2});
+  tv6->merge(0);
+  tv6->split(0, 128);
+  tv6->split(0, 4);
+  
+  tv6->axis(0)->parallelize(ParallelType::BIDx);
+
+  tv0->computeAt(tv6, 1);
+  tv1->computeAt(tv6, 1);
+  tv2->computeAt(tv6, 1);
+
+  tv3->axis(-2)->parallelize(ParallelType::Unroll);
+  tv3->axis(-1)->parallelize(ParallelType::TIDx);
+  tv4->axis(-2)->parallelize(ParallelType::Unroll);
+  tv4->axis(-1)->parallelize(ParallelType::TIDx);
+  tv5->axis(-2)->parallelize(ParallelType::Unroll);
+  tv5->axis(-1)->parallelize(ParallelType::TIDx);
+
+  fe.compileFusion(&fusion);
+  auto outputs = fe.runFusion({t0, t1, t2});
+
+  auto t3 = t0.add(1.0);
+  auto t4 = t3.add(t1);
+  auto t5 = t3.add(t2);
+  auto t6 = t4.add(t5);
+
+  TORCH_CHECK(t4.allclose(outputs[0]));
+}
+
 void testGPU_FusionSimpleBCast() {
   {
     Fusion fusion;

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -198,6 +198,7 @@ namespace jit {
   _(GPU_FusionTraversalOrder5)                      \
   _(GPU_FusionTraversalOrder6)                      \
   _(GPU_FusionTraversalOrder7)                      \
+  _(GPU_FusionBranches)                             \
   _(GPU_FusionThreadPredicate)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -244,6 +244,9 @@ class TORCH_CUDA_API TensorView : public Val {
     return relative_compute_at_axis_;
   }
 
+  // Return position in compute_at_view that lines up with this->axis(pos)?
+  int getComputeAtRelPos(int pos);
+
   // Will check if an axis is inside computeAtAxis and will fetch the reference
   // to be used in code generation.
   std::pair<int, TensorView*> getComputeAtPos(int pos) {
@@ -389,8 +392,6 @@ class TORCH_CUDA_API TensorView : public Val {
       TensorView* current,
       TensorView* producer);
 
-  // Return position in compute_at_view that lines up with this->axis(pos)?
-  int getComputeAtRelPos(int pos);
   void setThisComputeAtAxis();
 
  private:

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -358,7 +358,12 @@ void findTargetTensor(Expr* expr, TensorView*& target, unsigned& score) {
 
   auto axis = out_tv->getRelativeComputeAtAxis();
   target = out_tv->getComputeAtView();
-  std::tie(axis, target) = target->getComputeAtPos(axis);
+  while (target->hasComputeAt()) {
+    if (target->getThisComputeAtAxis() < axis) break;
+    TORCH_INTERNAL_ASSERT(target->getThisComputeAtAxis() == axis);
+    axis = target->getComputeAtRelPos(axis);
+    target = target->getComputeAtView();
+  }
 
   score = axis;
 }

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -359,7 +359,8 @@ void findTargetTensor(Expr* expr, TensorView*& target, unsigned& score) {
   auto axis = out_tv->getRelativeComputeAtAxis();
   target = out_tv->getComputeAtView();
   while (target->hasComputeAt()) {
-    if (target->getThisComputeAtAxis() < axis) break;
+    if (target->getThisComputeAtAxis() < axis)
+      break;
     TORCH_INTERNAL_ASSERT(target->getThisComputeAtAxis() == axis);
     axis = target->getComputeAtRelPos(axis);
     target = target->getComputeAtView();


### PR DESCRIPTION
Fixes #278.

Originally, I thought `TensorView::getComputeAtPos` tells which tensor and axis corresponds to the for-loop at the position, but that's not exactly what it returns.