### PR TITLE
Make a stateful expression evaluator

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -80,7 +80,7 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
       options.device.is_cuda(), "Provided device to CUDA fuser is the CPU.");
   max_device_smem =
       at::cuda::getDeviceProperties(options.device.index())->sharedMemPerBlock;
-  
+
   setUsedTVs();
   fusion_id_ = ++fusion_id_counter_;
   has_random_ = fusion->hasRNG();

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -135,7 +135,8 @@ at::Tensor inferAndAlloc(
     return at::zeros(isizes, tensor_options);
   } else {
     c10::IntArrayRef isizes(sizes);
-    return at::empty(isizes, tensor_options);
+    at::AutoNonVariableTypeMode non_variable_type_mode;
+    return at::native::empty_cuda(isizes, tensor_options);
   }
 }
 

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -337,16 +337,17 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
 
   std::vector<at::Tensor> alloced_outputs = outputs;
   if (outputs.empty() || outputs.size() != fusion_.outputs().size()) {
-    alloced_outputs = allocOutputs(evaluation_context);
+    alloced_outputs = allocOutputs(evaluator);
+  } else {
+    executor_utils::validateKernelOutputs(
+        &fusion_, alloced_outputs, options_.device);
   }
 
-  executor_utils::validateKernelOutputs(
-      &fusion_, alloced_outputs, options_.device);
+  auto buffers = allocGlobalVals(evaluator);
 
   KernelArgumentHolder kernel_arguments;
   kernel_arguments.push(inputs);
   kernel_arguments.push(alloced_outputs);
