### PR TITLE
Remove a false-positive assertion.

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -409,9 +409,9 @@ void findTargetTensor(Expr* expr, TensorView*& target, unsigned& score) {
   auto axis = out_tv->getRelativeComputeAtAxis();
   target = out_tv->getComputeAtView();
   while (target->hasComputeAt()) {
-    if (target->getThisComputeAtAxis() < axis)
+    if (target->getThisComputeAtAxis() < axis) {
       break;
-    TORCH_INTERNAL_ASSERT(target->getThisComputeAtAxis() == axis);
+    }
     axis = target->getComputeAtRelPos(axis);
     target = target->getComputeAtView();
   }


### PR DESCRIPTION
This should never be placed here.

Fixes #364

No test_gpu test fails, but I see a failure of the random topo python test:

```
======================================================================
FAIL: test_random_topo (__main__.TestCudaFuser)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nmaruyama/pytorch/debug3/torch/testing/_internal/common_utils.py", line 815, in wrapper
    method(*args, **kwargs)
  File "test/test_jit_cuda_fuser.py", line 523, in test_random_topo
    self.assertTrue(runDefaultTestWithSeed(28449))
AssertionError: False is not true
```
