### PR TITLE
Fixes to reduction heuristic usage and caching

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1,4 +1,4 @@
-// #if defined(USE_CUDA)
+#if defined(USE_CUDA)
 
 #include <test/cpp/jit/test_base.h>
 
@@ -5063,7 +5063,6 @@ void testGPU_FusionReductionSchedulerMultiDimNonFastest() {
   at::Tensor cg_output = at::empty(tensor_dims_out, options);
 
   // Apply reduction heuristic
-  const at::ArrayRef<c10::IValue> inputs({input});
   auto reduction_params = cuda::getReductionHeuristics(&fusion, {input}, tv1);
   TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
   cuda::scheduleReduction(&fusion, reduction_params.value(), tv1, {});
@@ -5102,7 +5101,6 @@ void testGPU_FusionReductionSchedulerMultiDimFastest() {
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input = at::randn(tensor_dims_in, options);
 
-  const at::ArrayRef<c10::IValue> inputs({input});
   auto reduction_params = cuda::getReductionHeuristics(&fusion, {input}, tv1);
   TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
   cuda::scheduleReduction(&fusion, reduction_params.value(), tv1, {});
@@ -6901,4 +6899,4 @@ void testGPU_FusionInputsIdLookup() {
 } // namespace jit
 } // namespace torch
 
-// #endif // #if defined(USE_CUDA)
+#endif // #if defined(USE_CUDA)

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_CUDA)
+// #if defined(USE_CUDA)
 
 #include <test/cpp/jit/test_base.h>
 
@@ -2381,12 +2381,8 @@ void test_op(
       op_str,
       " -- had a mismatch.",
       aten_inputs_to_str(),
-      "\nJIT: ",
-      output,
-      "\nREF: ",
-      ref_output,
-      "\nDIFF: ",
-      diff,
+      "\nABS MAX DIFF: ",
+      output.sub(ref_output).abs().max(),
       "\n");
 }
 
@@ -2712,14 +2708,8 @@ void testGPU_FusionCastOps() {
       "\nOp Type: -- ",
       "cast FP16->FP32->FP16",
       " -- had a mismatch.\n",
-      "IN1 : ",
-      input1,
-      "\n",
-      "JIT: ",
-      outputs[0],
-      "\n",
-      "REF: ",
-      ref_output,
+      "\nABS MAX DIFF: ",
+      outputs[0].sub(ref_output).abs().max(),
       "\n");
 }
 