-  auto buffers = allocGlobalVals(evaluation_context);
   kernel_arguments.push(buffers);
 
   if (has_random_) {

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -79,6 +79,12 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
 
   std::vector<at::Tensor> allocOutputs(EvaluationContext& ec);
 
+  void setUsedTVs();
+
+  const std::vector<TensorView*>& getUsedTVs() const {
+    return used_tvs;
+  };
+
  private:
   bool compiled_ = false;
 
@@ -91,6 +97,9 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
   CompileOptions options_;
   size_t max_device_smem = std::numeric_limits<size_t>().max();
   executor_utils::NvrtcFunction compiled_kernel_;
+
+  // TensorViews actually used in the kernel.
+  std::vector<TensorView*> used_tvs;
 
   // State of the fusion that's important
   bool has_random_ = false;

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -124,7 +124,7 @@ inline bool validateKernelArg(
     const Val* param,
     const c10::Device& device,
     std::stringstream& msg) {
-  if (arg.type()->kind() == c10::TypeKind::TensorType) {
+  if (arg.isTensor()) {
     return validateKernelArgTensor(arg.toTensor(), param, device, msg);
   } else {
     return validateKernelArgScalar(arg.type(), param, msg);

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -32,14 +32,14 @@ std::string kernelPreamble() {
 
 namespace {
 
-bool validateKernelArgTensor(
+inline bool validateKernelArgTensor(
     const at::Tensor& arg,
     const Val* param,
-    c10::Device device,
+    const c10::Device& device,
     std::stringstream& msg) {
   // Arg is a tensor. Param must be a tensor too.
   if (*param->getValType() != ValType::TensorView) {
-    msg << "Argument is a tensor, but the parameter is not.";
+    msg << "Argument is a tensor, but the parameter is not.\n";
     return false;
   }
 
@@ -54,12 +54,13 @@ bool validateKernelArgTensor(
   // check as necessary.
   if (arg_dim > param_dim) {
     msg << "Argument tensor's rank is " << arg_dim << ", but the parameter is "
-        << param_dim;
+        << param_dim << "\n";
     return false;
   }
 
   if (arg.device() != device) {
-    msg << "Argument is on device that is not compiled for";
+    msg << "Argument is on device that is not compiled for."
+        << "\n";
     return false;
   }
   // Check element type
@@ -77,22 +78,23 @@ bool validateKernelArgTensor(
       match = param_data_type == DataType::Bool;
       break;
     default:
-      msg << "Argument element type, " << arg_data_type
-          << ", is not supported.";
+      msg << "Argument element type, " << arg_data_type << ", is not supported."
+          << "\n";
       return false;
   }
   if (!match)
     msg << "Argument element type is " << arg_data_type
-        << ", but the parameter is " << param_data_type;
+        << ", but the parameter is " << param_data_type << "\n";
   return match;
 }
 
-bool validateKernelArgScalar(
+inline bool validateKernelArgScalar(
     const c10::TypePtr& arg_type,
     const Val* param,
     std::stringstream& msg) {
   if (!param->isScalar()) {
-    msg << "Argument is a scalar, but the parameter is not.";
+    msg << "Argument is a scalar, but the parameter is not."
+        << "\n";
     return false;
   }
   DataType param_type = *param->getDataType();
@@ -112,20 +114,20 @@ bool validateKernelArgScalar(
   }
   if (!match) {
     msg << "Argument type is " << *arg_type << ", but the parameter is "
-        << param_type;
+        << param_type << "\n";
   }
   return match;
 }
 
-bool validateKernelArg(
+inline bool validateKernelArg(
     const c10::IValue& arg,
     const Val* param,
-    c10::Device device,
+    const c10::Device& device,
     std::stringstream& msg) {
-  if (arg.type()->kind() != c10::TypeKind::TensorType) {
-    return validateKernelArgScalar(arg.type(), param, msg);
-  } else {
+  if (arg.type()->kind() == c10::TypeKind::TensorType) {
     return validateKernelArgTensor(arg.toTensor(), param, device, msg);
+  } else {
+    return validateKernelArgScalar(arg.type(), param, msg);
   }
 }
 
@@ -134,30 +136,29 @@ bool validateKernelArg(
 void validateKernelInputs(
     Fusion* fusion,
     const at::ArrayRef<IValue>& inputs,
-    c10::Device device) {
+    const c10::Device& device) {
   // This is necessary as we were traversing the fusion graph later in the check
   FusionGuard fg(fusion);
   // Check inputs
   TORCH_INTERNAL_ASSERT(
       inputs.size() == fusion->inputs().size(),
       "Wrong number of kernel inputs.");
+
+  std::stringstream msg;
+  bool mismatch = false;
   for (size_t i = 0; i < inputs.size(); ++i) {
     const IValue& arg = inputs[i];
     const Val* param = fusion->inputs()[i];
-    std::stringstream msg;
-    TORCH_INTERNAL_ASSERT(
-        validateKernelArg(arg, param, device, msg),
-        "Input argument at position ",
-        i,
-        " is invalid; ",
-        msg.str());
+    mismatch = validateKernelArg(arg, param, device, msg) && mismatch;
   }
+  TORCH_INTERNAL_ASSERT(
+      !mismatch, "Found one or more invalid arguments: ", msg.str());
 }
 
 void validateKernelOutputs(
     Fusion* fusion,
     const std::vector<at::Tensor>& outputs,
-    c10::Device device) {
+    const c10::Device& device) {
   TORCH_INTERNAL_ASSERT(
       fusion->outputs().size() != 0,
       "Kernel should have at least one output tensor.");
@@ -165,17 +166,16 @@ void validateKernelOutputs(
   TORCH_INTERNAL_ASSERT(
       outputs.size() == fusion->outputs().size(),
       "Wrong number of kernel outputs.");
+
+  std::stringstream msg;
+  bool mismatch = false;
   for (size_t i = 0; i < outputs.size(); ++i) {
     const at::Tensor& arg = outputs[i];
     const Val* param = fusion->outputs()[i];
-    std::stringstream msg;
-    TORCH_INTERNAL_ASSERT(
-        validateKernelArgTensor(arg, param, device, msg),
-        "Output argument at position ",
-        i,
-        " is invalid; ",
-        msg.str());
+    mismatch = validateKernelArg(arg, param, device, msg) && mismatch;
   }
+  TORCH_INTERNAL_ASSERT(
+      !mismatch, "Found one or more invalid arguments: ", msg.str());
 }
 
 void safeBind(

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -25,12 +25,12 @@ std::string kernelPreamble();
 void validateKernelInputs(
     Fusion* fusion,
     const at::ArrayRef<IValue>& inputs,
-    c10::Device device);
+    const c10::Device& device);
 
 void validateKernelOutputs(
     Fusion* fusion,
     const std::vector<at::Tensor>& outputs,
-    c10::Device device);
+    const c10::Device& device);
 
 // Check if a value is already bound, if so validate we're trying to bind to the
 // same value


### PR DESCRIPTION
This reduces latency of expression evaluation on a simple pointwise example by about 10us. On more complex examples where expression evaluator could be re-evaluating expressions multiple times it is expected to have greater returns, though that hasn't been measured.