### PR TITLE
Dtype for reduction

### DIFF
--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -224,18 +224,7 @@ void compileCudaFusionGroup(Node* fusion_node) {
   // This is not a critical code path, it's OK to do graph copy here;
   auto graph = fusion_node->g(attr::Subgraph)->copy();
 
-  if (!IsNewExecutorEnabled()) {
-    // TODO: this doesn't cover the case where input types are missing. If we do
-    //       the graph construction at run-time, it's expensive to copy graph
-    //       at critical path. We take the trade-off here as profiling executor
-    //       is the future;
-    //
-    // Type propagation that's here just to cover corner case, incase type
-    // propagation failed in the original subgraph. We currently need output
-    // types in order to support fp16, where we cast input to fp32 and output
-    // back to fp16.
-    TypePropagate(graph);
-  }
+  TypePropagate(graph);
 
   int32_t fusion_cache_id =
       CudaFusionManager::getManager().registerOrGetCacheId(graph);

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -507,6 +507,14 @@ class IrParser {
             // we don't support cast of output types yet;
             if (!node->inputs()[3]->type()->isSubtypeOf(
                     static_cast<c10::TypePtr>(NoneType::get()))) {
+              // We can only handle output as half and float;
+              if (auto opt_ivalue = toIValue(node->input(3))) {
+                auto scalar_type = opt_ivalue->toScalarType();
+                if (scalar_type == at::ScalarType::Float || 
+                    scalar_type == at::ScalarType::Half) {
+                  return true;
+                }
+              }
               return false;
             }
             // we don't support dynamic reduction axes;

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -510,7 +510,7 @@ class IrParser {
               // We can only handle output as half and float;
               if (auto opt_ivalue = toIValue(node->input(3))) {
                 auto scalar_type = opt_ivalue->toScalarType();
-                if (scalar_type == at::ScalarType::Float || 
+                if (scalar_type == at::ScalarType::Float ||
                     scalar_type == at::ScalarType::Half) {
                   return true;
                 }

--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -148,7 +148,14 @@ class NaiveTypePropagator {
         break;
       }
       case aten::sum: {
-        const auto out_type = node->input(0)->type()->cast<TensorType>();
+        auto out_type = node->input(0)->type()->cast<TensorType>();
+
+        if (!node->input(3)->type()->isSubtypeOf(
+            static_cast<c10::TypePtr>(NoneType::get()))) {
+          if (auto opt_ivalue = toIValue(node->input(3))) {
+            out_type = out_type->withScalarType(opt_ivalue->toScalarType());
+          }
+        }
         const auto dims = constant_as<c10::List<int64_t>>(node->input(1));
         const auto keepdim = constant_as<bool>(node->input(2));
         TORCH_CHECK(

--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -151,7 +151,7 @@ class NaiveTypePropagator {
         auto out_type = node->input(0)->type()->cast<TensorType>();
 
         if (!node->input(3)->type()->isSubtypeOf(
-            static_cast<c10::TypePtr>(NoneType::get()))) {
+                static_cast<c10::TypePtr>(NoneType::get()))) {
           if (auto opt_ivalue = toIValue(node->input(3))) {
             out_type = out_type->withScalarType(opt_ivalue->toScalarType());
           }


### PR DESCRIPTION
Fixes #357

Two things in this PR:
1. Do type propagation even for profiling executor -> this is the root cause for bug reported in #357
2. Allow dtype argument in `sum`, which is simply handled in our type propagation.