### PR TITLE
Cache eviction pr

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -6719,7 +6719,7 @@ void testGPU_FusionInputsIdLookup() {
 
   // testing basic function, same encoding for identical inputs
   auto id_0 = inputs_id_lookup.lookupId({t0, t1, 5.0});
-  auto id_0_lookup = inputs_id_lookup.lookupId({t0, t1, 5.0});
+  auto id_0_lookup = inputs_id_lookup.lookupId({t0, t1, 2.5});
   TORCH_CHECK(id_0.id == id_0_lookup.id);
   TORCH_CHECK(inputs_id_lookup.size() == 1);
   TORCH_CHECK(id_0.eviction == false);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -11,12 +11,12 @@
 #include <torch/csrc/jit/codegen/cuda/ir_graphviz.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 #include <torch/csrc/jit/codegen/cuda/ir_utils.h>
+#include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
 #include <torch/csrc/jit/codegen/cuda/lower2device.h>
 #include <torch/csrc/jit/codegen/cuda/mutator.h>
 #include <torch/csrc/jit/codegen/cuda/scheduler.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 #include <torch/csrc/jit/codegen/cuda/transform_rfactor.h>
-#include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
 
 // fuser and IR parser
 #include <torch/csrc/jit/codegen/cuda/parser.h>

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -16,6 +16,7 @@
 #include <torch/csrc/jit/codegen/cuda/scheduler.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 #include <torch/csrc/jit/codegen/cuda/transform_rfactor.h>
+#include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
 
 // fuser and IR parser
 #include <torch/csrc/jit/codegen/cuda/parser.h>
@@ -6705,6 +6706,44 @@ void testGPU_FusionComputeAtMultiBCast() {
 
   // This is not supported and should throw an exception.
   ASSERT_ANY_THROW(tv1->computeAt(tv3, -1));
+}
+
+void testGPU_FusionInputsIdLookup() {
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({16, 8, 8}, options);
+  at::Tensor t1 = at::randn({8, 8}, options);
+  at::Tensor t2 = at::randn({6, 4}, options);
+
+  // create a cache with max size 2;
+  auto inputs_id_lookup = torch::jit::fuser::cuda::InputsIdLookup(2);
+
+  // testing basic function, same encoding for identical inputs
+  auto id_0 = inputs_id_lookup.lookupId({t0, t1, 5.0});
+  auto id_0_lookup = inputs_id_lookup.lookupId({t0, t1, 5.0});
+  TORCH_CHECK(id_0.id == id_0_lookup.id);
+  TORCH_CHECK(inputs_id_lookup.size() == 1);
+  TORCH_CHECK(id_0.eviction == false);
+
+  // new input (even tho same shape, but we have different signature because of
+  // missing scalar input
+  auto id_1 = inputs_id_lookup.lookupId({t0, t1});
+  auto id_1_lookup = inputs_id_lookup.lookupId({t0, t1});
+  TORCH_CHECK(id_1.id == id_1_lookup.id);
+  TORCH_CHECK(inputs_id_lookup.size() == 2);
+  TORCH_CHECK(id_1.eviction == false);
+
+  // eviction should happen at this point
+  auto id_2 = inputs_id_lookup.lookupId({t2, t1});
+  TORCH_CHECK(id_2.id != id_0.id);
+  TORCH_CHECK(id_2.id != id_1.id);
+  TORCH_CHECK(inputs_id_lookup.size() == 2);
+  TORCH_CHECK(id_2.eviction == true);
+  TORCH_CHECK(id_2.evict_id == id_0.id);
+
+  // look at input 1 again
+  auto id_1_relook = inputs_id_lookup.lookupId({t0, t1});
+  TORCH_CHECK(id_1_relook.id == id_1.id);
+  TORCH_CHECK(id_1_relook.eviction == false);
 }
 
 } // namespace jit

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -227,7 +227,8 @@ namespace jit {
   _(GPU_FusionBranches)                             \
   _(GPU_FusionThreadPredicate)                      \
   _(GPU_FusionLSTMCell)                             \
-  _(GPU_FusionComputeAtMultiBCast)
+  _(GPU_FusionComputeAtMultiBCast)                  \
+  _(GPU_FusionInputsIdLookup)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -52,7 +52,7 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
     return fusion_id_ != -1;
   };
 
-  inline void evictCache(size_t cache_id) {
+  void evictCache(size_t cache_id) {
     executor_entry_lookup_.erase(cache_id);
   }
 

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -52,6 +52,10 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
     return fusion_id_ != -1;
   };
 
+  inline void evictCache(size_t cache_id) {
+    executor_entry_lookup_.erase(cache_id);
+  }
+
   // TODO: strides would also be important when we handle permutations in
   //       codegen.
   // struct used to hold necessary information to launch compiled kernel on a

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -583,7 +583,9 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
   const size_t unique_id = id_lookup_ret.id;
 
   if (id_lookup_ret.eviction) {
-    code_to_index_lookup_.erase(id_lookup_ret.evict_id);
+    auto index_lookup_iter = code_to_index_lookup_.find(id_lookup_ret.evict_id);
+    fe_cache_[index_lookup_iter->second]->evictCache(index_lookup_iter->first);
+    code_to_index_lookup_.erase(index_lookup_iter);
   }
 
   FusionExecutorCache* fusion_executor_cache = nullptr;

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -182,7 +182,8 @@ at::DimVector inversePermutation(
 
 } // namespace
 
-InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(const at::ArrayRef<IValue>& inputs) {
+InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
+    const at::ArrayRef<IValue>& inputs) {
   IdLookupReturn ret;
   std::stringstream encoded_inputs;
   for (const auto& input : inputs) {
@@ -230,7 +231,8 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(const at::ArrayRef<IValu
   }
 
   ret.id = id_iter_pair.first;
-  id_iter_pair.second = used_entry_.insert(used_entry_.begin(), encoded_inputs.str());
+  id_iter_pair.second =
+      used_entry_.insert(used_entry_.begin(), encoded_inputs.str());
   return ret;
 }
 
@@ -585,7 +587,8 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
   // if we went over the cache size for short-cut, we evict entries using LRU;
   if (id_lookup_ret.eviction) {
     auto index_lookup_iter = code_to_index_lookup_.find(id_lookup_ret.evict_id);
-    TORCH_INTERNAL_ASSERT(index_lookup_iter != code_to_index_lookup_.end(),
+    TORCH_INTERNAL_ASSERT(
+        index_lookup_iter != code_to_index_lookup_.end(),
         "evicting cache entry not found in lookup table");
     // evict nested cache in FusionExecutorCache
     fe_cache_[index_lookup_iter->second]->evictCache(index_lookup_iter->first);

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -582,8 +582,12 @@ std::vector<at::Tensor> GraphCache::runGraphWithInputs(
   auto id_lookup_ret = inputs_id_lookup_.lookupId(inputs);
   const size_t unique_id = id_lookup_ret.id;
 
+  // if we went over the cache size for short-cut, we evict entries using LRU;
   if (id_lookup_ret.eviction) {
     auto index_lookup_iter = code_to_index_lookup_.find(id_lookup_ret.evict_id);
+    TORCH_INTERNAL_ASSERT(index_lookup_iter != code_to_index_lookup_.end(),
+        "evicting cache entry not found in lookup table");
+    // evict nested cache in FusionExecutorCache
     fe_cache_[index_lookup_iter->second]->evictCache(index_lookup_iter->first);
     code_to_index_lookup_.erase(index_lookup_iter);
   }

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -210,28 +210,28 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   auto& id_iter_pair = encoding_lookup_[encoded_inputs.str()];
 
   // short-cut to leave LRU entry as is;
-  if (id_iter_pair.second == used_entry_.begin()) {
-    ret.id = id_iter_pair.first;
+  if (id_iter_pair.lru_iter == used_entry_.begin()) {
+    ret.id = id_iter_pair.id;
     return ret;
   }
 
-  if (id_iter_pair.first == 0) {
+  if (id_iter_pair.id == 0) {
     // no entry existed for given input set, set id for given entry
-    id_iter_pair.first = current_id_++;
+    id_iter_pair.id = current_id_++;
     if (used_entry_.size() == max_cache_size_) {
       // pop least recently used cache;
       const auto& remove_iter = encoding_lookup_.find(used_entry_.back());
       used_entry_.pop_back();
-      ret.evict_id = remove_iter->second.first;
+      ret.evict_id = remove_iter->second.id;
       ret.eviction = true;
       encoding_lookup_.erase(remove_iter);
     }
   } else {
-    used_entry_.erase(id_iter_pair.second);
+    used_entry_.erase(id_iter_pair.lru_iter);
   }
 
-  ret.id = id_iter_pair.first;
-  id_iter_pair.second =
+  ret.id = id_iter_pair.id;
+  id_iter_pair.lru_iter =
       used_entry_.insert(used_entry_.begin(), encoded_inputs.str());
   return ret;
 }

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -63,7 +63,7 @@ TORCH_CUDA_API class InputsIdLookup {
   // conflicts
   size_t current_id_ = 1;
 
-  // entry in the cache, This is used to implement LRU cache, where entries in 
+  // entry in the cache, This is used to implement LRU cache, where entries in
   // the list is ordered by their recent usage (freshly used entry is placed at
   // the beginning)
   std::list<std::string> used_entry_;

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -15,20 +15,33 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
+// encoding an input set to unique id, which is used to short-cut cache entry
+// selection in our nested cache implementation to cut off overhead.
+//
+// We have implemented naive LRU cache eviction policy here, since each entry in
+// `InputsIdLookup` is attached to a static input shape/stride, and could grow
+// gigantic when we have input shapes that does not stabalize to a finite set.
+//
 // Note, the uniqueness of the ide generated for a given input set is only local
 // to the instance of `InputsIdLookup`.
-class InputsIdLookup {
+TORCH_CUDA_API class InputsIdLookup {
  public:
-  InputsIdLookup(size_t max_cache_size = 10)
+  // constructor where maximum cache size is fixed during init
+  explicit InputsIdLookup(size_t max_cache_size = 10)
       : max_cache_size_(max_cache_size){};
 
+  // struct to hold return value for lookupId.
   struct IdLookupReturn {
     size_t id = 0;
     size_t evict_id = 0;
     bool eviction = false;
   };
 
-  // encode each unique input sets to an unique id;
+  // encode each input sets to with an unique id;
+  // Returned data structure also indicates whether eviction has happened within
+  // the lookup cache. This is needed because lookup shortcut is also cached in
+  // nested `GraphCache`, `FusionExecutorCache` and `FusionExecutor`.
+  // see [ Note -- 2 level cache implementation ]
   TORCH_CUDA_API IdLookupReturn lookupId(const at::ArrayRef<IValue>& inputs);
 
   // debugging API
@@ -37,16 +50,27 @@ class InputsIdLookup {
   }
 
  private:
-  size_t max_cache_size_;
+  // entry stored in `encoding_lookup_` to implement LRU
+  struct EncodingEntry {
+    size_t id;
+    std::list<std::string>::iterator lru_iter;
+  };
+
+  // maximum cache size for LRU
+  const size_t max_cache_size_;
+
+  // next available unique id, we monotonically increase `current_id_` avoid
+  // conflicts
   size_t current_id_ = 1;
 
+  // entry in the cache, This is used to implement LRU cache, where entries in 
+  // the list is ordered by their recent usage (freshly used entry is placed at
+  // the beginning)
   std::list<std::string> used_entry_;
 
-  // TODO: change this to a trie for efficiency;
-  std::unordered_map<
-      std::string,
-      std::pair<size_t, std::list<std::string>::iterator>>
-      encoding_lookup_;
+  // map from `std::string` to a unique id `size_t` (packaged in `EncodingEntry`
+  // ). We store an iterator to `used_entry_` to implement LRU
+  std::unordered_map<std::string, EncodingEntry> encoding_lookup_;
 };
 
 // [ Note -- 2 level cache implementation ]

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -19,7 +19,8 @@ namespace cuda {
 // to the instance of `InputsIdLookup`.
 class InputsIdLookup {
  public:
-  InputsIdLookup(size_t max_cache_size = 10) : max_cache_size_(max_cache_size) {};
+  InputsIdLookup(size_t max_cache_size = 10)
+      : max_cache_size_(max_cache_size){};
 
   struct IdLookupReturn {
     size_t id = 0;
@@ -42,7 +43,10 @@ class InputsIdLookup {
   std::list<std::string> used_entry_;
 
   // TODO: change this to a trie for efficiency;
-  std::unordered_map<std::string, std::pair<size_t, std::list<std::string>::iterator>> encoding_lookup_;
+  std::unordered_map<
+      std::string,
+      std::pair<size_t, std::list<std::string>::iterator>>
+      encoding_lookup_;
 };
 
 // [ Note -- 2 level cache implementation ]
@@ -102,7 +106,9 @@ class FusionExecutorCache {
   // evict cached short cut entry in `code_to_fe_lookup_`;
   inline void evictCache(size_t cache_id) {
     auto iter = code_to_fe_lookup_.find(cache_id);
-    TORCH_INTERNAL_ASSERT(iter != code_to_fe_lookup_.end(), "evict cache failed to find an entry");
+    TORCH_INTERNAL_ASSERT(
+        iter != code_to_fe_lookup_.end(),
+        "evict cache failed to find an entry");
     // evict nested lookup entry in nested FusionExecutor
     (iter->second)->evictCache(cache_id);
     code_to_fe_lookup_.erase(iter);

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -19,7 +19,7 @@ namespace cuda {
 // to the instance of `InputsIdLookup`.
 class InputsIdLookup {
  public:
-  InputsIdLookup() : max_cache_size_(10) {};
+  InputsIdLookup(size_t max_cache_size = 10) : max_cache_size_(max_cache_size) {};
 
   struct IdLookupReturn {
     size_t id = 0;
@@ -28,7 +28,12 @@ class InputsIdLookup {
   };
 
   // encode each unique input sets to an unique id;
-  IdLookupReturn lookupId(const at::ArrayRef<IValue>& inputs);
+  TORCH_CUDA_API IdLookupReturn lookupId(const at::ArrayRef<IValue>& inputs);
+
+  // debugging API
+  size_t size() const {
+    return encoding_lookup_.size();
+  }
 
  private:
   size_t max_cache_size_;
@@ -98,6 +103,7 @@ class FusionExecutorCache {
   inline void evictCache(size_t cache_id) {
     auto iter = code_to_fe_lookup_.find(cache_id);
     TORCH_INTERNAL_ASSERT(iter != code_to_fe_lookup_.end(), "evict cache failed to find an entry");
+    // evict nested lookup entry in nested FusionExecutor
     (iter->second)->evictCache(cache_id);
     code_to_fe_lookup_.erase(iter);
   };


### PR DESCRIPTION
Simple implementation on LRU cache eviction. Something to note:

We only evict the entries of short cut lookup table, but not the compiled kernel. Because compiled kernels for a computation graph is a very limited number. In the contrary, lookup table is bound to a given input set and could grow indefinitely with input size / stride, hence the need for lookup eviction.