### PR TITLE
Enable Global Intermediate Buffers

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -209,6 +209,8 @@ namespace jit {
   _(GPU_FusionSmemDynamicReductionSymbolic)         \
   _(GPU_FusionSmemDynamicReductionSymbolicArg)      \
   _(GPU_FusionSmemDynamicPwiseMulSymbolicArg)       \
+  _(GPU_FusionGlobalIntermediate)                   \
+  _(GPU_FusionGlobalIntermediateDefaultSchedule)    \
   _(GPU_FusionConstCheck)                           \
   _(GPU_FusionSymbolicReduction)                    \
   _(GPU_FusionUnrollWithAlloc)                      \

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -116,7 +116,7 @@ at::Tensor inferAndAlloc(
     const CompileOptions& options,
     bool zero_init = false) {
   std::vector<int64_t> sizes;
-  for (auto id : TensorDomain::noReductions(tv->getRootDomain())) {
+  for (auto id : TensorDomain::noReductions(tv->getMaybeRFactorDomain())) {
     auto inferred_val = ExpressionEvaluator::evaluate(id->rawExtent(), &ec);
     TORCH_INTERNAL_ASSERT(
         inferred_val.has_value(),

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -288,15 +288,7 @@ FusionExecutor::GlobalBuffers FusionExecutor::allocGlobalVals(
         alloc->buffer()->as<kir::TensorView>()->fuserTv(),
         ec,
         options_,
-        false));
-  }
-
-  for (auto alloc : lowered_.sync_allocations()) {
-    TORCH_INTERNAL_ASSERT(
-        alloc->buffer()->getValType() == ValType::KirTensorView,
-        "Cannot allocate global buffers that are not tensors.");
-    global_buffers.zero_buffers.push_back(inferAndAlloc(
-        alloc->buffer()->as<kir::TensorView>()->fuserTv(), ec, options_, true));
+        alloc->zeroInit()));
   }
 
   return global_buffers;

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -240,9 +240,6 @@ void Fusion::addInput(Val* const input) {
           " has a reduction axis, but this does nothing in the fusion.");
     }
     tv->setMemoryType(MemoryType::Global);
-    TORCH_INTERNAL_ASSERT(
-        tv->getMemoryType() == MemoryType::Global,
-        "The input to the fusion must have the global memory type.");
   }
 
   TORCH_INTERNAL_ASSERT(
@@ -267,9 +264,6 @@ void Fusion::addOutput(Val* const output) {
           " cannot be registered as an output as it has a broadcast axis.");
     }
     tv->setMemoryType(MemoryType::Global);