@@ -4982,16 +4972,14 @@ void testGPU_FusionReductionScheduler() {
   at::Tensor input = at::randn({bid_x, tid_x}, options);
 
   // Apply reduction heuristic
-  const at::ArrayRef<c10::IValue> inputs({input});
-
-  const auto rparams = cuda::getReductionHeuristics(&fusion, inputs, tv1);
-  TORCH_CHECK(rparams.has_value(), "Reduction heuristics was not generated!");
-  cuda::scheduleReduction(&fusion, rparams.value(), tv1, {});
+  auto reduction_params = cuda::getReductionHeuristics(&fusion, {input}, tv1);
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  cuda::scheduleReduction(&fusion, reduction_params.value(), tv1, {});
 
   cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
   // no broadcasting needed, omitting the last optional argument;
-  auto outputs = fe.runFusion({input});
+  auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
   auto aten_output = input.sum({red_dim});
 
   TORCH_CHECK(
@@ -5076,14 +5064,13 @@ void testGPU_FusionReductionSchedulerMultiDimNonFastest() {
 
   // Apply reduction heuristic
   const at::ArrayRef<c10::IValue> inputs({input});
-
-  const auto rparams = cuda::getReductionHeuristics(&fusion, inputs, tv1);
-  TORCH_CHECK(rparams.has_value(), "Reduction heuristics was not generated!");
-  cuda::scheduleReduction(&fusion, rparams.value(), tv1, {});
+  auto reduction_params = cuda::getReductionHeuristics(&fusion, {input}, tv1);
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  cuda::scheduleReduction(&fusion, reduction_params.value(), tv1, {});
 
   torch::jit::fuser::cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
-  auto outputs = fe.runFusion({input});
+  auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
 
   auto aten_output = input.sum(red_dims64);
 
@@ -5115,13 +5102,14 @@ void testGPU_FusionReductionSchedulerMultiDimFastest() {
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input = at::randn(tensor_dims_in, options);
 
-  const auto rparams = cuda::getReductionHeuristics(&fusion, {input}, tv1);
-  TORCH_CHECK(rparams.has_value(), "Reduction heuristics was not generated!");
-  cuda::scheduleReduction(&fusion, rparams.value(), tv1, {});
+  const at::ArrayRef<c10::IValue> inputs({input});
+  auto reduction_params = cuda::getReductionHeuristics(&fusion, {input}, tv1);
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  cuda::scheduleReduction(&fusion, reduction_params.value(), tv1, {});
 
   torch::jit::fuser::cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
-  auto outputs = fe.runFusion({input});
+  auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
 
   auto aten_output = input.sum(red_dims64);
 
@@ -5179,28 +5167,28 @@ void testGPU_FusionReductionSchedulerDimShmoo() {
               (axis ? at::randn({odim, rdim}, options)
                     : at::randn({rdim, odim}, options));
 
-          const at::ArrayRef<c10::IValue> inputs({input});
           std::vector<TensorView*> outputs_of_red;
           if (fp16) {
             outputs_of_red.push_back(tv1_cast);
           }
-          const auto rparams =
-              cuda::getReductionHeuristics(&fusion, inputs, tv1);
-          TORCH_CHECK(
-              rparams.has_value(), "Reduction heuristics was not generated!");
+
+          auto reduction_params =
+              cuda::getReductionHeuristics(&fusion, {input}, tv1);
+          TORCH_CHECK(reduction_params.has_value(), "Reduction is not found!");
           cuda::scheduleReduction(
-              &fusion, rparams.value(), tv1, outputs_of_red);
+              &fusion, reduction_params.value(), tv1, outputs_of_red);
 
           torch::jit::fuser::cuda::FusionExecutor fe;
           fe.compileFusion(&fusion);
 
-          auto cg_output = fe.runFusion({input});
+          auto outputs =
+              fe.runFusion({input}, reduction_params.value().lparams);
           auto aten_output = input.sum({axis});
 
           TORCH_CHECK(
-              aten_output.allclose(cg_output[0], 1e-03, 1e-03),
+              aten_output.allclose(outputs[0], 1e-03, 1e-03),
               "Error of: ",
-              aten_output.sub(cg_output[0]).abs().max());
+              aten_output.sub(outputs[0]).abs().max());
         }
       }
     }
@@ -6838,14 +6826,28 @@ void testGPU_FusionReductionHalf() {
       at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor input = at::randn({8, 8, 16}, options);
 
-  const auto rparams = cuda::getReductionHeuristics(&fusion, {input}, tv3);
-  TORCH_CHECK(rparams.has_value(), "Reduction heuristics was not generated!");
-  cuda::scheduleReduction(&fusion, rparams.value(), tv3, {tv4});
+  auto reduction_tv = tv3;
+
+  auto outputsOfReduction = DependencyCheck::getAllOutputsOf({reduction_tv});
+
+  // Grab only tensor views, though there shouldn't be any other type
+  auto tv_entries = ir_utils::filterByType<TensorView>(outputsOfReduction);
+
+  std::vector<TensorView*> tvOutputsOfReduction(
+      tv_entries.begin(), tv_entries.end());
+
+  auto reduction_params =
+      cuda::getReductionHeuristics(&fusion, {input}, reduction_tv);
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  cuda::scheduleReduction(
+      &fusion, reduction_params.value(), reduction_tv, tvOutputsOfReduction);
+
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
 
   cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
   // no broadcasting needed, omitting the last optional argument;
-  auto outputs = fe.runFusion({input});
+  auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
 
   auto aten_output = input.to(c10::ScalarType::Float)
                          .add(1.0)
@@ -6899,4 +6901,4 @@ void testGPU_FusionInputsIdLookup() {
 } // namespace jit
 } // namespace torch
 
