### PR TITLE
Kernel IR refactoring: part 6.1

### DIFF
--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -198,10 +198,7 @@ class TORCH_CUDA_API Fusion final {
   std::unordered_set<Expr*> unordered_uses(Val* val) const;
 
   // Return the Expr that produces val
-  Expr* origin(Val* val) const;
-
-  // Return the Expr that produces val (const version)
-  const Expr* origin(const Val* val) const;
+  Expr* origin(const Val* val) const;
 
   // Indicate to kernel to set itself up to generate random numbers
   bool hasRNG();
@@ -247,7 +244,7 @@ class TORCH_CUDA_API Fusion final {
   StmtNameType expr_name_counter_ = 0;
 
   // Dependency tracking for Vals. Where did it come from? Where is it used?
-  std::unordered_map<Val*, Expr*> origin_;
+  std::unordered_map<const Val*, Expr*> origin_;
   std::unordered_map<Val*, std::unordered_set<Expr*>> uses_;
 
   // Fusion inputs and outputs
@@ -257,6 +254,7 @@ class TORCH_CUDA_API Fusion final {
   // Lowered IR
   std::unordered_set<Val*> lowered_val_set_;
   std::unordered_set<Expr*> lowered_expr_set_;
+  std::unordered_map<const Val*, Expr*> lowered_origin_;
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -121,6 +121,26 @@ class ConstCheck : OptOutConstDispatch {
     is_const_ = is_const_ && false;
   }
 
+  void handle(const kir::Bool* b) override {
+    is_const_ = is_const_ && b->isConst();
+  }
+
+  void handle(const kir::Float* f) override {
+    is_const_ = is_const_ && f->isConst();
+  }
+
+  void handle(const kir::Half* h) override {
+    is_const_ = is_const_ && h->isConst();
+  }
+
+  void handle(const kir::Int* i) override {
+    is_const_ = is_const_ && i->isConst();
+  }
+
+  void handle(const kir::NamedScalar* ns) override {
+    is_const_ = is_const_ && false;
+  }
+
   void handle(const Expr* expr) override {
     for (auto inp : expr->inputs()) {
       handle(inp);

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -157,9 +157,9 @@ at::DimVector inversePermutation(
     for (const auto& dim : permuted) {
       int adjusted_offset = 0;
       for (const auto& red_dim : reduction_axes) {
-        if (red_dim < (const unsigned long)dim) {
+        if (red_dim < (unsigned long)dim) {
           adjusted_offset++; // 1.b
-        } else if (red_dim == (const unsigned long)dim) {
+        } else if (red_dim == (unsigned long)dim) {
           adjusted_offset = -1; // 1.a
           break;
         }


### PR DESCRIPTION
Removing support for cloning Kernel IR nodes, which is not needed today.
