### PR TITLE
Move prediatation inside block/gridReduciton functions

### DIFF
--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -703,6 +703,14 @@ void IrPrinter::handle(const kir::ReductionOp* rop) {
     os_ << "reduction_" << op_type << "_" << d_type;
     os_ << ", threadIdx, blockDim";
     os_ << ", static_cast<" << d_type << "*>(shared_mem)";
+    if (rop->pred() == nullptr) {
+      os_ << ", true";
+    } else {
+      os_ << ", ";
+      print_inline(rop->pred());
+    }
+    os_ << ", ";
+    print_inline(rop->init());
     os_ << ");\n";
   }
 }
@@ -758,6 +766,14 @@ void IrPrinter::handle(const kir::GridReduction* gr) {
   os_ << ", &T" << work_buffer->name() << "[0]";
   os_ << ", T" << sync_buffer->name() << "";
   os_ << ", static_cast<" << d_type << "*>(shared_mem)";
+  if (gr->pred() == nullptr) {
+    os_ << ", true";
+  } else {
+    os_ << ", ";
+    print_inline(gr->pred());
+  }
+  os_ << ", ";
+  print_inline(gr->reduction_op()->init());
   os_ << ");\n";
 }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -197,12 +197,14 @@ ReductionOp::ReductionOp(
     BinaryOpType reduction_op_type,
     Val* init,
     Val* out,
-    Val* in)
+    Val* in,
+    Bool* pred)
     : Expr(ExprType::KirReductionOp),
       reduction_op_type_(reduction_op_type),
       init_(init),
       out_(out),
-      in_(in) {
+      in_(in),
+      pred_(pred) {
   addOutput(out);
   addInput(in);
   name_ = FusionGuard::getCurFusion()->registerLoweredExpr(this);
@@ -417,12 +419,14 @@ GridReduction::GridReduction(ReductionOp* reduction_op)
 
 GridReduction::GridReduction(
     ReductionOp* reduction_op,
-    kir::Allocate* reduction_buffer,
-    kir::Allocate* sync_buffer)
+    Allocate* reduction_buffer,
+    Allocate* sync_buffer,
+    Bool* pred)
     : Expr(ExprType::GridReduction),
       reduction_op_(reduction_op),
       reduction_buffer_(reduction_buffer),
-      sync_buffer_(sync_buffer) {}
+      sync_buffer_(sync_buffer),
+      pred_(pred) {}
 
 std::string GridReduction::getPredicateFlagName(const TensorView* val) {
   std::stringstream ss;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -389,7 +389,12 @@ class TORCH_CUDA_API TernaryOp : public Expr {
 
 class TORCH_CUDA_API ReductionOp : public Expr {
  public:
-  ReductionOp(BinaryOpType reduction_op_type, Val* init, Val* out, Val* in);
+  ReductionOp(
+      BinaryOpType reduction_op_type,
+      Val* init,
+      Val* out,
+      Val* in,
+      Bool* pred = nullptr);
 
   Val* out() const {
     return out_;
@@ -401,6 +406,10 @@ class TORCH_CUDA_API ReductionOp : public Expr {
 
   Val* init() const {
     return init_;
+  }
+
+  Bool* pred() const {
+    return pred_;
   }
 
   BinaryOpType getReductionOpType() const {
@@ -418,6 +427,7 @@ class TORCH_CUDA_API ReductionOp : public Expr {
   Val* const init_ = nullptr;
   Val* const out_ = nullptr;
   Val* const in_ = nullptr;
+  Bool* const pred_ = nullptr;
 };
 
 class TORCH_CUDA_API TensorIndex : public Val {
@@ -663,7 +673,8 @@ class TORCH_CUDA_API GridReduction : public Expr {
   GridReduction(
       ReductionOp* reduction_op,
       Allocate* reduction_buffer,
-      Allocate* sync_buffer);
+      Allocate* sync_buffer,
+      Bool* pred = nullptr);
 
   ReductionOp* reduction_op() const {
     return reduction_op_;
@@ -677,6 +688,10 @@ class TORCH_CUDA_API GridReduction : public Expr {
     return sync_buffer_;
   }
 
+  Bool* pred() const {
+    return pred_;
+  }
+
   static std::string getPredicateFlagName(const TensorView* val);
   static std::string getPredicateFlagName(const fuser::TensorView* val);
 
@@ -684,6 +699,7 @@ class TORCH_CUDA_API GridReduction : public Expr {
   ReductionOp* reduction_op_ = nullptr;
   Allocate* reduction_buffer_ = nullptr;
   Allocate* sync_buffer_ = nullptr;
+  Bool* pred_ = nullptr;
 };
 
 // Simple classification helpers

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -71,8 +71,17 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
 kir::Bool* PredicateCompute::getInlinePredicate(
     Expr* expr,
     const std::vector<kir::ForLoop*>& loops,
-    kir::Bool* thread_pred) {
+    kir::Bool* thread_pred,
+    bool ignore_block_grid_reductions) {
   if (loops.empty()) {
+    return new kir::Bool(true);
+  }
+
+  // Handle these elsewhere
+  if (ignore_block_grid_reductions &&
+      expr->getExprType() == ExprType::ReductionOp &&
+      (expr->as<ReductionOp>()->out()->as<TensorView>()->hasBlockReduction() ||
+       expr->as<ReductionOp>()->out()->as<TensorView>()->hasGridReduction())) {
     return new kir::Bool(true);
   }
 

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.h
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.h
@@ -45,7 +45,8 @@ class PredicateCompute {
   static kir::Bool* getInlinePredicate(
       Expr* expr,
       const std::vector<kir::ForLoop*>& loops,
-      kir::Bool* thread_pred);
+      kir::Bool* thread_pred,
+      bool ignore_block_grid_reductions = true);
 };
 
 class TORCH_CUDA_API UnrollPredicate {


### PR DESCRIPTION
This is part of the GEMM PR (#368). Since that PR has several independent changes, I just extracted the specific changes that are related to `blockReduce` and `gridReduce` device functions. These functions now accept predicate flags that indicate whether a thread should join the reduction. The change is meant to fix the deadlock issue (#365).