-#endif // #if defined(USE_CUDA)
+// #endif // #if defined(USE_CUDA)

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -266,14 +266,6 @@ void Fusion::addOutput(Val* output) {
   assertInFusion(output, "Cannot register output ");
   if (output->getValType().value() == ValType::TensorView) {
     auto tv = output->as<TensorView>();
-    if (TensorDomain::hasBroadcast(tv->getRootDomain())) {
-      // Go to the root as we can merge bcast and
-      // non-bcast dims, making a non-bcast dim.
-      TORCH_INTERNAL_ASSERT( // Should we warn instead?
-          false,
-          output,
-          " cannot be registered as an output as it has a broadcast axis.");
-    }
     tv->setMemoryType(MemoryType::Global);
   }
   outputs_.push_back(output);

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -388,16 +388,16 @@ void scheduleReduction(
       //                --------------------------------
       //                Reduction Dimensions
       red_tv->split(1, rparams.loop_unroll);
-      red_tv->split(1, rparams.lparams.bdimx());
+      red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDx));
 
       // Output Splits
       //      [|Out-Leftover, Out-PerBlock|, <Reduction Dims>]
       // Idx:  |     0             1      |   2(-2) -- 3(-1)
       //       ----------------------------
       //       Output Dimensions
-      red_tv->split(0, rparams.lparams.bdimy());
+      red_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDy));
       for (auto iter_tv : outs_of_red) {
-        iter_tv->split(0, rparams.lparams.bdimy());
+        iter_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDy));
       }
 
       auto red_tv_rf = red_tv->rFactor({-3, -1});
@@ -445,9 +445,9 @@ void scheduleReduction(
         //                -------------------------------------------------
         //                Reduction Dimensions
         red_tv->split(1, rparams.loop_unroll);
-        red_tv->split(1, rparams.lparams.bdimx());
-        red_tv->split(1, rparams.lparams.bdimy());
-        red_tv->split(1, rparams.lparams.gdimy());
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDx));
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDy));
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::BIDy));
 
         auto red_tv_rf = red_tv->rFactor(
             {-5, -1}); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
@@ -492,8 +492,8 @@ void scheduleReduction(
         //                -----------------------------------------
         //                Reduction Dimensions
         red_tv->split(1, rparams.loop_unroll);
-        red_tv->split(1, rparams.lparams.bdimx());
-        red_tv->split(1, rparams.lparams.bdimy());
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDx));
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDy));
 
         auto red_tv_rf = red_tv->rFactor({-4, -1});
 
@@ -539,8 +539,8 @@ void scheduleReduction(
         // Idx:     0     |   1(-4)       2(-3)     3(-2)   4(-1) |
         //                -----------------------------------------
         //                Reduction Dimensions
-        red_tv->split(1, rparams.lparams.bdimy());
-        red_tv->split(1, rparams.lparams.gdimy());
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDy));
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::BIDy));
         red_tv->split(1, kLoopUnrollSplit);
 
         // Reordering the Unroll dimension eases applying computeAt()
@@ -558,9 +558,9 @@ void scheduleReduction(
         // Idx:  |     0             1      |   2(-4) -- 5(-1)
         //       ----------------------------
         //       Output Dimensions
-        red_tv->split(0, rparams.lparams.bdimx());
+        red_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDx));
         for (auto iter_tv : outs_of_red) {
-          iter_tv->split(0, rparams.lparams.bdimx());
+          iter_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDx));
         }
 
         auto red_tv_rf = red_tv->rFactor({-4, -1});
@@ -606,7 +606,7 @@ void scheduleReduction(
         // Idx:     0     |   1(-3)       2(-2)     3(-1) |
         //                ---------------------------------
         //                Reduction Dimensions
-        red_tv->split(1, rparams.lparams.bdimy());
+        red_tv->split(1, NamedScalar::getParallelDim(ParallelType::TIDy));
         red_tv->split(1, kLoopUnrollSplit);
 
         // Reordering the Unroll dimension eases applying computeAt()
@@ -624,9 +624,9 @@ void scheduleReduction(
         // Idx:  |     0             1      |   2(-3) -- 4(-1)
         //       ----------------------------
         //       Output Dimensions
-        red_tv->split(0, rparams.lparams.bdimx());
+        red_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDx));
         for (auto iter_tv : outs_of_red) {
-          iter_tv->split(0, rparams.lparams.bdimx());
+          iter_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDx));
         }
 
         auto red_tv_rf = red_tv->rFactor({-3, -1});
