### PR TITLE
Stateful evaluation

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -74,11 +74,11 @@ TensorView* makeTensorWithContig(
 }
 
 void checkIntValue(
-    const EvaluationContext* eval_context,
+    StatefulExpressionEvaluator& evaluator,
     Val* val,
     Int::ScalarType expected_value) {
   TORCH_CHECK(val->isAnInt());
-  const auto actual_value = ExpressionEvaluator::evaluate(val, eval_context);
+  const auto actual_value = evaluator.inferValue(val);
   TORCH_CHECK(actual_value.has_value());
   TORCH_CHECK(actual_value.value() == expected_value);
 }
@@ -163,16 +163,16 @@ void testGPU_FusionExprEvalConstants() {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  EvaluationContext eval_context(&fusion);
+  StatefulExpressionEvaluator evaluator(&fusion);
 
   auto* a = new Int(7);
   auto* b = new Int(3);
 
-  checkIntValue(&eval_context, neg(a), -7);
-  checkIntValue(&eval_context, add(a, b), 10);
-  checkIntValue(&eval_context, neg(mul(sub(a, b), div(a, b))), -8);
-  checkIntValue(&eval_context, mod(a, b), 1);
-  checkIntValue(&eval_context, ceilDiv(a, b), 3);
+  checkIntValue(evaluator, neg(a), -7);
+  checkIntValue(evaluator, add(a, b), 10);
+  checkIntValue(evaluator, neg(mul(sub(a, b), div(a, b))), -8);
+  checkIntValue(evaluator, mod(a, b), 1);
+  checkIntValue(evaluator, ceilDiv(a, b), 3);
 }
 
 // Evaluate basic scalar operations with bound values
