### PR TITLE
Cleanup of hasBlockBroadcast

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -76,7 +76,6 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
   FusionGuard fg(&fusion_);
   options_ = options;
 
-
   TORCH_INTERNAL_ASSERT(
       options.device.is_cuda(), "Provided device to CUDA fuser is the CPU.");
   max_device_smem =

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -6,6 +6,7 @@
 
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 
+#include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
 #include <c10/core/DeviceGuard.h>
@@ -36,7 +37,7 @@ std::string FusionExecutor::getStructuredCode(const std::string& kernel) {
   return code;
 }
 
-void FusionExecutor::compileFusionFromStr(
+void FusionExecutor::debugCompileFusionFromStr(
     Fusion* fusion,
     const std::string& code,
     const std::string& name,
@@ -75,8 +76,17 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
   FusionGuard fg(&fusion_);
   options_ = options;
 
+
+  TORCH_INTERNAL_ASSERT(
+      options.device.is_cuda(), "Provided device to CUDA fuser is the CPU.");
+  max_device_smem =
+      at::cuda::getDeviceProperties(options.device.index())->sharedMemPerBlock;
+
   fusion_id_ = ++fusion_id_counter_;
   has_random_ = fusion->hasRNG();
+  has_block_reductions = fusion_.hasBlockReduction();
+  has_grid_reductions = fusion_.hasGridReduction();
+  has_block_broadcasts = fusion_.hasBlockBroadcast();
   lowered_ = GpuLower(&fusion_);
   const auto kernel = lowered_.getKernel(kernelName());
   const auto structured_code = getStructuredCode(kernel);
@@ -86,8 +96,7 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
     unsigned static_smem_size =
         computeSharedMemory(evaluation_context, lowered_.static_allocations());
     TORCH_INTERNAL_ASSERT(
-        static_smem_size <
-            at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock,
+        static_smem_size < max_device_smem,
         "The static shared memory allocation is larger than available memory.");
   }
 
@@ -246,8 +255,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
   // Calculate Dynamic Shared Memory Size
   // Add workspace for reduction and broadcast
   uint64_t reduction_broadcast_workspace = 0;
-  if (fusion_.hasBlockReduction() || fusion_.hasGridReduction() ||
-      lowered_.hasBlockBroadcast()) {
+  if (has_block_reductions || has_grid_reductions || has_block_broadcasts) {
     // Not using nThreads here since it does not handle uninitialized value
     reduction_broadcast_workspace =
         dataTypeSize(fusion_.getMaximumSmemDataType()) * launch_params.bdimx() *
@@ -261,8 +269,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
       computeSharedMemory(ec, lowered_.static_allocations());
 
   TORCH_INTERNAL_ASSERT(
-      (dynamic_smem_size + static_smem_size) <
-          at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock,
+      (dynamic_smem_size + static_smem_size) < max_device_smem,
       "The total shared memory allocation is larger than available memory.");
   launch_params.setSmem(dynamic_smem_size);
 

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -23,7 +23,9 @@ struct TORCH_CUDA_API CompileOptions {
 
 class TORCH_CUDA_API FusionExecutor : public NonCopyable {
  public:
-  void compileFusionFromStr(
+  // Unsafe compilation that's useful for debugging kernels, iterating over
+  // slight modifications of a generated kernel
+  void debugCompileFusionFromStr(
       Fusion* fusion,
       const std::string& code,
       const std::string& name,
@@ -82,8 +84,12 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
 
   Fusion fusion_;
 
-  CompileOptions options_;
+  bool has_block_reductions = false;
+  bool has_grid_reductions = false;
+  bool has_block_broadcasts = false;
 
+  CompileOptions options_;
+  size_t max_device_smem = std::numeric_limits<size_t>().max();
   executor_utils::NvrtcFunction compiled_kernel_;
 
   // State of the fusion that's important

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -586,6 +586,19 @@ bool Fusion::hasGridReduction() {
   return false;
 }
 
+bool Fusion::hasBlockBroadcast() {
+  for (auto expr : exprs(true)) {
+    for (auto out : expr->outputs()) {
+      if (out->getValType() == ValType::TensorView) {
+        if (out->as<TensorView>()->hasBlockBroadcast()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 bool Fusion::hasBroadcast() {
   for (auto expr : exprs(true))
     for (auto out : expr->outputs())

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -208,6 +208,7 @@ class TORCH_CUDA_API Fusion final {
   bool hasReduction();
   bool hasBlockReduction();
   bool hasGridReduction();
+  bool hasBlockBroadcast();
   bool hasBroadcast();
   DataType getMaximumSmemDataType();
   size_t gridReductionTempBufferSize();

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -224,6 +224,7 @@ class TORCH_CUDA_API TensorView : public Val {
   bool hasReduction() const;
   bool hasBlockReduction() const;
   bool hasGridReduction() const;
+  bool hasBlockBroadcast() const;
   bool hasBroadcast() const;
   bool hasRFactor() const;
 

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -418,6 +418,7 @@ class TORCH_CUDA_API TensorDomain : public Val {
   bool hasReduction() const;
   bool hasBlockReduction() const;
   bool hasGridReduction() const;
+  bool hasBlockBroadcast() const;
   bool hasBroadcast() const;
   bool hasRFactor() const;
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -632,6 +632,12 @@ bool TensorDomain::hasGridReduction() const {
   });
 }
 
+bool TensorDomain::hasBlockBroadcast() const {
+  return std::any_of(domain_.begin(), domain_.end(), [](IterDomain* id) {
+    return id->isBroadcast() && id->isThreadDim();
+  });
+}
+
 bool TensorDomain::hasBroadcast() const {
   return no_bcast_domain_.size() != domain_.size();
 }

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -219,7 +219,6 @@ void GpuLower::lower() {
   sync_allocations_ = be.getSyncAllocs();
   dynamic_smem_allocations_ = be.getDynamicAllocs();
   static_smem_allocations_ = be.getStaticAllocs();
-  has_block_broadcast_ = be.hasBlockBroadcast();
 }
 
 // Traverse through the fusion and print CUDA code associated with it

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -45,10 +45,6 @@ class TORCH_CUDA_API GpuLower {
     return static_smem_allocations_;
   }
 
-  bool hasBlockBroadcast() {
-    return has_block_broadcast_;
-  }
-
   // Converts a Fusion IR value into the Kernel IR equivalent
   //
   // TODO(kir): revisit this interface
@@ -84,9 +80,6 @@ class TORCH_CUDA_API GpuLower {
 
   // List of static shared memory buffers
   std::vector<kir::Allocate*> static_smem_allocations_;
-
-  // Check if kernel has shared memory broadcast op
-  bool has_block_broadcast_;
 
   // Lowered IR
   std::vector<Expr*> lowered_exprs_;

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -107,6 +107,10 @@ bool TensorView::hasGridReduction() const {
   return domain()->hasGridReduction();
 }
 
+bool TensorView::hasBlockBroadcast() const {
+  return domain()->hasBlockBroadcast();
+}
+
 bool TensorView::hasBroadcast() const {
   return domain()->hasBroadcast();
 }


### PR DESCRIPTION
Implement hasBlockBroadcast like has[Grid,Block]Reduction. Save the results of these functions during compilation.