### PR TITLE
Detect computeAt causing mismatched TensorDomain

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -6055,6 +6055,24 @@ void testGPU_FusionLSTMCell() {
   TORCH_CHECK(at_hy.allclose(outputs[1], 1e-4, 1e-7));
 }
 
+void testGPU_FusionComputeAtMultiBCast() {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeDummyTensor(1);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = mul(tv0, new Float(0.5));
+  TensorView* tv2 = broadcast(tv1, {true, false});
+  TensorView* tv3 = broadcast(tv1, {false, true});
+  TensorView* tv4 = add(tv2, tv3);
+  fusion.addOutput(tv4);
+
+  // This is not supported and should throw an exception.
+  ASSERT_ANY_THROW(tv1->computeAt(tv3, -1));
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -216,7 +216,8 @@ namespace jit {
   _(GPU_FusionTraversalOrder7)                      \
   _(GPU_FusionBranches)                             \
   _(GPU_FusionThreadPredicate)                      \
-  _(GPU_FusionLSTMCell)
+  _(GPU_FusionLSTMCell)                             \
+  _(GPU_FusionComputeAtMultiBCast)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -82,6 +82,20 @@ void ComputeAtData::validateNewComputeAt() const {
       ".");
 }
 
+void ComputeAtData::setComputeAtDomain(TensorDomain* td) {
+  if (new_compute_at_domain_ != original_domain_) {
+    TORCH_INTERNAL_ASSERT(
+        *new_compute_at_domain_ == *td,
+        "TensorDomain, ",
+        td,
+        ", does not match with the previously set domain of ",
+        tv_ref_,
+        ", which is ",
+        new_compute_at_domain_);
+  }
+  new_compute_at_domain_ = td;
+}
+
 namespace {
 // Wrapper around set_intersection
 template <typename T>

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -56,9 +56,7 @@ class ComputeAtData {
   // If we set computeAt, save the domain so we can reset it after traversal.
   // Traversal state can deviate from the domain we will want to save after the
   // entire computeAt pass.
-  void setComputeAtDomain(TensorDomain* td) {
-    new_compute_at_domain_ = td;
-  }
+  void setComputeAtDomain(TensorDomain* td);
 
   // Return domain set in setComputeAtDomain
   TensorDomain* getComputeAtDomain() const {

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -384,6 +384,11 @@ class TORCH_CUDA_API TensorDomain : public Val {
 
   TensorDomain(const TensorDomain* src, IrCloner* ir_cloner);
 
+  bool operator==(const TensorDomain& other) const;
+  bool operator!=(const TensorDomain& other) const {
+    return !(*this == other);
+  }
+
   std::vector<IterDomain*>::size_type nDims() const {
     return domain_.size();
   }

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -571,6 +571,15 @@ TensorDomain::TensorDomain(const TensorDomain* src, IrCloner* ir_cloner)
       rfactor_domain_(ir_cloner->clone(src->rfactor_domain_)),
       contiguity_(src->contiguity()) {}
 
+bool TensorDomain::operator==(const TensorDomain& other) const {
+  // Checks equality of each class field. Should not be necessary to
+  // check no_bcast_domain_ and no_reduction_domain_ as they are just
+  // derived from domain_.
+  return root_domain_ == other.root_domain_ && domain_ == other.domain_ &&
+      rfactor_domain_ == other.rfactor_domain_ &&
+      contiguity_ == other.contiguity_;
+}
+
 bool TensorDomain::sameAs(const TensorDomain* const other) const {
   if (nDims() != other->nDims())
     return false;


### PR DESCRIPTION
In the computeAt transformatin, a new TensorDomain may be set for a TensorView. This PR errors out when multiple different TensorDomains are set for a TensorView, which means that the TensorView must be transformed to multiple different tensors. I believe this should be considered an error.

An example of this error happens with `tv4` of `testGPU_FusionComputeAtMultiBCast`. `tv4` is transformed twice in the `forwardComputeAt` phase. First, it is transformed by `replayCasP` with `tv2` as a producer and `tv4` as a consumer, swapping the two dimensions of `tv4`. Then, `replayCasP` is called but with `tv3` as a producer and `tv4` as a consumer, again swapping the two dimensions of `tv4`, effectively reverting the transformation enforced by `tv2`. In other words, `tv2` requires the dimensions of `tv4` to be in the swapped order, whereas `tv3` needs the dimensions in the original order.

This PR is for the first failing fusion of #322. Note that the issue remains; at this time, I am not sure what the real solution for #322 should look like. For the mean time, this PR gives an early error, i.e., at the time of the computeAt transformation rather than the lowering time. 