@@ -180,7 +180,7 @@ void testGPU_FusionExprEvalBindings() {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  EvaluationContext eval_context(&fusion);
+  StatefulExpressionEvaluator evaluator(&fusion);
 
   auto* a = new Int();
   auto* b = new Int();
@@ -189,35 +189,35 @@ void testGPU_FusionExprEvalBindings() {
   auto* e = new Int(0);
 
   // trying to evaluate before binding should give empty results
-  TORCH_CHECK(!ExpressionEvaluator::evaluate(a, &eval_context).has_value());
-  TORCH_CHECK(!ExpressionEvaluator::evaluate(d, &eval_context).has_value());
+  TORCH_CHECK(!evaluator.inferValue(a).has_value());
+  TORCH_CHECK(!evaluator.inferValue(d).has_value());
 
-  eval_context.bind(a, 7);
-  eval_context.bind(b, 3);
+  evaluator.safeBind(a, 7);
+  evaluator.safeBind(b, 3);
 
   // can't bind to the results of expressions
-  ASSERT_ANY_THROW(eval_context.bind(c, 100));
+  ASSERT_ANY_THROW(evaluator.safeBind(c, 100));
 
   // can't bind to concrete values
-  ASSERT_ANY_THROW(eval_context.bind(e, 100));
+  ASSERT_ANY_THROW(evaluator.safeBind(e, 100));
 
-  checkIntValue(&eval_context, c, 10);
-  checkIntValue(&eval_context, sub(a, b), 4);
-  checkIntValue(&eval_context, mod(a, b), 1);
-  checkIntValue(&eval_context, ceilDiv(a, b), 3);
-  checkIntValue(&eval_context, d, -4);
+  checkIntValue(evaluator, c, 10);
+  checkIntValue(evaluator, sub(a, b), 4);
+  checkIntValue(evaluator, mod(a, b), 1);
+  checkIntValue(evaluator, ceilDiv(a, b), 3);
+  checkIntValue(evaluator, d, -4);
 
   // Reset evaluation context
-  eval_context = EvaluationContext(&fusion);
+  evaluator = StatefulExpressionEvaluator(&fusion);
 
-  eval_context.bind(a, 2);
-  eval_context.bind(b, 5);
+  evaluator.safeBind(a, 2);
+  evaluator.safeBind(b, 5);
 
-  checkIntValue(&eval_context, c, 7);
-  checkIntValue(&eval_context, sub(a, b), -3);
-  checkIntValue(&eval_context, mod(a, b), 2);
-  checkIntValue(&eval_context, ceilDiv(a, b), 1);
-  checkIntValue(&eval_context, d, -2);
+  checkIntValue(evaluator, c, 7);
+  checkIntValue(evaluator, sub(a, b), -3);
+  checkIntValue(evaluator, mod(a, b), 2);
+  checkIntValue(evaluator, ceilDiv(a, b), 1);
+  checkIntValue(evaluator, d, -2);
 }
 
 // Evaluate expressions in a simple IR
@@ -248,8 +248,8 @@ void testGPU_FusionExprEvalBasic() {
   tv2->axis(-1)->parallelize(ParallelType::TIDx);
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
 
-  // 1. Create an evaluation context
-  EvaluationContext eval_context(&fusion);
+  // 1. Create an evaluator
+  StatefulExpressionEvaluator evaluator(&fusion);
 
   // 2. Bind values
   //
@@ -259,21 +259,21 @@ void testGPU_FusionExprEvalBasic() {
   //  (ex. `tv0->getRootDomain()[0]->extent()`
   //   instead of `tv0->axis(0)->extent()`)
   //
-  eval_context.bind(tv0->getRootDomain()[0]->extent(), 6);
-  eval_context.bind(tv0->getRootDomain()[1]->extent(), 128);
-  eval_context.bind(tv1->getRootDomain()[0]->extent(), 6);
-  eval_context.bind(tv1->getRootDomain()[1]->extent(), 128);
+  evaluator.safeBind(tv0->getRootDomain()[0]->extent(), 6);
+  evaluator.safeBind(tv0->getRootDomain()[1]->extent(), 128);
+  evaluator.safeBind(tv1->getRootDomain()[0]->extent(), 6);
+  evaluator.safeBind(tv1->getRootDomain()[1]->extent(), 128);
 
   // 3. Evaluate and check result values
   TORCH_CHECK(tv2->domain()->nDims() == 3);
-  checkIntValue(&eval_context, tv2->axis(0)->rawExtent(), 2);
-  checkIntValue(&eval_context, tv2->axis(1)->rawExtent(), 4);
-  checkIntValue(&eval_context, tv2->axis(2)->rawExtent(), 128);
+  checkIntValue(evaluator, tv2->axis(0)->rawExtent(), 2);
+  checkIntValue(evaluator, tv2->axis(1)->rawExtent(), 4);
+  checkIntValue(evaluator, tv2->axis(2)->rawExtent(), 128);
 
   TORCH_CHECK(tv3->domain()->nDims() == 3);
-  checkIntValue(&eval_context, tv3->axis(0)->rawExtent(), 2);
-  checkIntValue(&eval_context, tv3->axis(1)->rawExtent(), 4);
-  checkIntValue(&eval_context, tv3->axis(2)->rawExtent(), 128);
+  checkIntValue(evaluator, tv3->axis(0)->rawExtent(), 2);
+  checkIntValue(evaluator, tv3->axis(1)->rawExtent(), 4);
+  checkIntValue(evaluator, tv3->axis(2)->rawExtent(), 128);
 }
 
 // Evaluate expressions in a more complex IR
@@ -299,33 +299,33 @@ void testGPU_FusionExprEvalComplex() {
   tv6->split(0, 5);
   tv5->merge(0);
 
-  // 1. Create an evaluation context
-  EvaluationContext eval_context(&fusion);
+  // 1. Create an evaluator
+  StatefulExpressionEvaluator evaluator(&fusion);
 
   // 2. Bind values
-  eval_context.bind(tv0->getRootDomain()[0]->extent(), 129);
-  eval_context.bind(tv0->getRootDomain()[1]->extent(), 127);
+  evaluator.safeBind(tv0->getRootDomain()[0]->extent(), 129);
+  evaluator.safeBind(tv0->getRootDomain()[1]->extent(), 127);
 
   // Evaluate and check extent values
   TORCH_CHECK(tv0->domain()->nDims() == 2);
-  checkIntValue(&eval_context, tv0->axis(0)->rawExtent(), 129);
-  checkIntValue(&eval_context, tv0->axis(1)->rawExtent(), 127);
+  checkIntValue(evaluator, tv0->axis(0)->rawExtent(), 129);
+  checkIntValue(evaluator, tv0->axis(1)->rawExtent(), 127);
 
   TORCH_CHECK(tv3->domain()->nDims() == 2);
-  checkIntValue(&eval_context, tv3->axis(0)->rawExtent(), 129);
-  checkIntValue(&eval_context, tv3->axis(1)->rawExtent(), 127);
+  checkIntValue(evaluator, tv3->axis(0)->rawExtent(), 129);
+  checkIntValue(evaluator, tv3->axis(1)->rawExtent(), 127);
 
   TORCH_CHECK(tv4->domain()->nDims() == 2);
-  checkIntValue(&eval_context, tv4->axis(0)->rawExtent(), 129);
-  checkIntValue(&eval_context, tv4->axis(1)->rawExtent(), 127);
+  checkIntValue(evaluator, tv4->axis(0)->rawExtent(), 129);
+  checkIntValue(evaluator, tv4->axis(1)->rawExtent(), 127);
 
   TORCH_CHECK(tv5->domain()->nDims() == 1);
-  checkIntValue(&eval_context, tv5->axis(0)->rawExtent(), 16383);
+  checkIntValue(evaluator, tv5->axis(0)->rawExtent(), 16383);
 
   TORCH_CHECK(tv6->domain()->nDims() == 3);
-  checkIntValue(&eval_context, tv6->axis(0)->rawExtent(), 26);
-  checkIntValue(&eval_context, tv6->axis(1)->rawExtent(), 5);
-  checkIntValue(&eval_context, tv6->axis(2)->rawExtent(), 127);
+  checkIntValue(evaluator, tv6->axis(0)->rawExtent(), 26);
+  checkIntValue(evaluator, tv6->axis(1)->rawExtent(), 5);
+  checkIntValue(evaluator, tv6->axis(2)->rawExtent(), 127);
 }
 
 // Evaluate expressions post lowering
@@ -365,27 +365,27 @@ void testGPU_FusionExprEvalPostLower() {
   gpulw.printKernel(kernel);
 
   // 1. Create an evaluation context
-  EvaluationContext eval_context(&fusion);
+  StatefulExpressionEvaluator evaluator(&fusion);
 
   // 2. Bind values
-  eval_context.bind(tv0->getRootDomain()[0]->extent(), 6);
-  eval_context.bind(tv0->getRootDomain()[1]->extent(), 128);
-  eval_context.bind(tv1->getRootDomain()[0]->extent(), 6);
-  eval_context.bind(tv1->getRootDomain()[1]->extent(), 128);
+  evaluator.safeBind(tv0->getRootDomain()[0]->extent(), 6);
+  evaluator.safeBind(tv0->getRootDomain()[1]->extent(), 128);
+  evaluator.safeBind(tv1->getRootDomain()[0]->extent(), 6);
+  evaluator.safeBind(tv1->getRootDomain()[1]->extent(), 128);
 
   // 3. Evaluate and check result values
   TORCH_CHECK(tv2->domain()->nDims() == 3);
-  checkIntValue(&eval_context, tv2->axis(0)->rawExtent(), 2);
-  checkIntValue(&eval_context, tv2->axis(1)->rawExtent(), 4);
-  checkIntValue(&eval_context, tv2->axis(2)->rawExtent(), 128);
+  checkIntValue(evaluator, tv2->axis(0)->rawExtent(), 2);
+  checkIntValue(evaluator, tv2->axis(1)->rawExtent(), 4);
+  checkIntValue(evaluator, tv2->axis(2)->rawExtent(), 128);
 
   TORCH_CHECK(tv3->domain()->nDims() == 3);
-  checkIntValue(&eval_context, tv3->axis(0)->rawExtent(), 2);
-  checkIntValue(&eval_context, tv3->axis(1)->rawExtent(), 4);
-  checkIntValue(&eval_context, tv3->axis(2)->rawExtent(), 128);
+  checkIntValue(evaluator, tv3->axis(0)->rawExtent(), 2);
+  checkIntValue(evaluator, tv3->axis(1)->rawExtent(), 4);
+  checkIntValue(evaluator, tv3->axis(2)->rawExtent(), 128);
 
-  checkIntValue(&eval_context, bid_x, 2);
-  checkIntValue(&eval_context, tid_x, 128);
+  checkIntValue(evaluator, bid_x, 2);
+  checkIntValue(evaluator, tid_x, 128);
 }
 
 void testGPU_FusionClear() {
@@ -5772,6 +5772,8 @@ void testGPU_FusionSmemBlockGemmCache() {
 }
 
 void testGPU_FusionSmemDynamicReductionSymbolic() {
+  // Disabling test due to https://github.com/csarofeen/pytorch/issues/356
+#if 0
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -5817,9 +5819,12 @@ void testGPU_FusionSmemDynamicReductionSymbolic() {
       aten_output.allclose(outputs[0], 1e-5, 1e-5),
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
+#endif
 }
 
 void testGPU_FusionSmemDynamicReductionSymbolicArg() {
+  // Disabling test due to https://github.com/csarofeen/pytorch/issues/356
+#if 0
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -5875,9 +5880,12 @@ void testGPU_FusionSmemDynamicReductionSymbolicArg() {
       aten_output.allclose(outputs[0], 1e-5, 1e-5),
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
+#endif
 }
 
 void testGPU_FusionSmemDynamicPwiseMulSymbolicArg() {
+  // Disabling test due to https://github.com/csarofeen/pytorch/issues/356
+#if 0
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -5932,6 +5940,7 @@ void testGPU_FusionSmemDynamicPwiseMulSymbolicArg() {
       aten_output.allclose(outputs[0], 1e-5, 1e-5),
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
+#endif
 }
 
 void testGPU_FusionConstCheck() {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5772,8 +5772,6 @@ void testGPU_FusionSmemBlockGemmCache() {
 }
 
 void testGPU_FusionSmemDynamicReductionSymbolic() {
-  // Disabling test due to https://github.com/csarofeen/pytorch/issues/356
-#if 0
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -5819,12 +5817,9 @@ void testGPU_FusionSmemDynamicReductionSymbolic() {
       aten_output.allclose(outputs[0], 1e-5, 1e-5),
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
-#endif
 }
 
 void testGPU_FusionSmemDynamicReductionSymbolicArg() {
-  // Disabling test due to https://github.com/csarofeen/pytorch/issues/356
-#if 0
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -5880,12 +5875,9 @@ void testGPU_FusionSmemDynamicReductionSymbolicArg() {
       aten_output.allclose(outputs[0], 1e-5, 1e-5),
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
-#endif
 }
 
 void testGPU_FusionSmemDynamicPwiseMulSymbolicArg() {
-  // Disabling test due to https://github.com/csarofeen/pytorch/issues/356
-#if 0
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -5940,7 +5932,6 @@ void testGPU_FusionSmemDynamicPwiseMulSymbolicArg() {
       aten_output.allclose(outputs[0], 1e-5, 1e-5),
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
-#endif
 }
 
 void testGPU_FusionConstCheck() {

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -223,7 +223,8 @@ LaunchParams FusionExecutor::computeLaunchParams(
             // Bind the launch constraint into our evaluation context
             see.safeBind(
                 parallel_id->rawExtent(),
-                launch_constraints.getDim(entry.first));
+                launch_constraints.getDim(entry.first),
+                &lowered_);
             launch_params.bind(launch_constraints.getDim(p_type), p_type);
           }
         }
@@ -326,7 +327,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   auto stream = at::cuda::getCurrentCUDAStream();
 
   StatefulExpressionEvaluator evaluator =
-      executor_utils::statefulBindInputs(inputs, &fusion_);
+      executor_utils::statefulBindInputs(inputs, &fusion_, &lowered_);
 
   LaunchParams launch_params =
       computeLaunchParams(inputs, launch_constraints, evaluator);

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -284,11 +284,19 @@ FusionExecutor::GlobalBuffers FusionExecutor::allocGlobalVals(
     TORCH_INTERNAL_ASSERT(
         alloc->buffer()->getValType() == ValType::KirTensorView,
         "Cannot allocate global buffers that are not tensors.");
-    global_buffers.empty_buffers.push_back(inferAndAlloc(
-        alloc->buffer()->as<kir::TensorView>()->fuserTv(),
-        ec,
-        options_,
-        alloc->zeroInit()));
+    if (!alloc->zeroInit()) {
+      global_buffers.empty_buffers.push_back(inferAndAlloc(
+          alloc->buffer()->as<kir::TensorView>()->fuserTv(),
+          ec,
+          options_,
+          false));
+    } else {
+      global_buffers.zero_buffers.push_back(inferAndAlloc(
+          alloc->buffer()->as<kir::TensorView>()->fuserTv(),
+          ec,
+          options_,
+          true));
+    }
   }
 
   return global_buffers;

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -209,7 +209,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
         for (auto parallel_id : parallel_ids) {
           auto inferred_val = see.inferValue(parallel_id->rawExtent());
           if (inferred_val.has_value()) {
-            // This value could have been infered, make sure it was set right.
+            // This value could have been inferred, make sure it was set right.
             TORCH_CHECK(
                 inferred_val.value() == launch_constraints.getDim(p_type) ||
                     launch_constraints.getRawVal(p_type) == -1,

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -67,7 +67,7 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
   LaunchParams computeLaunchParams(
       const at::ArrayRef<IValue>& aten_inputs,
       const LaunchParams& launch_constraints,
-      EvaluationContext& ec);
+      StatefulExpressionEvaluator& see);
 
   uint64_t computeSharedMemory(
       EvaluationContext& ec,
@@ -75,9 +75,8 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
       bool align_padding = false,
       uint64_t total = 0);
 
-  std::vector<at::Tensor> allocGlobalVals(EvaluationContext& ec);
-
-  std::vector<at::Tensor> allocOutputs(EvaluationContext& ec);
+  std::vector<at::Tensor> allocGlobalVals(StatefulExpressionEvaluator& see);
+  std::vector<at::Tensor> allocOutputs(StatefulExpressionEvaluator& see);
 
  private:
   bool compiled_ = false;

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -70,7 +70,7 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
       StatefulExpressionEvaluator& see);
 
   uint64_t computeSharedMemory(
-      EvaluationContext& ec,
+      StatefulExpressionEvaluator& see,
       const std::vector<kir::Allocate*>& buffers,
       bool align_padding = false,
       uint64_t total = 0);

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -89,6 +89,7 @@ class TORCH_CUDA_API FusionExecutor : public NonCopyable {
 
   CompileOptions options_;
   size_t max_device_smem = std::numeric_limits<size_t>().max();
+  size_t static_smem_size = 0;
   executor_utils::NvrtcFunction compiled_kernel_;
 
   // State of the fusion that's important

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -32,20 +32,9 @@ void validateKernelOutputs(
     const std::vector<at::Tensor>& outputs,
     c10::Device device);
 
-// Check if a value is already bound, if so validate we're trying to bind to the
-// same value
-void safeBind(
-    EvaluationContext& ec,
-    const Val* value,
-    Int::ScalarType concrete_value);
-
-// Bind Inputs to Fusion IR
-EvaluationContext bindInputs(
+StatefulExpressionEvaluator statefulBindInputs(
     const at::ArrayRef<IValue>& aten_inputs,
     Fusion* fusion);
-
-TORCH_CUDA_API StatefulExpressionEvaluator
-statefulBindInputs(const at::ArrayRef<IValue>& aten_inputs, Fusion* fusion);
 
 struct NvrtcFunction {
   CUmodule module = CUmodule();

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -44,9 +44,8 @@ EvaluationContext bindInputs(
     const at::ArrayRef<IValue>& aten_inputs,
     Fusion* fusion);
 
-StatefulExpressionEvaluator statefulBindInputs(
-    const at::ArrayRef<IValue>& aten_inputs,
-    Fusion* fusion);
+TORCH_CUDA_API StatefulExpressionEvaluator
+statefulBindInputs(const at::ArrayRef<IValue>& aten_inputs, Fusion* fusion);
 
 struct NvrtcFunction {
   CUmodule module = CUmodule();

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -34,7 +34,8 @@ void validateKernelOutputs(
 
 StatefulExpressionEvaluator statefulBindInputs(
     const at::ArrayRef<IValue>& aten_inputs,
-    Fusion* fusion);
+    Fusion* fusion,
+    GpuLower* lower = nullptr);
 
 struct NvrtcFunction {
   CUmodule module = CUmodule();

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -44,11 +44,9 @@ EvaluationContext bindInputs(
     const at::ArrayRef<IValue>& aten_inputs,
     Fusion* fusion);
 
-// Bind Inputs to Fusion and Kernel IR
-EvaluationContext bindInputs(
+StatefulExpressionEvaluator statefulBindInputs(
     const at::ArrayRef<IValue>& aten_inputs,
-    Fusion* fusion,
-    GpuLower* lowered);
+    Fusion* fusion);
 
 struct NvrtcFunction {
   CUmodule module = CUmodule();

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
@@ -9,222 +9,6 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-void EvaluationContext::bind(const Val* value, Int::ScalarType concrete_value) {
-  TORCH_INTERNAL_ASSERT(
-      value->isAnInt(),
-      "Expression Evaluation does not support values other than integers at this time.");
-
-  if (value->isConstScalar()) {
-    auto const_value = value->as<Int>()->value().value();
-    TORCH_INTERNAL_ASSERT(
-        concrete_value == const_value,
-        "Tried to bind ",
-        concrete_value,
-        " to ",
-        value,
-        " however ",
-        value,
-        " is set to a constant ",
-        const_value);
-  }
-
-  TORCH_INTERNAL_ASSERT(
-      fusion_->origin(value) == nullptr,
-      "Tried to bind to a value that is computed in the fusion IR. ",
-      "Can only bind to symbolic values to the fusion that do not have an origin expr.");
-
-  bindings_[value] = concrete_value;
-}
-
-c10::optional<Int::ScalarType> EvaluationContext::concreteValue(
-    const Val* value) const {
-  const auto it = bindings_.find(value);
-  return (it != bindings_.end()) ? c10::optional<Int::ScalarType>(it->second)
-                                 : c10::nullopt;
-}
-
-void EvaluationContext::print() const {
-  std::cout << "\nEvaluation context\n";
-  std::cout << "--------------------\n";
-  for (const auto& kv : bindings_) {
-    std::cout << kv.first << " = " << kv.second;
-    if (kv.first->isConstScalar()) {
-      std::cout << " ; original value = "
-                << kv.first->as<Int>()->value().value();
-    }
-    std::cout << " ; " << *kv.first->getValType() << "\n";
-  }
-  std::cout << "--------------------\n\n";
-}
-
-c10::optional<Int::ScalarType> ExpressionEvaluator::evaluate(
-    Val* val,
-    const EvaluationContext* context) {
-  TORCH_CHECK(context != nullptr);
-  ExpressionEvaluator evaluator(context);
-  evaluator.traverseFrom(context->fusion(), {val}, false);
-  return evaluator.value(val);
-}
-
-c10::optional<Int::ScalarType> ExpressionEvaluator::value(
-    const Statement* stmt) const {
-  const auto it = values_.find(stmt);
-  return (it != values_.end()) ? c10::optional<Int::ScalarType>(it->second)
-                               : c10::nullopt;
-}
-
-void ExpressionEvaluator::handle(NamedScalar* i) {
-  if (i->isAnInt()) {
-    const auto& bound_value = context_->concreteValue(i);
-    if (bound_value.has_value()) {
-      values_[i] = *bound_value;
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(Int* i) {
-  if (i->value().has_value()) {
-    values_[i] = *i->value();
-  } else if (const auto* def = context_->fusion()->origin(i)) {
-    const auto& def_result = value(def);
-    if (def_result.has_value()) {
-      values_[i] = *def_result;
-    }
-  } else {
-    const auto& bound_value = context_->concreteValue(i);
-    if (bound_value.has_value()) {
-      values_[i] = *bound_value;
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(UnaryOp* uop) {
-  const auto in = value(uop->in());
-  if (in.has_value()) {
-    switch (uop->getUnaryOpType()) {
-      case UnaryOpType::Neg:
-        values_[uop] = -*in;
-        break;
-      case UnaryOpType::Cast:
-        values_[uop] = *in;
-        break;
-      default:
-        TORCH_CHECK(!"Unexpected operator type");
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(BinaryOp* bop) {
-  const auto lhs = value(bop->lhs());
-  const auto rhs = value(bop->rhs());
-  if (lhs.has_value() && rhs.has_value()) {
-    switch (bop->getBinaryOpType()) {
-      case BinaryOpType::Add:
-        values_[bop] = *lhs + *rhs;
-        break;
-      case BinaryOpType::Sub:
-        values_[bop] = *lhs - *rhs;
-        break;
-      case BinaryOpType::Mul:
-        values_[bop] = *lhs * *rhs;
-        break;
-      case BinaryOpType::Div:
-        TORCH_CHECK(*rhs != 0);
-        values_[bop] = *lhs / *rhs;
-        break;
-      case BinaryOpType::Mod:
-        TORCH_CHECK(*rhs != 0);
-        values_[bop] = *lhs % *rhs;
-        break;
-      case BinaryOpType::CeilDiv:
-        TORCH_CHECK(*rhs != 0);
-        values_[bop] = (*lhs + *rhs - 1) / *rhs;
-        break;
-      case BinaryOpType::And:
-        values_[bop] = Int::ScalarType(*lhs && *rhs);
-        break;
-      default:
-        TORCH_CHECK(!"Unexpected operator type");
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(kir::NamedScalar* i) {
-  if (i->isAnInt()) {
-    const auto& bound_value = context_->concreteValue(i);
-    if (bound_value.has_value()) {
-      values_[i] = *bound_value;
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(kir::Int* i) {
-  if (i->value().has_value()) {
-    values_[i] = *i->value();
-  } else if (const auto* def = context_->fusion()->origin(i)) {
-    const auto& def_result = value(def);
-    if (def_result.has_value()) {
-      values_[i] = *def_result;
-    }
-  } else {
-    const auto& bound_value = context_->concreteValue(i);
-    if (bound_value.has_value()) {
-      values_[i] = *bound_value;
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(kir::UnaryOp* uop) {
-  const auto in = value(uop->in());
-  if (in.has_value()) {
-    switch (uop->getUnaryOpType()) {
-      case UnaryOpType::Neg:
-        values_[uop] = -*in;
-        break;
-      case UnaryOpType::Cast:
-        values_[uop] = *in;
-        break;
-      default:
-        TORCH_CHECK(!"Unexpected operator type");
-    }
-  }
-}
-
-void ExpressionEvaluator::handle(kir::BinaryOp* bop) {
-  const auto lhs = value(bop->lhs());
-  const auto rhs = value(bop->rhs());
-  if (lhs.has_value() && rhs.has_value()) {
-    switch (bop->getBinaryOpType()) {
-      case BinaryOpType::Add:
-        values_[bop] = *lhs + *rhs;
-        break;
-      case BinaryOpType::Sub:
-        values_[bop] = *lhs - *rhs;
-        break;
-      case BinaryOpType::Mul:
-        values_[bop] = *lhs * *rhs;
-        break;
-      case BinaryOpType::Div:
-        TORCH_CHECK(*rhs != 0);
-        values_[bop] = *lhs / *rhs;
-        break;
-      case BinaryOpType::Mod:
-        TORCH_CHECK(*rhs != 0);
-        values_[bop] = *lhs % *rhs;
-        break;
-      case BinaryOpType::CeilDiv:
-        TORCH_CHECK(*rhs != 0);
-        values_[bop] = (*lhs + *rhs - 1) / *rhs;
-        break;
-      case BinaryOpType::And:
-        values_[bop] = Int::ScalarType(*lhs && *rhs);
-        break;
-      default:
-        TORCH_CHECK(!"Unexpected operator type");
-    }
-  }
-}
-
 void StatefulExpressionEvaluator::safeBind(
     Val* value,
     Int::ScalarType concrete_value) {
@@ -251,6 +35,20 @@ void StatefulExpressionEvaluator::safeBind(
 c10::optional<Int::ScalarType> StatefulExpressionEvaluator::inferValue(
     Val* value) {
   return maybeHandle(value);
+}
+
+void StatefulExpressionEvaluator::print() const {
+  std::cout << "\nEvaluation context\n";
+  std::cout << "--------------------\n";
+  for (const auto& kv : bindings_) {
+    std::cout << kv.first << " = " << kv.second;
+    if (kv.first->isConstScalar()) {
+      std::cout << " ; original value = "
+                << kv.first->as<Int>()->value().value();
+    }
+    std::cout << " ; " << *kv.first->getValType() << "\n";
+  }
+  std::cout << "--------------------\n\n";
 }
 
 inline c10::optional<Int::ScalarType> StatefulExpressionEvaluator::getValue(

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
@@ -241,25 +241,7 @@ void StatefulExpressionEvaluator::safeBind(
         already_concrete_val.value());
   } else {
     TORCH_INTERNAL_ASSERT(
-        value->isAnInt(),
-        "Expressoin Evaluation does not support values other than integers at this time.");
-
-    if (value->isConstScalar()) {
-      auto const_value = value->as<Int>()->value().value();
-      TORCH_INTERNAL_ASSERT(
-          concrete_value == const_value,
-          "Tried to bind ",
-          concrete_value,
-          " to ",
-          value,
-          " however ",
-          value,
-          " is set to a constant ",
-          const_value);
-    }
-
-    TORCH_INTERNAL_ASSERT(
-        fusion_->origin(value) == nullptr,
+        value->getOrigin() == nullptr,
         "Tried to bind to a value that is computed in the fusion IR. ",
         "Can only bind to symbolic values to the fusion that do not have an origin expr.");
 
@@ -288,6 +270,7 @@ inline c10::optional<Int::ScalarType> StatefulExpressionEvaluator::getValue(
   if (value->as<Int>()->value().has_value()) {
     return value->as<Int>()->value();
   }
+
   auto it = bindings_.find(value);
   if (it != bindings_.end()) {
     return c10::optional<Int::ScalarType>(it->second);

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
@@ -267,7 +267,11 @@ inline c10::optional<Int::ScalarType> StatefulExpressionEvaluator::getValue(
       value->isAnInt(),
       "Expressoin Evaluation does not support values other than integers at this time.");
 
-  if (value->as<Int>()->value().has_value()) {
+  auto v_type = value->getValType().value();
+  bool is_named_scalar =
+      v_type == ValType::NamedScalar || v_type == ValType::KirNamedScalar;
+
+  if (!is_named_scalar && value->as<Int>()->value().has_value()) {
     return value->as<Int>()->value();
   }
 

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.cpp
@@ -1,4 +1,3 @@
-
 #include <torch/csrc/jit/codegen/cuda/expr_evaluator.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
@@ -356,8 +355,8 @@ void StatefulExpressionEvaluator::handle(kir::UnaryOp* uop) {
 }
 
 void StatefulExpressionEvaluator::handle(kir::BinaryOp* bop) {
-  const auto lhs = getValue(bop->lhs());
-  const auto rhs = getValue(bop->rhs());
+  const auto lhs = maybeHandle(bop->lhs());
+  const auto rhs = maybeHandle(bop->rhs());
   if (lhs.has_value() && rhs.has_value()) {
     switch (bop->getBinaryOpType()) {
       case BinaryOpType::Add:

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.h
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/codegen/cuda/ir_interface_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/iter_visitor.h>
+#include <torch/csrc/jit/codegen/cuda/lower2device.h>
 
 #include <c10/util/Optional.h>
 
@@ -21,7 +22,10 @@ class TORCH_CUDA_API StatefulExpressionEvaluator : private OptOutDispatch {
     return fusion_;
   }
 
-  void safeBind(Val* value, Int::ScalarType concrete_value);
+  void safeBind(
+      Val* value,
+      Int::ScalarType concrete_value,
+      GpuLower* lower = nullptr);
 
   // Returns value if found in mapping, otherwise returns c10::nullopt
   c10::optional<Int::ScalarType> getValue(Val* value);

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.h
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.h
@@ -103,6 +103,29 @@ class TORCH_CUDA_API StatefulExpressionEvaluator : private IterVisitor {
   using IterVisitor::handle;
   using IterVisitor::next;
 
+  void handle(Expr* expr) override {
+    switch (expr->getExprType().value()) {
+      case ExprType::UnaryOp:
+        handle(expr->as<UnaryOp>());
+        break;
+      case ExprType::BinaryOp:
+        handle(expr->as<BinaryOp>());
+        break;
+      case ExprType::KirUnaryOp:
+        handle(expr->as<kir::UnaryOp>());
+        break;
+      case ExprType::KirBinaryOp:
+        handle(expr->as<kir::BinaryOp>());
+        break;
+      default:
+        TORCH_INTERNAL_ASSERT(
+            false,
+            "Cannot handle Expr type: ",
+            expr->getExprType().value(),
+            " in stateful expression evaluator.");
+    }
+  }
+
   void handle(UnaryOp*) override;
   void handle(BinaryOp*) override;
 

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.h
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.h
@@ -13,72 +13,6 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-// Encapsulates a set of value bindings on top of a Fusion IR
-// (used to provide known values to ExpressionEvaluator)
-//
-// NOTE: currently it only supports Int values
-//
-class TORCH_CUDA_API EvaluationContext {
- public:
-  explicit EvaluationContext(Fusion* fusion) : fusion_(fusion) {}
-
-  // Set the concrete value for a Int*
-  void bind(const Val* value, Int::ScalarType concrete_value);
-
-  // Retrieves the concrete value, or nullopt if not set
-  c10::optional<Int::ScalarType> concreteValue(const Val* value) const;
-
-  Fusion* fusion() const {
-    return fusion_;
-  }
-
-  // Debugging helper, prints all the currently set values
-  void print() const;
-
- private:
-  std::unordered_map<const Val*, Int::ScalarType> bindings_;
-  Fusion* fusion_ = nullptr;
-};
-
-// Evaluates expressions in a Fusion IR, using the passed in
-// context (EvaluationContext) to query for concrete_values. The
-// evaluation context may override concrete values in the IR as well.
-class TORCH_CUDA_API ExpressionEvaluator : protected IterVisitor {
- public:
-  // Returns the result of the specified expression, or nullopt if
-  // the result cannot be evaluated
-  static c10::optional<Int::ScalarType> evaluate(
-      Val* val,
-      const EvaluationContext* context);
-
- protected:
-  explicit ExpressionEvaluator(const EvaluationContext* context)
-      : context_(context) {}
-
-  ~ExpressionEvaluator() override = default;
-
-  c10::optional<Int::ScalarType> value(const Statement* stmt) const;
-
-  using IterVisitor::handle;
-  using IterVisitor::next;
-  using IterVisitor::traverseFrom;
-
-  void handle(NamedScalar*) override;
-  void handle(Int*) override;
-  void handle(UnaryOp*) override;
-  void handle(BinaryOp*) override;
-
-  // TODO(kir): remove this
-  void handle(kir::NamedScalar*) override;
-  void handle(kir::Int*) override;
-  void handle(kir::UnaryOp*) override;
-  void handle(kir::BinaryOp*) override;
-
- protected:
-  const EvaluationContext* context_ = nullptr;
-  std::unordered_map<const Statement*, Int::ScalarType> values_;
-};
-
 class TORCH_CUDA_API StatefulExpressionEvaluator : private OptOutDispatch {
  public:
   explicit StatefulExpressionEvaluator(Fusion* fusion) : fusion_(fusion) {}
@@ -96,12 +30,16 @@ class TORCH_CUDA_API StatefulExpressionEvaluator : private OptOutDispatch {
   // runs traversal on value. Warning: should not be called in traversal.
   c10::optional<Int::ScalarType> inferValue(Val* value);
 
+  // Debugging helper, prints all the currently set values
+  void print() const;
+
  private:
   std::unordered_map<const Val*, Int::ScalarType> bindings_;
   Fusion* fusion_ = nullptr;
 
   using OptOutDispatch::handle;
 
+ private:
   void handle(Expr* expr) override {
     switch (expr->getExprType().value()) {
       case ExprType::UnaryOp:
@@ -125,14 +63,14 @@ class TORCH_CUDA_API StatefulExpressionEvaluator : private OptOutDispatch {
     }
   }
 
-  c10::optional<Int::ScalarType> maybeHandle(Val*);
-
   void handle(UnaryOp*) override;
   void handle(BinaryOp*) override;
 
   // TODO(kir): remove this
   void handle(kir::UnaryOp*) override;
   void handle(kir::BinaryOp*) override;
+
+  c10::optional<Int::ScalarType> maybeHandle(Val*);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -407,17 +407,15 @@ c10::optional<ReductionParams> scheduleReduction(
     red_tv->merge(-2, -1);
   }
 
-  EvaluationContext eval_context(
-      executor_utils::bindInputs(fusion_inputs, fusion));
+  StatefulExpressionEvaluator evaluator(
+      executor_utils::statefulBindInputs(fusion_inputs, fusion));
 
   // Evaluate Dimensions of Reduction TensorView
   auto red_ids = red_tv->domain()->domain();
   TORCH_INTERNAL_ASSERT(
       red_ids.size() == 2, "We coalesced all dimensions into 2 previously.");
-  const auto red_outputs =
-      ExpressionEvaluator::evaluate(red_ids[0]->extent(), &eval_context);
-  const auto red_elems =
-      ExpressionEvaluator::evaluate(red_ids[1]->extent(), &eval_context);
+  const auto red_outputs = evaluator.inferValue(red_ids[0]->extent());
+  const auto red_elems = evaluator.inferValue(red_ids[1]->extent());
   TORCH_INTERNAL_ASSERT(
       red_outputs != c10::nullopt,
       "The number of reduction outputs is expected.");


### PR DESCRIPTION
Re-evaluating expressions can add quite a bit of latency. This is primarily the construction of an expression evaluator that keeps its state, but also reverts to a simple recursive dispatch.
From: https://github.com/csarofeen/pytorch/issues/345
This reduces ~20us of latency.