### PR TITLE
cache on static input size/stride pr_0

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -554,9 +554,8 @@ class TestCudaFuser(JitTestCase):
         jit_o = t_jit(x, y)
         jit_o = t_jit(x, y)
         o = t(x, y)
-        for oo, jit_oo in zip(o, jit_o):
-            self.assertEqual(oo.dtype, jit_oo.dtype)
-            self.assertEqual(oo, jit_oo)
+        self.assertEqual(o.dtype, jit_o.dtype)
+        self.assertEqual(o, jit_o)
         self.assertGraphContains(t_jit.graph_for(x, y), FUSION_GROUP)
 
     # end-2-end test of permutation & contiguity handling in integration.
@@ -599,11 +598,10 @@ class TestCudaFuser(JitTestCase):
         jit_o = t_jit(x, y)
         jit_o = t_jit(x, y)
         o = t(x, y)
-        for oo, jit_oo in zip(o, jit_o):
-            self.assertEqual(oo.dtype, jit_oo.dtype)
-            # numerical issues here due to our scheduling.
-            # can't use `self.assertEqual(oo, jit_oo)`
-            self.assertTrue(self._compare("comparing output failed", oo, jit_oo, 1e-4))
+        self.assertEqual(o.dtype, jit_o.dtype)
+        # numerical issues here due to our scheduling.
+        # can't use `self.assertEqual(o, jit_o)`
+        self.assertTrue(self._compare("comparing output failed", o, jit_o, 1e-4))
         self.assertGraphContains(t_jit.graph_for(x, y), FUSION_GROUP)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
@@ -655,9 +653,8 @@ class TestCudaFuser(JitTestCase):
         jit_o = t_jit(x, y, z)
         jit_o = t_jit(x, y, z)
         o = t(x, y, z)
-        for oo, jit_oo in zip(o, jit_o):
-            self.assertEqual(oo.dtype, jit_oo.dtype)
-            self.assertEqual(oo, jit_oo)
+        self.assertEqual(o.dtype, jit_o.dtype)
+        self.assertEqual(o, jit_o)
         self.assertGraphContains(t_jit.graph_for(x, y, z), FUSION_GROUP)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
@@ -680,9 +677,8 @@ class TestCudaFuser(JitTestCase):
         jit_o = t_jit(x, y, z)
         jit_o = t_jit(x, y, z)
         o = t(x, y, z)
-        for oo, jit_oo in zip(o, jit_o):
-            self.assertEqual(oo.dtype, jit_oo.dtype)
-            self.assertEqual(oo, jit_oo)
+        self.assertEqual(o.dtype, jit_o.dtype)
+        self.assertEqual(o, jit_o)
         self.assertGraphContains(t_jit.graph_for(x, y, z), FUSION_GROUP)
 
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -287,7 +287,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   TORCH_INTERNAL_ASSERT(
       fusion_id_ > 0, "Cannot run fusion, it was not compiled.");
   TORCH_INTERNAL_ASSERT(
-      !opt_code.has_value() || !outputs.empty(), "short cut input cache is not compatible with pre-allocated output");
+      !opt_code.has_value() || outputs.empty(), "short cut input cache is not compatible with pre-allocated output");
 
   ExecutorEntry* executor_entry = nullptr;
   if (opt_code.has_value()) {
@@ -364,6 +364,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         executor_entry->zero_buffer_types.push_back(buffer.scalar_type());
       }
       executor_entry->rand_offset = rand_offset;
+      executor_entry->init = true;
     }
   }
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -320,7 +320,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     for (int i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {
       auto tensor_options =
           at::TensorOptions().dtype(executor_entry->zero_buffer_types[i]).device(options_.device);
-      zero_buffers.push_back(at::empty(executor_entry->zero_buffer_sizes[i], tensor_options));
+      zero_buffers.push_back(at::zeros(executor_entry->zero_buffer_sizes[i], tensor_options));
     }
     rand_offset = executor_entry->rand_offset;
   } else {

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -47,7 +47,6 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
   }
 
   fusion_ = *fusion;