-    TORCH_INTERNAL_ASSERT(
-        tv->getMemoryType() == MemoryType::Global,
-        "The input to the fusion must have the global memory type.");
   }
   outputs_.push_back(output);
 }

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -233,20 +233,24 @@ void Fusion::addInput(Val* const input) {
 
   if (input->getValType().value() == ValType::TensorView) {
     auto tv = input->as<TensorView>();
-    if (tv->hasReduction())
+    if (tv->hasReduction()) {
       TORCH_WARN_ONCE(
           "Registered input ",
           input,
           " has a reduction axis, but this does nothing in the fusion.");
+    }
+    tv->setMemoryType(MemoryType::Global);
+    TORCH_INTERNAL_ASSERT(
+        tv->getMemoryType() == MemoryType::Global,
+        "The input to the fusion must have the global memory type.");
   }
 
-  TORCH_CHECK(
+  TORCH_INTERNAL_ASSERT(
       input->getOrigin() == nullptr,
       input,
       " cannot be registered as an input as it is used as an output of an expression (",
       input->getOrigin(),
       ").");
-
   inputs_.push_back(input);
 }
 
@@ -254,13 +258,18 @@ void Fusion::addOutput(Val* const output) {
   assertInFusion(output, "Cannot register output ");
   if (output->getValType().value() == ValType::TensorView) {
     auto tv = output->as<TensorView>();
-    if (TensorDomain::hasBroadcast(tv->getRootDomain()))
+    if (TensorDomain::hasBroadcast(tv->getRootDomain())) {
       // Go to the root as we can merge bcast and
       // non-bcast dims, making a non-bcast dim.
-      TORCH_CHECK( // Should we warn instead?
+      TORCH_INTERNAL_ASSERT( // Should we warn instead?
           false,
           output,
           " cannot be registered as an output as it has a broadcast axis.");
+    }
+    tv->setMemoryType(MemoryType::Global);
+    TORCH_INTERNAL_ASSERT(
+        tv->getMemoryType() == MemoryType::Global,
+        "The input to the fusion must have the global memory type.");
   }
   outputs_.push_back(output);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -209,7 +209,10 @@ class TORCH_CUDA_API TensorView : public Val {
   TensorView(TensorView&& other) = delete;
   TensorView& operator=(TensorView&& other) = delete;
 
-  TensorView(TensorDomain* _domain, DataType dtype);
+  TensorView(
+      TensorDomain* _domain,
+      DataType dtype,
+      MemoryType mtype = MemoryType::Local);
 
   TensorView(const std::shared_ptr<c10::TensorType>& tensor_type);
 
@@ -407,7 +410,7 @@ class TORCH_CUDA_API TensorView : public Val {
   // compute at axis in compute at view
   unsigned int relative_compute_at_axis_ = 0;
   unsigned int this_compute_at_axis_ = 0;
-  MemoryType memory_type_ = MemoryType::Global;
+  MemoryType memory_type_ = MemoryType::Local;
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -67,8 +67,9 @@ void IRPrinter::printHeader(
         break;
       case ValType::KirTensorView:
         os << "Tensor<" << val->getDataType().value() << ", "
-           << kir::TensorDomain::noReductions(
-                  val->as<kir::TensorView>()->domain()->rootDomain())
+           << TensorDomain::noReductions(val->as<kir::TensorView>()
+                                             ->fuserTv()
+                                             ->getMaybeRFactorDomain())
                   .size()
            << "> T" << val->name();
         break;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -378,7 +378,10 @@ Allocate::Allocate(Val* buffer, MemoryType memory_type, Val* size)
         "Cannot allocate a non-TensorView buffer with a size != 1, received buffer: ",
         buffer_);
   } else {
-    TORCH_CHECK(buffer_->getValType().value() == ValType::KirTensorView);
+    TORCH_INTERNAL_ASSERT(
+        buffer_->getValType().value() == ValType::KirTensorView);
+    TORCH_INTERNAL_ASSERT(
+        buffer_->as<TensorView>()->getMemoryType() == memory_type_);
     const auto domain = buffer_->as<TensorView>()->domain();
     size_ = domain->nDims() == 0 ? new Int(1) : domain->axis(0)->extent();
     for (size_t i = 1; i < domain->nDims(); i++) {

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -366,11 +366,16 @@ Val* TensorIndex::index(int i) const {
   return indices_[i];
 }
 
-Allocate::Allocate(Val* buffer, MemoryType memory_type, Val* size)
+Allocate::Allocate(
+    Val* buffer,
+    MemoryType memory_type,
+    Val* size,
+    bool zero_init)
     : Expr(ExprType::Allocate),
       buffer_(buffer),
       memory_type_(memory_type),
-      size_(size) {
+      size_(size),
+      zero_init_(zero_init) {
   if (size_ != nullptr) {
     TORCH_INTERNAL_ASSERT(
         size_->isOneInt() ||

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -474,7 +474,8 @@ class TORCH_CUDA_API Allocate : public Expr {
   explicit Allocate(
       Val* buffer,
       MemoryType memory_type = MemoryType::Local,
-      Val* size = nullptr);
+      Val* size = nullptr,
+      bool zero_init = false);
 
   Val* buffer() const {
     return buffer_;
@@ -488,6 +489,10 @@ class TORCH_CUDA_API Allocate : public Expr {
     return size_;
   }
 
+  bool zeroInit() const {
+    return zero_init_;
+  }
+
   DataType buffer_type() const {
     return buffer_->getDataType().value();
   }
@@ -496,6 +501,7 @@ class TORCH_CUDA_API Allocate : public Expr {
   Val* buffer_ = nullptr;
   MemoryType memory_type_ = MemoryType::Local;
   Val* size_ = nullptr;
+  bool zero_init_ = false;
 };
 
 // Sync represents __syncthreads barrier for block level coordination.

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -300,7 +300,7 @@ class TORCH_CUDA_API TensorView : public Val {
 
  private:
   TensorDomain* domain_ = nullptr;
-  MemoryType memory_type_ = MemoryType::Global;
+  MemoryType memory_type_ = MemoryType::Local;
 
   // TODO(kir): remove temporary hack
   const fuser::TensorView* fuser_tv_ = nullptr;

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -158,17 +158,6 @@ void GpuLower::buildSizesMap() {
   }
 }
 
-void GpuLower::adjustMemoryTypes() {
-  for (auto val : fusion_->deterministic_vals()) {
-    if (ir_utils::isTV(val)) {
-      auto tv = val->as<TensorView>();
-      if (fusion_->hasInput(tv) || fusion_->hasOutput(tv)) {
-        tv->setMemoryType(MemoryType::Global);
-      }
-    }
-  }
-}
-
 void GpuLower::lower() {
   TORCH_INTERNAL_ASSERT(fusion_ != nullptr);
   TORCH_INTERNAL_ASSERT(
@@ -189,7 +178,6 @@ void GpuLower::lower() {
   // prepare for lowering
   validateIr(fusion_);
   buildSizesMap();
-  adjustMemoryTypes();
 
   // Compute thread predicates
   ThreadPredicateMap preds(fusion_);

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -60,9 +60,6 @@ class TORCH_CUDA_API GpuLower {
   // tensors to reference the runtime structure containing sizes.
   void buildSizesMap();
 
-  // Adjust memory types to make sure they are valid
-  void adjustMemoryTypes();
-
  private:
   // List of global buffers
   // Allocate nodes track if it needs to be initialized to 0

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -29,12 +29,8 @@ class TORCH_CUDA_API GpuLower {
 
   std::string getKernel(const std::string& kernel_name = "CUDAGeneratedKernel");
 
-  std::unordered_set<kir::Allocate*> global_allocations() {
+  std::vector<kir::Allocate*> global_allocations() {
     return global_allocations_;
-  }
-
-  std::unordered_set<kir::Allocate*> sync_allocations() {
-    return sync_allocations_;
   }
 
   std::vector<kir::Allocate*> dynamic_allocations() {
@@ -68,12 +64,9 @@ class TORCH_CUDA_API GpuLower {
   void adjustMemoryTypes();
 
  private:
-  // List of global buffers (not including buffers for grid syncronization)
-  std::unordered_set<kir::Allocate*> global_allocations_;
-
-  // List of syncronization buffers that must be initialized to 0 when running
-  // the fusion
-  std::unordered_set<kir::Allocate*> sync_allocations_;
+  // List of global buffers
+  // Allocate nodes track if it needs to be initialized to 0
+  std::vector<kir::Allocate*> global_allocations_;
 
   // List of dynamic shared memory buffers
   std::vector<kir::Allocate*> dynamic_smem_allocations_;

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -29,11 +29,11 @@ class TORCH_CUDA_API GpuLower {
 
   std::string getKernel(const std::string& kernel_name = "CUDAGeneratedKernel");
 
-  std::vector<kir::Allocate*> global_allocations() {
+  std::unordered_set<kir::Allocate*> global_allocations() {
     return global_allocations_;
   }
 
-  std::vector<kir::Allocate*> sync_allocations() {
+  std::unordered_set<kir::Allocate*> sync_allocations() {
     return sync_allocations_;
   }
 
@@ -69,11 +69,11 @@ class TORCH_CUDA_API GpuLower {
 
  private:
   // List of global buffers (not including buffers for grid syncronization)
-  std::vector<kir::Allocate*> global_allocations_;
+  std::unordered_set<kir::Allocate*> global_allocations_;
 
   // List of syncronization buffers that must be initialized to 0 when running
   // the fusion
-  std::vector<kir::Allocate*> sync_allocations_;
+  std::unordered_set<kir::Allocate*> sync_allocations_;
 
   // List of dynamic shared memory buffers
   std::vector<kir::Allocate*> dynamic_smem_allocations_;

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -228,7 +228,10 @@ void IndexLowering::handle(ReductionOp* rop) {
     const auto reduce_buffer = new kir::Allocate(
         kir::lowerValue(reduce_buffer_tv), reduce_sync_tv->getMemoryType());
     const auto sync_buffer = new kir::Allocate(
-        kir::lowerValue(reduce_sync_tv), reduce_sync_tv->getMemoryType());
+        kir::lowerValue(reduce_sync_tv),
+        reduce_sync_tv->getMemoryType(),
+        nullptr,
+        true);
 
     const auto grid_reduction_op = block_reduction_op == nullptr
         ? new kir::ReductionOp(

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -217,16 +217,18 @@ void IndexLowering::handle(ReductionOp* rop) {
 
     IterDomain* buffer_id = new IterDomain(new Int(0), buffer_size);
     TensorView* reduce_buffer_tv = new TensorView(
-        new TensorDomain({buffer_id}), out->getDataType().value());
+        new TensorDomain({buffer_id}),
+        out->getDataType().value(),
+        MemoryType::Global);
 
     IterDomain* sync_id = new IterDomain(new Int(0), sync_size);
-    TensorView* reduce_sync_tv =
-        new TensorView(new TensorDomain({sync_id}), DataType::Int);
+    TensorView* reduce_sync_tv = new TensorView(
+        new TensorDomain({sync_id}), DataType::Int, MemoryType::Global);
 
     const auto reduce_buffer = new kir::Allocate(
-        kir::lowerValue(reduce_buffer_tv), MemoryType::Global);
-    const auto sync_buffer =
-        new kir::Allocate(kir::lowerValue(reduce_sync_tv), MemoryType::Global);
+        kir::lowerValue(reduce_buffer_tv), reduce_sync_tv->getMemoryType());
+    const auto sync_buffer = new kir::Allocate(
+        kir::lowerValue(reduce_sync_tv), reduce_sync_tv->getMemoryType());
 
     const auto grid_reduction_op = block_reduction_op == nullptr
         ? new kir::ReductionOp(

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -557,10 +557,6 @@ void TensorView::setMemoryType(MemoryType mt) {
     TORCH_INTERNAL_ASSERT(
         mt == MemoryType::Global,
         "Tried to set an input or output to the fusion to a non-global memory type.");
-  } else {
-    TORCH_INTERNAL_ASSERT(
-        mt != MemoryType::Global,
-        "Tried to set an intermediate tensor in the fusion to the global memory type.");
   }
 }
 

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -24,8 +24,8 @@ DataType aten_opt_type_map(const c10::optional<at::ScalarType>& scalar_type) {
 }
 } // namespace
 
-TensorView::TensorView(TensorDomain* _domain, DataType dtype)
-    : Val(ValType::TensorView, dtype), domain_(_domain) {}
+TensorView::TensorView(TensorDomain* _domain, DataType dtype, MemoryType mtype)
+    : Val(ValType::TensorView, dtype), domain_(_domain), memory_type_(mtype) {}
 
 TensorView::TensorView(const std::shared_ptr<c10::TensorType>& tensor_type)
     : Val(ValType::TensorView,


### PR DESCRIPTION
- [X] When the user designates a intermediate TensorView with the Global memory type, the fuser will pass the intermediate value as an argument to the kernel via global memory.
- [X] Enable support for the default schedule.