### PR TITLE
[WIP] Improve Dynamic Shared Memory

### DIFF
--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -167,6 +167,9 @@ void Expr::dispatch(T handler, Expr* expr) {
     case ExprType::Allocate:
       ptr(handler)->handle(expr->as<kir::Allocate>());
       return;
+    case ExprType::Deallocate:
+      ptr(handler)->handle(expr->as<kir::Deallocate>());
+      return;
     case ExprType::Sync:
       ptr(handler)->handle(expr->as<kir::Sync>());
       return;
@@ -314,6 +317,9 @@ void Expr::constDispatch(T handler, const Expr* expr) {
     case ExprType::Allocate:
       ptr(handler)->handle(expr->as<kir::Allocate>());
       return;
+    case ExprType::Deallocate:
+      ptr(handler)->handle(expr->as<kir::Deallocate>());
+      return;
     case ExprType::Sync:
       ptr(handler)->handle(expr->as<kir::Sync>());
       return;
@@ -402,6 +408,8 @@ Statement* Expr::mutatorDispatch(T mutator, Expr* expr) {
       return ptr(mutator)->mutate(expr->as<kir::IfThenElse>());
     case ExprType::Allocate:
       return ptr(mutator)->mutate(expr->as<kir::Allocate>());
+    case ExprType::Deallocate:
+      return ptr(mutator)->mutate(expr->as<kir::Deallocate>());
     case ExprType::Sync:
       return ptr(mutator)->mutate(expr->as<kir::Sync>());
     default:

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -95,6 +95,7 @@ class BroadcastOp;
 
 class TensorIndex;
 class Allocate;
+class Deallocate;
 class ForLoop;
 class IfThenElse;
 class GridReduction;
@@ -163,6 +164,7 @@ class TORCH_CUDA_API OptOutConstDispatch {
   virtual void handle(const kir::ForLoop*) {}
   virtual void handle(const kir::IfThenElse*) {}
   virtual void handle(const kir::Allocate*) {}
+  virtual void handle(const kir::Deallocate*) {}
   virtual void handle(const kir::Sync*) {}
 };
 
@@ -223,6 +225,7 @@ class TORCH_CUDA_API OptOutDispatch {
   virtual void handle(kir::ForLoop*) {}
   virtual void handle(kir::IfThenElse*) {}
   virtual void handle(kir::Allocate*) {}
+  virtual void handle(kir::Deallocate*) {}
   virtual void handle(kir::Sync*) {}
 };
 
@@ -347,6 +350,9 @@ class TORCH_CUDA_API OptInConstDispatch {
   }
   virtual void handle(const kir::Allocate*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for kir::Allocate.");
+  }
+  virtual void handle(const kir::Deallocate*) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for kir::Deallocate.");
   }
   virtual void handle(const kir::Sync*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for kir::Sync.");
@@ -485,6 +491,9 @@ class TORCH_CUDA_API OptInDispatch {
   virtual void handle(kir::Allocate*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for kir::Allocate.");
   }
+  virtual void handle(kir::Deallocate*) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for kir::Deallocate.");
+  }
   virtual void handle(kir::Sync*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for kir::Sync.");
   }
@@ -555,6 +564,7 @@ class TORCH_CUDA_API OptOutMutator {
   virtual Statement* mutate(kir::ForLoop*);
   virtual Statement* mutate(kir::IfThenElse*);
   virtual Statement* mutate(kir::Allocate*);
+  virtual Statement* mutate(kir::Deallocate*);
   virtual Statement* mutate(kir::Sync*);
 };
 
@@ -640,6 +650,9 @@ class TORCH_CUDA_API OptInMutator {
   }
   virtual Statement* mutate(kir::Allocate*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Allocate.");
+  }
+  virtual Statement* mutate(kir::Deallocate*) {
+    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Deallocate.");
   }
   virtual Statement* mutate(kir::Sync*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Sync.");

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -399,6 +399,15 @@ void IrPrinter::handle(const kir::Allocate* a) {
   os_ << "kir::Allocate";
 }
 
+void IrPrinter::handle(const kir::Deallocate* a) {
+  indent();
+  os_ << "offset -= (";
+  print_inline(a->size());
+  os_ << " * sizeof(";
+  os_ << a->buffer_type();
+  os_ << "));\n";
+}
+
 void IrPrinter::handle(const kir::Sync* a) {
   os_ << "kir::Sync";
 }

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -89,6 +89,7 @@ class TORCH_CUDA_API IrPrinter : public OptInConstDispatch {
   void handle(const kir::ForLoop*) override;
   void handle(const kir::IfThenElse*) override;
   void handle(const kir::Allocate*) override;
+  void handle(const kir::Deallocate*) override;
   void handle(const kir::Sync*) override;
 
   void handle(const Split*) override;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -419,6 +419,12 @@ Allocate::Allocate(
   name_ = FusionGuard::getCurFusion()->registerLoweredExpr(this);
 }
 
+Deallocate::Deallocate(Allocate* buffer)
+    : Expr(ExprType::Deallocate), buffer_(buffer) {
+  addInput(buffer_->size());
+  name_ = FusionGuard::getCurFusion()->registerLoweredExpr(this);
+}
+
 GridReduction::GridReduction(ReductionOp* reduction_op)
     : Expr(ExprType::GridReduction), reduction_op_(reduction_op) {
   TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -514,6 +514,28 @@ class TORCH_CUDA_API Allocate : public Expr {
   bool zero_init_ = false;
 };
 
+// Deallocate is a lower level Node that indicates when to release
+// a shared memory buffer within a kernel
+class TORCH_CUDA_API Deallocate : public Expr {
+ public:
+  explicit Deallocate(Allocate* buffer);
+
+  Allocate* buffer() const {
+    return buffer_;
+  }
+
+  Val* size() const {
+    return buffer_->size();
+  }
+
+  DataType buffer_type() const {
+    return buffer_->buffer_type();
+  }
+
+ private:
+  Allocate* buffer_ = nullptr;
+};
+
 // Sync represents __syncthreads barrier for block level coordination.
 class TORCH_CUDA_API Sync : public Expr {
  public:

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -233,13 +233,13 @@ void LoopNestGenerator::handle(Expr* expr) {
     return;
   }
 
-  //  0) Apply SyncThreads if any shared memory inputs are modified
+  //  Apply SyncThreads if any shared memory inputs are modified
   bool shared_memory_sync = false;
   for (auto in : expr->inputs()) {
     shared_memory_sync |= isModifiedSharedMemory(in);
   }
   if (shared_memory_sync) {
-    // push Sync to the back of the last for loop
+    // push Sync to the back of the latest for loop
     scope_utils::pushBack(for_loops.back(), new kir::Sync());
     cleanSharedMemory();
   }
@@ -254,7 +254,7 @@ void LoopNestGenerator::handle(Expr* expr) {
   // Check where in the previous view our last axis was in that view
   int64_t last_ca_view_ind = 0;
 
-  // Look at each axis individually in out's domain
+  // Look at each axis individually in OUT's domain
   for (int64_t out_i = 0; out_i < (int64_t)out->getThisComputeAtAxis();
        out_i++) {
     // Grab the axis information
@@ -263,7 +263,7 @@ void LoopNestGenerator::handle(Expr* expr) {
     auto ca_id = ca_point.first;
 
     // Figure out if there are axes in the compute at tensor view that aren't
-    // in out, make sure to also open them. Check where to start looking for
+    // in OUT, make sure to also open them. Check where to start looking for
     // them in the compute at view.
     size_t start = 0;
     if (last_ca_view == nullptr) {
@@ -314,9 +314,9 @@ void LoopNestGenerator::handle(Expr* expr) {
     loop_structure.push_back(out->getComputeAtAxis(out_i));
   }
 
-  // At this point loop_structure contains our overal target loop nest structure
-  // Lets get a copy of the loop structure, and figure out which loops we need
-  // to open.
+  // At this point loop_structure contains our overall target loop nest
+  // structure Lets get a copy of the loop structure, and figure out which loops
+  // we need to open.
   decltype(loop_structure) loops_to_open(loop_structure);
   // Pop out loops already opened
   for (const auto& existing_loop : for_loops) {
@@ -330,7 +330,7 @@ void LoopNestGenerator::handle(Expr* expr) {
     }
   }
 
-  // At this point for_loops + loops_to_open contains our overal target loop
+  // At this point for_loops + loops_to_open contains our overall target loop
   // nest structure. Open loops in "loops_to_open".
   while (!loops_to_open.empty()) {
     openFor(loops_to_open.front());

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -109,6 +109,10 @@ Statement* OptOutMutator::mutate(kir::Allocate* a) {
   return a;
 }
 
+Statement* OptOutMutator::mutate(kir::Deallocate* a) {
+  return a;
+}
+
 Statement* OptOutMutator::mutate(kir::Sync* a) {
   return a;
 }

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -101,6 +101,8 @@ static const char* expr_type2string(ExprType t) {
       return "IfThenElse";
     case ExprType::Allocate:
       return "Allocate";
+    case ExprType::Deallocate:
+      return "Deallocate";
     case ExprType::Sync:
       return "SyncThreads";
     case ExprType::Split:

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -55,6 +55,7 @@ enum class ExprType {
   ForLoop,
   IfThenElse,
   Allocate,
+  Deallocate,
   Sync,
   KirUnaryOp,
   KirBinaryOp,


### PR DESCRIPTION
Goal: Reduce shared memory usage by deallocating buffers

- [X] Create a node to deallocate dynamic shared memory buffer
- [ ] Allocate dynamic shared memory as-needed instead of preallocating at the beginning of the kernel
- [ ] Deallocate dynamic shared memory immediately after all input uses
- [ ] Sum together all Allocate and Deallocate nodes to find max dynamic shared memory
- [ ] Add warning for poor algorithm scheduling that prevents buffer deallocation