-  FusionGuard fg(&fusion_);
   options_ = options;
 
   fusion_id_ = ++fusion_id_counter_;

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -308,21 +308,25 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   uint64_t rand_offset = 0;
 
   if (executor_entry && executor_entry->init) {
-    // take the short-cut for launch if we see a recorded input set again;
-    launch_params = executor_entry->launch_params;
-    for (size_t i = 0; i < executor_entry->output_sizes.size(); i++) {
-      auto tensor_options = at::TensorOptions()
-                                .dtype(executor_entry->output_types[i])
-                                .device(options_.device);
-      alloced_outputs.push_back(
-          at::empty(executor_entry->output_sizes[i], tensor_options));
-    }
-    for (size_t i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
-      auto tensor_options = at::TensorOptions()
-                                .dtype(executor_entry->empty_buffer_types[i])
-                                .device(options_.device);
-      global_buffers.empty_buffers.push_back(
-          at::empty(executor_entry->empty_buffer_sizes[i], tensor_options));
+    {
+      // context manager to disable auto grad for `empty_cuda` calls later;
+      at::AutoNonVariableTypeMode non_variable_type_mode;
+      // take the short-cut for launch if we see a recorded input set again;
+      launch_params = executor_entry->launch_params;
+      for (size_t i = 0; i < executor_entry->output_sizes.size(); i++) {
+        auto tensor_options = at::TensorOptions()
+                                  .dtype(executor_entry->output_types[i])
+                                  .device(options_.device);
+        alloced_outputs.push_back(
+            at::native::empty_cuda(executor_entry->output_sizes[i], tensor_options));
+      }
+      for (size_t i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
+        auto tensor_options = at::TensorOptions()
+                                  .dtype(executor_entry->empty_buffer_types[i])
+                                  .device(options_.device);
+        global_buffers.empty_buffers.push_back(
+            at::native::empty_cuda(executor_entry->empty_buffer_sizes[i], tensor_options));
+      }
     }
     for (size_t i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {
       auto tensor_options = at::TensorOptions()

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -333,6 +333,9 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     }
     rand_offset = executor_entry->rand_offset;
   } else {
+    // code path to take when either:
+    //   1. no opt_code is provided or;
+    //   2. `executor_entry` is not initialized
     executor_utils::validateKernelInputs(&fusion_, inputs, options_.device);
 
     EvaluationContext evaluation_context =
@@ -364,8 +367,10 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
            1);
     }
 
-    // record the the short-cut executor entry for the given input set;
+    // This is the entry when we have provided `opt_code` but the entry has not
+    // been initialized yet.
     if (executor_entry) {
+      // record the the short-cut executor entry for the given input set;
       executor_entry->launch_params = launch_params;
       for (const auto& output : alloced_outputs) {
         executor_entry->output_sizes.push_back(output.sizes().vec());

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -70,7 +70,6 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
       structured_code,
       (kernelNamespace() + "::" + kernelName()).c_str(),
       fusion_id_);
-  compiled_ = true;
 }
 
 namespace {
@@ -244,13 +243,13 @@ LaunchParams FusionExecutor::computeLaunchParams(
   return launch_params;
 }
 
-std::vector<at::Tensor> FusionExecutor::allocGlobalVals(EvaluationContext& ec) {
-  std::vector<at::Tensor> global_buffers;
+std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> FusionExecutor::allocGlobalVals(EvaluationContext& ec) {
+  std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> global_buffers;
   for (auto alloc : lowered_.global_allocations()) {
     TORCH_INTERNAL_ASSERT(
         alloc->buffer()->getValType() == ValType::KirTensorView,
         "Cannot allocate global buffers that are not tensors.");
-    global_buffers.push_back(inferAndAlloc(
+    global_buffers.first.push_back(inferAndAlloc(
         alloc->buffer()->as<kir::TensorView>()->fuserTv(),
         ec,
         options_,
@@ -261,7 +260,7 @@ std::vector<at::Tensor> FusionExecutor::allocGlobalVals(EvaluationContext& ec) {
     TORCH_INTERNAL_ASSERT(
         alloc->buffer()->getValType() == ValType::KirTensorView,
         "Cannot allocate global buffers that are not tensors.");
-    global_buffers.push_back(inferAndAlloc(
+    global_buffers.second.push_back(inferAndAlloc(
         alloc->buffer()->as<kir::TensorView>()->fuserTv(), ec, options_, true));
   }
 
@@ -283,42 +282,97 @@ std::vector<at::Tensor> FusionExecutor::allocOutputs(EvaluationContext& ec) {
 std::vector<at::Tensor> FusionExecutor::runFusion(
     const at::ArrayRef<IValue>& inputs,
     const std::vector<at::Tensor>& outputs,
-    const LaunchParams& launch_constraints) {
+    const LaunchParams& launch_constraints,
+    const c10::optional<size_t> opt_code) {
   TORCH_INTERNAL_ASSERT(
       fusion_id_ > 0, "Cannot run fusion, it was not compiled.");
+  TORCH_INTERNAL_ASSERT(
+      !opt_code.has_value() || !outputs.empty(), "short cut input cache is not compatible with pre-allocated output");
+
+  ExecutorEntry* executor_entry = nullptr;
+  if (opt_code.has_value()) {
+    executor_entry = &executor_entry_lookup_[*opt_code];
+  }
 
   FusionGuard fg(&fusion_);
-
-  executor_utils::validateKernelInputs(&fusion_, inputs, options_.device);
-
   c10::DeviceGuard dg(options_.device);
   auto stream = at::cuda::getCurrentCUDAStream();
 
-  EvaluationContext evaluation_context =
-      executor_utils::bindInputs(inputs, &fusion_, &lowered_);
-
-  LaunchParams launch_params =
-      computeLaunchParams(inputs, launch_constraints, evaluation_context);
-
+  LaunchParams launch_params;
   std::vector<at::Tensor> alloced_outputs = outputs;
-  if (outputs.empty() || outputs.size() != fusion_.outputs().size()) {
-    alloced_outputs = allocOutputs(evaluation_context);
-  }
+  std::vector<at::Tensor> empty_buffers;
+  std::vector<at::Tensor> zero_buffers;
+  uint64_t rand_offset = 0;
 
-  executor_utils::validateKernelOutputs(
-      &fusion_, alloced_outputs, options_.device);
+  // only validate inputs if we haven't seen/record the input set;
+  if (executor_entry && executor_entry->init) {
+    launch_params = executor_entry->launch_params;
+    for (int i = 0; i < executor_entry->output_sizes.size(); i++) {
+      auto tensor_options =
+          at::TensorOptions().dtype(executor_entry->output_types[i]).device(options_.device);
+      alloced_outputs.push_back(at::empty(executor_entry->output_sizes[i], tensor_options));
+    }
+    for (int i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
+      auto tensor_options =
+          at::TensorOptions().dtype(executor_entry->empty_buffer_types[i]).device(options_.device);
+      empty_buffers.push_back(at::empty(executor_entry->empty_buffer_sizes[i], tensor_options));
+    }
+    for (int i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {
+      auto tensor_options =
+          at::TensorOptions().dtype(executor_entry->zero_buffer_types[i]).device(options_.device);
+      zero_buffers.push_back(at::empty(executor_entry->zero_buffer_sizes[i], tensor_options));
+    }
+    rand_offset = executor_entry->rand_offset;
+  } else {
+    executor_utils::validateKernelInputs(&fusion_, inputs, options_.device);
+
+    EvaluationContext evaluation_context =
+        executor_utils::bindInputs(inputs, &fusion_, &lowered_);
+
+    launch_params = 
+          computeLaunchParams(inputs, launch_constraints, evaluation_context);
+
+    if (outputs.empty() || outputs.size() != fusion_.outputs().size()) {
+      alloced_outputs = allocOutputs(evaluation_context);
+    }
+
+
+    executor_utils::validateKernelOutputs(
+        &fusion_, alloced_outputs, options_.device);
+
+    std::tie(empty_buffers, zero_buffers) = allocGlobalVals(evaluation_context);
+
+    if (has_random_) {
+      rand_offset = 4 *
+          (std::ceil(
+               alloced_outputs[0].numel() / (4.0 * 128 * launch_params.gdimx())) +
+           1);
+    }
+
+    if (executor_entry) {
+      executor_entry->launch_params = launch_params;
+      for (const auto& output : alloced_outputs) {
+        executor_entry->output_sizes.push_back(output.sizes().vec());
+        executor_entry->output_types.push_back(output.scalar_type());
+      }
+      for (const auto& buffer : empty_buffers) {
+        executor_entry->empty_buffer_sizes.push_back(buffer.sizes().vec());
+        executor_entry->empty_buffer_types.push_back(buffer.scalar_type());
+      }
+      for (const auto& buffer : zero_buffers) {
+        executor_entry->zero_buffer_sizes.push_back(buffer.sizes().vec());
+        executor_entry->zero_buffer_types.push_back(buffer.scalar_type());
+      }
+      executor_entry->rand_offset = rand_offset;
+    }
+  }
 
   KernelArgumentHolder kernel_arguments;
   kernel_arguments.push(inputs);
   kernel_arguments.push(alloced_outputs);
-  auto buffers = allocGlobalVals(evaluation_context);
-  kernel_arguments.push(buffers);
-
+  kernel_arguments.push(empty_buffers);
+  kernel_arguments.push(zero_buffers);
   if (has_random_) {
-    const auto rand_offset = 4 *
-        (std::ceil(
-             alloced_outputs[0].numel() / (4.0 * 128 * launch_params.gdimx())) +
-         1);
     kernel_arguments.appendPhiloxRNGSeed(rand_offset);
   }
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -243,7 +243,8 @@ LaunchParams FusionExecutor::computeLaunchParams(
   return launch_params;
 }
 
-std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> FusionExecutor::allocGlobalVals(EvaluationContext& ec) {
+std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> FusionExecutor::
+    allocGlobalVals(EvaluationContext& ec) {
   std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> global_buffers;
   for (auto alloc : lowered_.global_allocations()) {
     TORCH_INTERNAL_ASSERT(
@@ -287,7 +288,8 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   TORCH_INTERNAL_ASSERT(
       fusion_id_ > 0, "Cannot run fusion, it was not compiled.");
   TORCH_INTERNAL_ASSERT(
-      !opt_code.has_value() || outputs.empty(), "short cut input cache is not compatible with pre-allocated output");
+      !opt_code.has_value() || outputs.empty(),
+      "short cut input cache is not compatible with pre-allocated output");
 
   ExecutorEntry* executor_entry = nullptr;
   if (opt_code.has_value()) {
@@ -308,19 +310,25 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   if (executor_entry && executor_entry->init) {
     launch_params = executor_entry->launch_params;
     for (int i = 0; i < executor_entry->output_sizes.size(); i++) {
-      auto tensor_options =
-          at::TensorOptions().dtype(executor_entry->output_types[i]).device(options_.device);
-      alloced_outputs.push_back(at::empty(executor_entry->output_sizes[i], tensor_options));
+      auto tensor_options = at::TensorOptions()
+                                .dtype(executor_entry->output_types[i])
+                                .device(options_.device);
+      alloced_outputs.push_back(
+          at::empty(executor_entry->output_sizes[i], tensor_options));
     }
     for (int i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
-      auto tensor_options =
-          at::TensorOptions().dtype(executor_entry->empty_buffer_types[i]).device(options_.device);
-      empty_buffers.push_back(at::empty(executor_entry->empty_buffer_sizes[i], tensor_options));
+      auto tensor_options = at::TensorOptions()
+                                .dtype(executor_entry->empty_buffer_types[i])
+                                .device(options_.device);
+      empty_buffers.push_back(
+          at::empty(executor_entry->empty_buffer_sizes[i], tensor_options));
     }
     for (int i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {
-      auto tensor_options =
-          at::TensorOptions().dtype(executor_entry->zero_buffer_types[i]).device(options_.device);
-      zero_buffers.push_back(at::zeros(executor_entry->zero_buffer_sizes[i], tensor_options));
+      auto tensor_options = at::TensorOptions()
+                                .dtype(executor_entry->zero_buffer_types[i])
+                                .device(options_.device);
+      zero_buffers.push_back(
+          at::zeros(executor_entry->zero_buffer_sizes[i], tensor_options));
     }
     rand_offset = executor_entry->rand_offset;
   } else {
@@ -329,13 +337,12 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     EvaluationContext evaluation_context =
         executor_utils::bindInputs(inputs, &fusion_, &lowered_);
 
-    launch_params = 
-          computeLaunchParams(inputs, launch_constraints, evaluation_context);
+    launch_params =
+        computeLaunchParams(inputs, launch_constraints, evaluation_context);
 
     if (outputs.empty() || outputs.size() != fusion_.outputs().size()) {
       alloced_outputs = allocOutputs(evaluation_context);
     }
-
 
     executor_utils::validateKernelOutputs(
         &fusion_, alloced_outputs, options_.device);
@@ -345,7 +352,8 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     if (has_random_) {
       rand_offset = 4 *
           (std::ceil(
-               alloced_outputs[0].numel() / (4.0 * 128 * launch_params.gdimx())) +
+               alloced_outputs[0].numel() /
+               (4.0 * 128 * launch_params.gdimx())) +
            1);
     }
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -284,7 +284,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     const at::ArrayRef<IValue>& inputs,
     const std::vector<at::Tensor>& outputs,
     const LaunchParams& launch_constraints,
-    const c10::optional<size_t> opt_code) {
+    const c10::optional<size_t>& opt_code) {
   TORCH_INTERNAL_ASSERT(
       fusion_id_ > 0, "Cannot run fusion, it was not compiled.");
   TORCH_INTERNAL_ASSERT(
@@ -309,21 +309,21 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   // only validate inputs if we haven't seen/record the input set;
   if (executor_entry && executor_entry->init) {
     launch_params = executor_entry->launch_params;
-    for (int i = 0; i < executor_entry->output_sizes.size(); i++) {
+    for (size_t i = 0; i < executor_entry->output_sizes.size(); i++) {
       auto tensor_options = at::TensorOptions()
                                 .dtype(executor_entry->output_types[i])
                                 .device(options_.device);
       alloced_outputs.push_back(
           at::empty(executor_entry->output_sizes[i], tensor_options));
     }
-    for (int i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
+    for (size_t i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
       auto tensor_options = at::TensorOptions()
                                 .dtype(executor_entry->empty_buffer_types[i])
                                 .device(options_.device);
       empty_buffers.push_back(
           at::empty(executor_entry->empty_buffer_sizes[i], tensor_options));
     }
-    for (int i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {
+    for (size_t i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {
       auto tensor_options = at::TensorOptions()
                                 .dtype(executor_entry->zero_buffer_types[i])
                                 .device(options_.device);
@@ -353,7 +353,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
       rand_offset = 4 *
           (std::ceil(
                alloced_outputs[0].numel() /
-               (4.0 * 128 * launch_params.gdimx())) +
+               (4.0 * 128 * launch_params.gdimx())) + // NOLINT
            1);
     }
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -296,7 +296,6 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     executor_entry = &executor_entry_lookup_[*opt_code];
   }
 
-  FusionGuard fg(&fusion_);
   c10::DeviceGuard dg(options_.device);
   auto stream = at::cuda::getCurrentCUDAStream();
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -306,8 +306,8 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   std::vector<at::Tensor> zero_buffers;
   uint64_t rand_offset = 0;
 
-  // only validate inputs if we haven't seen/record the input set;
   if (executor_entry && executor_entry->init) {
+    // take the short-cut for launch if we see a recorded input set again;
     launch_params = executor_entry->launch_params;
     for (size_t i = 0; i < executor_entry->output_sizes.size(); i++) {
       auto tensor_options = at::TensorOptions()
@@ -357,6 +357,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
            1);
     }
 
+    // record the the short-cut executor entry for the given input set;
     if (executor_entry) {
       executor_entry->launch_params = launch_params;
       for (const auto& output : alloced_outputs) {

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -245,7 +245,8 @@ LaunchParams FusionExecutor::computeLaunchParams(
   return launch_params;
 }
 
-FusionExecutor::GlobalBuffers FusionExecutor::allocGlobalVals(EvaluationContext& ec) {
+FusionExecutor::GlobalBuffers FusionExecutor::allocGlobalVals(
+    EvaluationContext& ec) {
   GlobalBuffers global_buffers;
   for (auto alloc : lowered_.global_allocations()) {
     TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -47,6 +47,7 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
   }
 
   fusion_ = *fusion;
+  FusionGuard fg(&fusion_);
   options_ = options;
 
   fusion_id_ = ++fusion_id_counter_;
@@ -296,6 +297,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     executor_entry = &executor_entry_lookup_[*opt_code];
   }
 
+  FusionGuard fg(&fusion_);
   c10::DeviceGuard dg(options_.device);
   auto stream = at::cuda::getCurrentCUDAStream();
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -317,15 +317,15 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         auto tensor_options = at::TensorOptions()
                                   .dtype(executor_entry->output_types[i])
                                   .device(options_.device);
-        alloced_outputs.push_back(
-            at::native::empty_cuda(executor_entry->output_sizes[i], tensor_options));
+        alloced_outputs.push_back(at::native::empty_cuda(
+            executor_entry->output_sizes[i], tensor_options));
       }
       for (size_t i = 0; i < executor_entry->empty_buffer_sizes.size(); i++) {
         auto tensor_options = at::TensorOptions()
                                   .dtype(executor_entry->empty_buffer_types[i])
                                   .device(options_.device);
-        global_buffers.empty_buffers.push_back(
-            at::native::empty_cuda(executor_entry->empty_buffer_sizes[i], tensor_options));
+        global_buffers.empty_buffers.push_back(at::native::empty_cuda(
+            executor_entry->empty_buffer_sizes[i], tensor_options));
       }
     }
     for (size_t i = 0; i < executor_entry->zero_buffer_sizes.size(); i++) {

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -84,7 +84,8 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
       bool align_padding = false,
       uint64_t total = 0);
 
-  std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> allocGlobalVals(EvaluationContext& ec);
+  std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> allocGlobalVals(
+      EvaluationContext& ec);
 
   std::vector<at::Tensor> allocOutputs(EvaluationContext& ec);
 

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -29,12 +29,12 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
       const at::ArrayRef<IValue>& inputs,
       const std::vector<at::Tensor>& outputs,
       const LaunchParams& launch_constraints = LaunchParams(),
-      const c10::optional<size_t> opt_code = c10::nullopt);
+      const c10::optional<size_t>& opt_code = c10::nullopt);
 
   std::vector<at::Tensor> runFusion(
       const at::ArrayRef<IValue>& inputs,
       const LaunchParams& launch_constraints = LaunchParams(),
-      const c10::optional<size_t> opt_code = c10::nullopt) {
+      const c10::optional<size_t>& opt_code = c10::nullopt) {
     return runFusion(inputs, {}, launch_constraints, opt_code);
   }
 

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -46,7 +46,8 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
 
   // TODO: strides would also be important when we handle permutations in
   //       codegen.
-  // struct used to hold launch configurations;
+  // struct used to hold necessary information to launch compiled kernel on a
+  // given input set;
   struct ExecutorEntry {
     bool init = false;
     LaunchParams launch_params;
@@ -84,6 +85,8 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
       bool align_padding = false,
       uint64_t total = 0);
 
+  // return a pair of vector of tensors, where tensors in the first vector are
+  // not initialized, while the second vector contains zero-initiliazed tensors
   std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> allocGlobalVals(
       EvaluationContext& ec);
 
@@ -105,6 +108,8 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
 
   GpuLower lowered_;
 
+  // lookup table to take short cut to retrieve recorded information in order to
+  // launch kernels without re-inference parameters.
   std::unordered_map<size_t, ExecutorEntry> executor_entry_lookup_;
 };
 

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -28,18 +28,35 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
   std::vector<at::Tensor> runFusion(
       const at::ArrayRef<IValue>& inputs,
       const std::vector<at::Tensor>& outputs,
-      const LaunchParams& launch_constraints = LaunchParams());
+      const LaunchParams& launch_constraints = LaunchParams(),
+      const c10::optional<size_t> opt_code = c10::nullopt);
 
   std::vector<at::Tensor> runFusion(
       const at::ArrayRef<IValue>& inputs,
-      const LaunchParams& launch_constraints = LaunchParams()) {
-    return runFusion(inputs, {}, launch_constraints);
+      const LaunchParams& launch_constraints = LaunchParams(),
+      const c10::optional<size_t> opt_code = c10::nullopt) {
+    return runFusion(inputs, {}, launch_constraints, opt_code);
   }
 
   // function to query whether a `FusionExecutor` has a compiled kernel to
   // execute
   bool compiled() const {
-    return compiled_;
+    return fusion_id_ != -1;
+  };
+
+  // TODO: strides would also be important when we handle permutations in
+  //       codegen.
+  // struct used to hold launch configurations;
+  struct ExecutorEntry {
+    bool init = false;
+    LaunchParams launch_params;
+    std::vector<std::vector<int64_t>> output_sizes;
+    std::vector<at::ScalarType> output_types;
+    std::vector<std::vector<int64_t>> empty_buffer_sizes;
+    std::vector<at::ScalarType> empty_buffer_types;
+    std::vector<std::vector<int64_t>> zero_buffer_sizes;
+    std::vector<at::ScalarType> zero_buffer_types;
+    uint64_t rand_offset;
   };
 
  private:
@@ -67,13 +84,11 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
       bool align_padding = false,
       uint64_t total = 0);
 
-  std::vector<at::Tensor> allocGlobalVals(EvaluationContext& ec);
+  std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> allocGlobalVals(EvaluationContext& ec);
 
   std::vector<at::Tensor> allocOutputs(EvaluationContext& ec);
 
  private:
-  bool compiled_ = false;
-
   Fusion fusion_;
 
   CompileOptions options_;
@@ -88,6 +103,8 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
   static int fusion_id_counter_;
 
   GpuLower lowered_;
+
+  std::unordered_map<size_t, ExecutorEntry> executor_entry_lookup_;
 };
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -47,7 +47,7 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
   // TODO: strides would also be important when we handle permutations in
   //       codegen.
   // struct used to hold necessary information to launch compiled kernel on a
-  // given input set;
+  // given input set.
   struct ExecutorEntry {
     bool init = false;
     LaunchParams launch_params;
@@ -61,6 +61,11 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
   };
 
  private:
+  struct GlobalBuffers {
+    std::vector<at::Tensor> empty_buffers;
+    std::vector<at::Tensor> zero_buffers;
+  };
+
   std::string kernelName() const {
     std::stringstream ss;
     ss << "kernel" << fusion_id_;
@@ -87,8 +92,7 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
 
   // return a pair of vector of tensors, where tensors in the first vector are
   // not initialized, while the second vector contains zero-initiliazed tensors
-  std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>> allocGlobalVals(
-      EvaluationContext& ec);
+  GlobalBuffers allocGlobalVals(EvaluationContext& ec);
 
   std::vector<at::Tensor> allocOutputs(EvaluationContext& ec);
 

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -135,8 +135,6 @@ void validateKernelInputs(
     Fusion* fusion,
     const at::ArrayRef<IValue>& inputs,
     c10::Device device) {
-  // This is necessary as we were traversing the fusion graph later in the check
-  FusionGuard fg(fusion);
   // Check inputs
   TORCH_INTERNAL_ASSERT(
       inputs.size() == fusion->inputs().size(),
@@ -261,6 +259,9 @@ EvaluationContext bindInputs(
 
       for (size_t dim = 0; dim < root_dom.size(); dim++) {
         auto extent = root_dom[dim]->extent();
+        // For some reason, the next line requires FusionGuard, otherwise it
+        // segfaults
+        FusionGuard fg(fusion);
         safeBind(eval_context, extent, aten_tensor.sizes()[dim]);
         if (!extent->isConstScalar()) {
           safeBind(

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -259,9 +259,6 @@ EvaluationContext bindInputs(
 
       for (size_t dim = 0; dim < root_dom.size(); dim++) {
         auto extent = root_dom[dim]->extent();
-        // For some reason, the next line requires FusionGuard, otherwise it
-        // segfaults
-        FusionGuard fg(fusion);
         safeBind(eval_context, extent, aten_tensor.sizes()[dim]);
         if (!extent->isConstScalar()) {
           safeBind(

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -315,7 +315,6 @@ NvrtcFunction nvrtcCompile(
   const char* disable_fma = getenv("PYTORCH_CUDA_FUSER_DISABLE_FMA");
   // int disable_fma_flag = disable_fma ? atoi(disable_fma) : 0;
   if (disable_fma && atoi(disable_fma)) {
-    printf("disabling fmad\n");
     args.push_back("--fmad=false");
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -269,7 +269,8 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
       code_to_fe_lookup_[unique_id] = pw_fusion_executor_cache_.get();
     }
   }
-  return code_to_fe_lookup_[unique_id]->runFusion(inputs, LaunchParams(), unique_id);
+  return code_to_fe_lookup_[unique_id]->runFusion(
+      inputs, LaunchParams(), unique_id);
 }
 
 GraphCache::InputsRequirement::InputsRequirement(

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -196,13 +196,13 @@ size_t InputsCodeLookup::getCode(const at::ArrayRef<IValue>& inputs) {
       auto sep = "";
       for (auto size : input_tensor.sizes()) {
         encoded_inputs << sep << size;
-				sep = ",";
+        sep = ",";
       }
       encoded_inputs << "@";
       sep = "";
       for (auto stride : input_tensor.strides()) {
         encoded_inputs << sep << stride;
-				sep = ",";
+        sep = ",";
       }
     } else {
       // encode s for scalar;
@@ -228,12 +228,11 @@ FusionExecutorCache::FusionExecutorCache(
 std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
     const at::ArrayRef<IValue>& inputs,
     const size_t code) {
-
   if (code_to_fe_lookup_.count(code) == 0) {
     // caching strategy is different for pw-fusion and reduction-fusion.
     if (has_reduction_) {
-      // copy the fusion, since each FusionExecutor needs to manipulate the fusion
-      // in order to generate kernel.
+      // copy the fusion, since each FusionExecutor needs to manipulate the
+      // fusion in order to generate kernel.
       Fusion fusion = *fusion_;
       FusionGuard fg(&fusion);
       TensorView* red_tv = nullptr;
@@ -558,7 +557,6 @@ GraphCache::GraphCache(std::shared_ptr<Graph> graph)
 
 std::vector<at::Tensor> GraphCache::runGraphWithInputs(
     const at::ArrayRef<IValue>& inputs) {
-
   size_t code = input_code_lookup_.getCode(inputs);
 
   FusionExecutorCache* fusion_executor_cache = nullptr;
@@ -584,7 +582,8 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
   } else {
     fusion_executor_cache = fe_cache_[code_to_index_lookup_[code]].get();
   }
-  InputsRequirement* input_requirement = &input_stacks_[code_to_index_lookup_[code]];
+  InputsRequirement* input_requirement =
+      &input_stacks_[code_to_index_lookup_[code]];
 
   // GraphCache need to permute inputs/outputs to accommodate dimension
   // coalescing
@@ -599,7 +598,8 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
         permuted_inputs.emplace_back(input);
       }
     }
-    auto outputs = fusion_executor_cache->runFusionWithInputs(permuted_inputs, code);
+    auto outputs =
+        fusion_executor_cache->runFusionWithInputs(permuted_inputs, code);
     std::vector<at::Tensor> permuted_outputs;
     permuted_outputs.reserve(outputs.size());
     for (const auto& output : outputs) {

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -272,7 +272,7 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
     }
   }
   // TODO: plumb code to FusionExecutor;
-  return code_to_fe_lookup_[code]->runFusion(inputs);
+  return code_to_fe_lookup_[code]->runFusion(inputs, LaunchParams(), code);
 }
 
 GraphCache::InputsRequirement::InputsRequirement(

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -232,7 +232,6 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
       // copy the fusion, since each FusionExecutor needs to manipulate the
       // fusion in order to generate kernel.
       Fusion fusion = *fusion_;
-      FusionGuard fg(&fusion);
       TensorView* red_tv = nullptr;
       for (auto expr : fusion.exprs()) {
         if (expr->getExprType().has_value() &&

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -248,16 +248,16 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
       TORCH_INTERNAL_ASSERT(
           reduction_params.has_value(),
           "reduction schedule failed in `scheduleReduction`");
-      auto& fusion_executor =
-          red_fusion_executor_cache_[reduction_params.value()];
-      if (!fusion_executor.compiled()) {
+      auto fusion_executor =
+          &red_fusion_executor_cache_[reduction_params.value()];
+      if (!fusion_executor->compiled()) {
         // This means we have not found a previously generated kernel that's
         // compatible with the new reduction params. We need to finish codegen.
         CompileOptions options;
         options.device = device_;
-        fusion_executor.compileFusion(&fusion, options);
+        fusion_executor->compileFusion(&fusion, options);
       }
-      code_to_fe_lookup_[code] = &fusion_executor;
+      code_to_fe_lookup_[code] = fusion_executor;
     } else {
       if (!pw_fusion_executor_cache_) {
         pw_fusion_executor_cache_ = std::make_unique<FusionExecutor>();

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/jit/codegen/cuda/scheduler.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 
+#include <nvToolsExt.h>
 // TODO: This class is dead at the moment, but we need to figure out a generic
 // cacheing system that will suite our needs.
 
@@ -185,6 +186,36 @@ at::DimVector inversePermutation(
 
 } // namespace
 
+size_t InputsCodeLookup::getCode(const at::ArrayRef<IValue>& inputs) {
+  std::stringstream encoded_inputs;
+  for (const auto& input : inputs) {
+    if (input.isTensor()) {
+      auto input_tensor = input.toTensor();
+
+      encoded_inputs << ";";
+      auto sep = "";
+      for (auto size : input_tensor.sizes()) {
+        encoded_inputs << sep << size;
+				sep = ",";
+      }
+      encoded_inputs << "@";
+      sep = "";
+      for (auto stride : input_tensor.strides()) {
+        encoded_inputs << sep << stride;
+				sep = ",";
+      }
+    } else {
+      // encode s for scalar;
+      encoded_inputs << ";s";
+    }
+  }
+  auto& iter = inputs_code_lookup_[encoded_inputs.str()];
+  if (iter == 0) {
+    iter = current_id_++;
+  }
+  return iter;
+}
+
 FusionExecutorCache::FusionExecutorCache(
     std::unique_ptr<Fusion>&& fusion,
     at::Device device)
@@ -195,47 +226,53 @@ FusionExecutorCache::FusionExecutorCache(
 
 // TODO: dummy cache
 std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
-    const at::ArrayRef<IValue>& inputs) {
-  // caching strategy is different for pw-fusion and reduction-fusion.
-  if (has_reduction_) {
-    // copy the fusion, since each FusionExecutor needs to manipulate the fusion
-    // in order to generate kernel.
-    Fusion fusion = *fusion_;
-    FusionGuard fg(&fusion);
-    TensorView* red_tv = nullptr;
-    for (auto expr : fusion.exprs()) {
-      if (expr->getExprType().has_value() &&
-          expr->getExprType().value() == ExprType::ReductionOp) {
-        red_tv = expr->outputs()[0]->as<TensorView>();
-        break;
+    const at::ArrayRef<IValue>& inputs,
+    const size_t code) {
+
+  if (code_to_fe_lookup_.count(code) == 0) {
+    // caching strategy is different for pw-fusion and reduction-fusion.
+    if (has_reduction_) {
+      // copy the fusion, since each FusionExecutor needs to manipulate the fusion
+      // in order to generate kernel.
+      Fusion fusion = *fusion_;
+      FusionGuard fg(&fusion);
+      TensorView* red_tv = nullptr;
+      for (auto expr : fusion.exprs()) {
+        if (expr->getExprType().has_value() &&
+            expr->getExprType().value() == ExprType::ReductionOp) {
+          red_tv = expr->outputs()[0]->as<TensorView>();
+          break;
+        }
       }
+      auto reduction_params = scheduleReduction(&fusion, inputs, red_tv);
+      TORCH_INTERNAL_ASSERT(
+          reduction_params.has_value(),
+          "reduction schedule failed in `scheduleReduction`");
+      auto& fusion_executor =
+          red_fusion_executor_cache_[reduction_params.value()];
+      if (!fusion_executor.compiled()) {
+        // This means we have not found a previously generated kernel that's
+        // compatible with the new reduction params. We need to finish codegen.
+        CompileOptions options;
+        options.device = device_;
+        fusion_executor.compileFusion(&fusion, options);
+      }
+      code_to_fe_lookup_[code] = &fusion_executor;
+    } else {
+      if (!pw_fusion_executor_cache_) {
+        pw_fusion_executor_cache_ = std::make_unique<FusionExecutor>();
+        CompileOptions options;
+        options.device = device_;
+        // no need to copy fusion_, as we are not generating more than 1 kernel
+        // for PW.
+        scheduleFusion(fusion_.get(), inputs);
+        pw_fusion_executor_cache_->compileFusion(fusion_.get(), options);
+      }
+      code_to_fe_lookup_[code] = pw_fusion_executor_cache_.get();
     }
-    auto reduction_params = scheduleReduction(&fusion, inputs, red_tv);
-    TORCH_INTERNAL_ASSERT(
-        reduction_params.has_value(),
-        "reduction schedule failed in `scheduleReduction`");
-    auto& fusion_executor =
-        red_fusion_executor_cache_[reduction_params.value()];
-    if (!fusion_executor.compiled()) {
-      // This means we have not found a previously generated kernel that's
-      // compatible with the new reduction params. We need to finish codegen.
-      CompileOptions options;
-      options.device = device_;
-      fusion_executor.compileFusion(&fusion, options);
-    }
-    return fusion_executor.runFusion(inputs);
-  } else {
-    if (!pw_fusion_executor_cache_) {
-      pw_fusion_executor_cache_ = std::make_unique<FusionExecutor>();
-      CompileOptions options;
-      options.device = device_;
-      // no need to copy fusion_, as we are not generating more than 1 kernel
-      // for PW.
-      scheduleFusion(fusion_.get(), inputs);
-      pw_fusion_executor_cache_->compileFusion(fusion_.get(), options);
-    }
-    return pw_fusion_executor_cache_->runFusion(inputs);
   }
+  // TODO: plumb code to FusionExecutor;
+  return code_to_fe_lookup_[code]->runFusion(inputs);
 }
 
 GraphCache::InputsRequirement::InputsRequirement(
@@ -384,7 +421,7 @@ bool GraphCache::InputsRequirement::complyWith(
   return true;
 }
 
-FusionExecutorCache* GraphCache::createFusionExecutorCache(
+FusionExecutorCache* GraphCache::appendFusionExecutorCache(
     const InputsRequirement& input_stack) {
   input_stacks_.emplace_back(input_stack);
   std::shared_ptr<Graph> parsing_graph = graph_->copy();
@@ -514,50 +551,64 @@ GraphCache::GraphCache(std::shared_ptr<Graph> graph)
   // compile a kernel if we have enough information from graph (profiling
   // record)
   if (IsNewExecutorEnabled()) {
-    createFusionExecutorCache(
+    appendFusionExecutorCache(
         InputsRequirement(graph_, toVector(reduction_axes_)));
   }
 }
 
 std::vector<at::Tensor> GraphCache::runGraphWithInputs(
     const at::ArrayRef<IValue>& inputs) {
-  InputsRequirement input_stack(inputs, toVector(reduction_axes_));
+
+  size_t code = input_code_lookup_.getCode(inputs);
+
   FusionExecutorCache* fusion_executor_cache = nullptr;
 
-  // TODO: hash indexing;
-  for (size_t i = 0; i < fe_cache_.size(); i++) {
-    if (input_stack.complyWith(input_stacks_[i])) {
-      fusion_executor_cache = fe_cache_[i].get();
-      break;
+  if (code_to_index_lookup_.count(code) == 0) {
+    nvtxRangePush("input_stack");
+    InputsRequirement input_stack(inputs, toVector(reduction_axes_));
+    nvtxRangePop();
+
+    // TODO: hash indexing;
+    for (size_t i = 0; i < fe_cache_.size(); i++) {
+      if (input_stack.complyWith(input_stacks_[i])) {
+        // found compliable fe_cache_ entry
+        fusion_executor_cache = fe_cache_[i].get();
+        code_to_index_lookup_[code] = i;
+        break;
+      }
     }
+    if (!fusion_executor_cache) {
+      fusion_executor_cache = appendFusionExecutorCache(input_stack);
+      code_to_index_lookup_[code] = fe_cache_.size() - 1;
+    }
+  } else {
+    fusion_executor_cache = fe_cache_[code_to_index_lookup_[code]].get();
   }
-  if (!fusion_executor_cache) {
-    fusion_executor_cache = createFusionExecutorCache(input_stack);
-  }
+  InputsRequirement* input_requirement = &input_stacks_[code_to_index_lookup_[code]];
 
   // GraphCache need to permute inputs/outputs to accommodate dimension
   // coalescing
-  if (input_stack.requiresPermutation()) {
+  if (input_requirement->requiresPermutation()) {
     std::vector<IValue> permuted_inputs;
     permuted_inputs.reserve(inputs.size());
     for (const auto& input : inputs) {
       if (input.isTensor()) {
         permuted_inputs.emplace_back(
-            input.toTensor().permute(input_stack.input_permutation_));
+            input.toTensor().permute(input_requirement->input_permutation_));
       } else {
         permuted_inputs.emplace_back(input);
       }
     }
-    auto outputs = fusion_executor_cache->runFusionWithInputs(permuted_inputs);
+    auto outputs = fusion_executor_cache->runFusionWithInputs(permuted_inputs, code);
     std::vector<at::Tensor> permuted_outputs;
     permuted_outputs.reserve(outputs.size());
     for (const auto& output : outputs) {
       permuted_outputs.emplace_back(
-          output.permute(input_stack.output_permutation_));
+          output.permute(input_requirement->output_permutation_));
     }
     return permuted_outputs;
   } else {
-    return fusion_executor_cache->runFusionWithInputs(inputs);
+    return fusion_executor_cache->runFusionWithInputs(inputs, code);
   }
 }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -573,6 +573,12 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
       }
     }
     if (!fusion_executor_cache) {
+      // This is the ugly bit, each level of cache has their own entry. At this
+      // point, we are creating an instance of FusionExecutorCache as well as a
+      // cache entry for GraphCache;
+      // But we are not creating any cache entry for nested structures. We only
+      // create cache entry below when we later call
+      // `fusion_executor_cache->runFusionWithInputs`
       fusion_executor_cache = appendFusionExecutorCache(input_stack);
       // record short cut to designated fusion executor
       code_to_index_lookup_[unique_id] = fe_cache_.size() - 1;

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -27,7 +27,6 @@ class InputsCodeLookup {
   std::unordered_map<std::string, size_t> inputs_code_lookup_;
 };
 
-
 // [ Note -- 2 level cache implementation ]
 //
 // 2 level hierarchically nested cache is to handle the code generation and

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -16,17 +16,17 @@ namespace fuser {
 namespace cuda {
 
 // Note, the uniqueness of the ide generated for a given input set is only local
-// to the instance of `InputsCodeLookup`.
-class InputsCodeLookup {
+// to the instance of `InputsIdLookup`.
+class InputsIdLookup {
  public:
   // encode each unique input sets to an unique id;
   size_t getCode(const at::ArrayRef<IValue>& inputs);
 
- protected:
+ private:
   size_t current_id_ = 1;
 
   // TODO: change this to a trie for efficiency;
-  std::unordered_map<std::string, size_t> inputs_code_lookup_;
+  std::unordered_map<std::string, size_t> encoding_lookup_;
 };
 
 // [ Note -- 2 level cache implementation ]
@@ -81,7 +81,7 @@ class FusionExecutorCache {
   // Execute fusion graph with given inputs, create `FusionExecutor` as needed;
   std::vector<at::Tensor> runFusionWithInputs(
       const at::ArrayRef<IValue>& inputs,
-      const size_t code);
+      size_t unique_id);
 
  private:
   // device_ where compiled binaries are loaded on & inputs are expected to
@@ -165,7 +165,6 @@ class GraphCache {
         const at::ArrayRef<IValue>& inputs,
         const std::vector<size_t>& reduction_axes);
 
-    // bool operator==(const InputsRequirement& other);
     bool complyWith(const InputsRequirement& expect);
 
     // helper function used at run-time to check whether a common permutation is
@@ -193,8 +192,8 @@ class GraphCache {
   std::vector<InputsRequirement> input_stacks_;
   std::vector<std::unique_ptr<FusionExecutorCache>> fe_cache_;
 
-  // inputs to code lookup table;
-  InputsCodeLookup input_code_lookup_;
+  // inputs to unique_id lookup table;
+  InputsIdLookup inputs_id_lookup_;
 };
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -15,9 +15,11 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
+// Note, the uniqueness of the ide generated for a given input set is only local
+// to the instance of `InputsCodeLookup`.
 class InputsCodeLookup {
  public:
-  // encode each unique input sets to an encoded id;
+  // encode each unique input sets to an unique id;
   size_t getCode(const at::ArrayRef<IValue>& inputs);
 
  protected:
@@ -117,7 +119,7 @@ class FusionExecutorCache {
   std::unordered_map<ReductionParams, FusionExecutor, ReductionParamsHash>
       red_fusion_executor_cache_;
 
-  // short cut for cache
+  // short cut to FusionExecutor for input set encoded with id;
   std::unordered_map<size_t, FusionExecutor*> code_to_fe_lookup_;
 };
 
@@ -183,7 +185,7 @@ class GraphCache {
   // TODO: poor name, we should use `eliminated_axes_` instead;
   at::DimVector reduction_axes_;
 
-  // short cut for cache
+  // short cut to index of stack for input set encoded with id;
   std::unordered_map<size_t, size_t> code_to_index_lookup_;
 
   // TODO: we should really hash instead of iterative check. Optimize later...


### PR DESCRIPTION
While our kernels handle dynamic input sizes, we are now caching kernel selection and launch parameters on static sizes. This improves kernel launch latency for repeated input sizes.

This is now done at GraphCache level, where we record and encode every seen inputs