### PR TITLE
use single dynamic smem for reduction/broadcast workspace

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor_launch_params.h
+++ b/torch/csrc/jit/codegen/cuda/executor_launch_params.h
@@ -27,6 +27,11 @@ class TORCH_CUDA_API LaunchParams {
   int64_t smem() const {
     return smem_;
   }
+
+  void setSmem(int64_t val) {
+    smem_ = val;
+  }
+
   int64_t nBlocks() const {
     return gdimx_ * gdimy_ * gdimz_;
   }

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -598,6 +598,16 @@ bool Fusion::hasGridReduction() {
   return false;
 }
 
+bool Fusion::hasBroadcast() {
+  for (auto expr : exprs(true))
+    for (auto out : expr->outputs())
+      if (out->getValType() == ValType::TensorView)
+        if (out->as<TensorView>()->hasBroadcast())
+          return true;
+
+  return false;
+}
+
 std::vector<Val*> Fusion::getTerminatingOutputs() {
   FusionGuard fg(this);
 

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -209,6 +209,7 @@ class TORCH_CUDA_API Fusion final {
   bool hasReduction();
   bool hasBlockReduction();
   bool hasGridReduction();
+  bool hasBroadcast();
   size_t gridReductionTempBufferSize();
 
   const auto& inputs() const {

--- a/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
@@ -197,7 +197,7 @@ template<bool X_REDUCE, bool Y_REDUCE, bool Z_REDUCE, typename T, typename Func>
 __inline__ __device__
 void blockReduce(T& out, const T inp_val, Func reduction_op, const dim3& thread_idx, const dim3& block_dim, T* shared_mem) {
 
-  unsigned int reduction_size 
+  unsigned int reduction_size
     = (X_REDUCE ? block_dim.x : 1)
     * (Y_REDUCE ? block_dim.y : 1)
     * (Z_REDUCE ? block_dim.z : 1);
@@ -223,8 +223,8 @@ void blockReduce(T& out, const T inp_val, Func reduction_op, const dim3& thread_
     reduction_tid = threadIdx.z * blockDim.x + threadIdx.x;
   } else {
     // Normal reduction in order
-    reduction_stride 
-    = (X_REDUCE ? 1 
+    reduction_stride
+    = (X_REDUCE ? 1
     : (Y_REDUCE ? block_dim.x
     : (Z_REDUCE ? block_dim.x * block_dim.y : 0)));
 
@@ -258,7 +258,7 @@ void blockReduce(T& out, const T inp_val, Func reduction_op, const dim3& thread_
   }
   if(should_write)
     out = shared_mem[linear_tid];
-  
+
 }
 )";
 
@@ -595,10 +595,7 @@ __host__ __device__ unsigned offset_of_source(const dim3& block_dim, const dim3&
     out: Per-thread output location
  */
 template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD, typename T>
-__device__ void blockBroadcast(T& out, T inp_val) {
-
-  // Use worst case for memory.
-  __shared__ T shared_mem[1024];
+__device__ void blockBroadcast(T& out, T inp_val, T* shared_mem) {
 
   const bool has_valid_data =
       (!X_THREAD || threadIdx.x == 0) &&


### PR DESCRIPTION
This PR let reducion and broadcast use dynamic shared memory. 
Size need to be calculated and specified at launch time. Currently fusion executor implements the calculation.
With the assumption that this is workspace, a single buffer is shared among all reduction and broadcast.