@@ -666,9 +666,9 @@ void scheduleReduction(
         }
       }
     } else {
-      red_tv->split(0, rparams.lparams.bdimx());
+      red_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDx));
       for (auto iter_tv : outs_of_red) {
-        iter_tv->split(0, rparams.lparams.bdimx());
+        iter_tv->split(0, NamedScalar::getParallelDim(ParallelType::TIDx));
       }
 
       if (!outs_of_red.empty()) {

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -476,8 +476,8 @@ void scheduleReduction(
           iter_tv->axis(0)->parallelize(ParallelType::BIDx);
         }
         red_tv->axis(-1)->parallelize(ParallelType::TIDx);
-        red_tv->axis(-2)->parallelize(ParallelType::BIDy);
-        red_tv->axis(-3)->parallelize(ParallelType::TIDy);
+        red_tv->axis(-2)->parallelize(ParallelType::TIDy);
+        red_tv->axis(-3)->parallelize(ParallelType::BIDy);
 
         // Bind Inputs to Reduction
         for (auto input : fusion->inputsOf(red_tv_rf)) {

--- a/torch/csrc/jit/codegen/cuda/scheduler.h
+++ b/torch/csrc/jit/codegen/cuda/scheduler.h
@@ -15,39 +15,44 @@ TORCH_CUDA_API bool scheduleFusion(
     Fusion* fusion,
     const at::ArrayRef<c10::IValue> inputs);
 
-// Parameters the Reduction Heuristic Generates to describe
-// the optimial schedule
+// Parameters the Reduction Heuristic Generates to describe the optimial
+// schedule. Warning: equal operator is intended for use in caching the kernel
+// associated with these reduction parameteres. It does not check if the launch
+// parameters are equivelent!
 struct ReductionParams {
-  // Reduction Attributes
+  // Reducing inner most dimension?
   bool fastest_dim = true;
+  // Reduce across the block?
   bool cross_block = false;
+  // Reduce across the grid?
   bool cross_grid = false;
+  // Perform multiple reductions per block?
   bool mul_reds_per_blk = false;
-
+  // Unrolling factor
   int loop_unroll = 4;
 
   LaunchParams lparams;
 
+  // Warning: Does not check launch parameters!
   bool operator==(const ReductionParams& other) const {
     bool attr_equal = other.fastest_dim == fastest_dim &&
         other.cross_block == cross_block && other.cross_grid == cross_grid &&
         other.mul_reds_per_blk == mul_reds_per_blk &&
         other.loop_unroll == loop_unroll;
-    return attr_equal && lparams == other.lparams;
+    return attr_equal;
   }
 };
 
+// Warning: Hash is not based on launch parameters!
 class ReductionParamsHash {
  public:
   size_t operator()(const ReductionParams& rp) const {
-    size_t lp_hash = rp.lparams.gdimx() ^ rp.lparams.gdimy() ^
-        rp.lparams.bdimx() ^ rp.lparams.bdimy() ^ rp.loop_unroll;
     constexpr size_t bits = sizeof(std::size_t) * 8;
     size_t attr_hash = static_cast<size_t>(rp.fastest_dim) << (bits - 1) |
         static_cast<size_t>(rp.cross_block) << (bits - 2) |
         static_cast<size_t>(rp.cross_grid) << (bits - 3) |
         static_cast<size_t>(rp.mul_reds_per_blk) << (bits - 4);
-    return lp_hash | attr_hash;
+    return attr_hash;
   }
 };
 


### PR DESCRIPTION
Fix reduction heuristics so we don't recompile and we use the correct launch params.
There's a bug in the reduction dim shmoo test, that didn't exist in the same commit on https://github.com/csarofeen/pytorch/pull/391
