### PR TITLE
Fix predicate generation, there was a broken root map.

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_unroll.h
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.h
@@ -92,7 +92,7 @@ class TORCH_CUDA_API UnrollPass : public OptOutDispatch {
       : fusion_(_fusion),
         incoming_exprs_(_incoming_exprs),
         thread_predicates_(_thread_predicates) {
-    auto p2c_root_map = loop_utils::p2cRootMap(_fusion->exprs(true));
+    p2c_root_map = loop_utils::p2cRootMap(_fusion->exprs(true));
   }
 
   // Generate the for Expr replacement map


### PR DESCRIPTION
There was a big issue with predicate generation, where to unroll a large set of pointwise ops we would generate a very redundant predicate:
```.cpp
  if ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T4.size[0] * T4.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T4.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T0.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T4.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T4.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T8.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T0.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T12.size[0] ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T4.size[0] * T4.size[1] ) ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T4.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T12.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T8.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T4.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T0.size[0] ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T4.size[0] * T4.size[1] ) ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T8.size[0] ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T0.size[0] * T0.size[1] ) ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T12.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T12.size[1] ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T12.size[0] * T12.size[1] ) ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T0.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T8.size[1] ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T4.size[0] * T4.size[1] ) ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T8.size[0] * T8.size[1] ) ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T8.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T4.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T0.size[1] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T8.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T12.size[0] ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) % T12.size[1] ) < T12.size[1] ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T12.size[0] * T12.size[1] ) ) ) 
&& ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T0.size[0] * T0.size[1] ) ) ) 
&& ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T0.size[0] ) ) )
```
instead of generating a simplified but complete predicate:
```.cpp
 if ( ( ( ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) / T12.size[1] ) < T8.size[0] )
 && ( ( ( ( ( blockIdx.x * 4 ) + ( 4 - 1 ) ) * 128 ) + threadIdx.x ) < ( T12.size[0] * T12.size[1] ) ) ) )
 ```