### PR TITLE
Adding value based root map analysis for loop nest sharing

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2083,6 +2083,7 @@ void testGPU_FusionComputeAtNoCommonConsumer() {
   TORCH_CHECK(at::allclose(kernel_tv6, t6));
 }
 
+namespace {
 void checkConcretized(
     TensorView* v0,
     int a0,
@@ -2097,6 +2098,7 @@ void checkConcretized(
         !IterDomain::concretizeDomain(v0->axis(a0))->sameAs(v1->axis(a1)));
   }
 }
+} // namespace
 
 void testGPU_FusionBCastConcretizeBasic() {
   Fusion fusion;
@@ -2160,6 +2162,7 @@ void testGPU_FusionBCastConcretizeRfactor() {
   checkConcretized(tv3, 0, tv5, 0, true);
 }
 
+namespace {
 void checkIdProvedEquivalent(
     TensorView* v0,
     int a0,
@@ -2172,6 +2175,7 @@ void checkIdProvedEquivalent(
     TORCH_CHECK(!IterDomain::proveEquivalent(v0->axis(a0), v1->axis(a1)));
   }
 }
+} // namespace
 
 void testGPU_FusionProveIdEqBasic() {
   Fusion fusion;

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2083,6 +2083,24 @@ void testGPU_FusionComputeAtNoCommonConsumer() {
   TORCH_CHECK(at::allclose(kernel_tv6, t6));
 }
 
+void testGPU_FusionRootMapping(){
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeDummyTensor(2);
+  fusion.addInput(tv0);
+  TensorView* tv1 = makeDummyTensor(3);
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv0,{true,false,false});
+  auto tv3 = add(tv2,tv1);
+
+  fusion.addOutput(tv3);
+ 
+  TORCH_CHECK(TensorDomain::ConcretizeDomain(tv2->axis(0))->sameAs(tv3->axis(0));
+  TORCH_CHECK(TensorDomain::ConcretizeDomain(tv2->axis(0))->sameAs(tv1->axis(0));
+}
+
 void testGPU_FusionScalarInputs() {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2084,71 +2084,154 @@ void testGPU_FusionComputeAtNoCommonConsumer() {
 }
 
 void testGPU_FusionBCastConcretize() {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  // tv0: [I I]
-  TensorView* tv0 = makeDummyTensor(2);
-
-  // tv1: [I I I]
-  TensorView* tv1 = makeDummyTensor(3);
-
-  fusion.addInput(tv0);
-  fusion.addInput(tv1);
-
-  // tv2*: [B I I]
-  auto tv2_0 = broadcast(tv0, {true, false, false});
-  auto tv2_1 = broadcast(tv0, {true, false, false});
-  auto tv2 = add(tv2_0, tv2_1);
-
-  // tv3: [I I I]
-  auto tv3 = add(tv2, tv1);
-
-  fusion.addOutput(tv3);
-
 #define CHECK_CONCRETIZE(v0, a0, v1, a1) \
   TORCH_CHECK(IterDomain::concretizeDomain(v0->axis(a0))->sameAs(v1->axis(a1)))
 
 #define CHECK_NOCONCRETIZE(v0, a0, v1, a1) \
   TORCH_CHECK(!IterDomain::concretizeDomain(v0->axis(a0))->sameAs(v1->axis(a1)))
-  CHECK_CONCRETIZE(tv2, 0, tv1, 0);
-  CHECK_CONCRETIZE(tv2_0, 0, tv1, 0);
-  CHECK_CONCRETIZE(tv2_1, 0, tv1, 0);
-  CHECK_NOCONCRETIZE(tv2_0, 1, tv1, 0);
-  CHECK_NOCONCRETIZE(tv2_0, 0, tv1, 1);
+
+  /*
+    Test 0 : base test
+  */
+  {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+
+    // tv0: [I I]
+    TensorView* tv0 = makeDummyTensor(2);
+
+    // tv1: [I I I]
+    TensorView* tv1 = makeDummyTensor(3);
+
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
+
+    // tv2*: [B I I]
+    auto tv2_0 = broadcast(tv0, {true, false, false});
+    auto tv2_1 = broadcast(tv0, {true, false, false});
+    auto tv2 = add(tv2_0, tv2_1);
+
+    // tv3: [I I I]
+    auto tv3 = add(tv2, tv1);
+
+    fusion.addOutput(tv3);
+
+    CHECK_CONCRETIZE(tv2, 0, tv1, 0);
+    CHECK_CONCRETIZE(tv2_0, 0, tv1, 0);
+    CHECK_CONCRETIZE(tv2_1, 0, tv1, 0);
+    CHECK_NOCONCRETIZE(tv2_0, 1, tv1, 0);
+    CHECK_NOCONCRETIZE(tv2_0, 0, tv1, 1);
+  }
+
+  /*
+    Test 1 : propagate through reduction and rfactor
+  */
+
+  {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+
+    // both tv0 and tv1 = [I, I]
+    TensorView* tv0 = makeDummyTensor(2);
+    TensorView* tv1 = makeDummyTensor(2);
+
+    //[B,I,I]
+    auto tv2 = broadcast(tv1, {true, false, false});
+
+    //[B,I,R]
+    auto tv3 = sum(tv2, {2});
+
+    auto tv5 = add(tv3, tv1);
+
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
+    fusion.addOutput(tv5);
+
+    // scheduling:
+    //[B,I,R0,R1=128], root = [B,I,R]
+    tv3->split(2, 128);
+
+    // root=[B,I,Irf], rfactor=[B,I,Irf,Rrf]
+    auto tv4 = tv3->rFactor({3});
+
+    CHECK_CONCRETIZE(tv2, 0, tv5, 0);
+    CHECK_CONCRETIZE(tv4, 0, tv5, 0);
+    CHECK_CONCRETIZE(tv3, 0, tv5, 0);
+  }
+
 #undef CHECK_CONCRETIZE
 #undef CHECK_NOCONCRETIZE
 }
 
 void testGPU_FusionProveIdEqual() {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  TensorView* tv0 = makeDummyTensor(2);
-  TensorView* tv1 = makeDummyTensor(2);
-  TensorView* tv2 = makeDummyTensor(3);
-
-  fusion.addInput(tv0);
-  fusion.addInput(tv1);
-  auto tv3 = broadcast(tv0, {true, false, false});
-  auto tv4 = broadcast(tv1, {false, true, false});
-  auto tv5 = add(tv3, tv4);
-  fusion.addOutput(tv5);
-
 #define CHECK_EQUAL(v0, a0, v1, a1) \
   TORCH_CHECK(IterDomain::proveEqual(v0->axis(a0), v1->axis(a1)))
 
 #define CHECK_NOEQUAL(v0, a0, v1, a1) \
   TORCH_CHECK(!IterDomain::proveEqual(v0->axis(a0), v1->axis(a1)))
 
-  CHECK_EQUAL(tv0, 0, tv4, 1);
-  CHECK_EQUAL(tv1, 0, tv4, 0);
-  CHECK_EQUAL(tv1, 1, tv0, 1);
-  CHECK_EQUAL(tv0, 0, tv5, 1);
-  CHECK_EQUAL(tv1, 1, tv5, 2);
-  CHECK_NOEQUAL(tv0, 0, tv1, 0)
-  CHECK_NOEQUAL(tv0, 1, tv1, 0)
-  CHECK_NOEQUAL(tv0, 0, tv1, 1)
+  /*
+    Test 0 : propagate through reduction and rfactor
+  */
+  {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+
+    TensorView* tv0 = makeDummyTensor(2);
+    TensorView* tv1 = makeDummyTensor(2);
+    TensorView* tv2 = makeDummyTensor(3);
+
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
+    auto tv3 = broadcast(tv0, {true, false, false});
+    auto tv4 = broadcast(tv1, {false, true, false});
+    auto tv5 = add(tv3, tv4);
+    fusion.addOutput(tv5);
+
+    CHECK_EQUAL(tv0, 0, tv4, 1);
+    CHECK_EQUAL(tv1, 0, tv4, 0);
+    CHECK_EQUAL(tv1, 1, tv0, 1);
+    CHECK_EQUAL(tv0, 0, tv5, 1);
+    CHECK_EQUAL(tv1, 1, tv5, 2);
+    CHECK_NOEQUAL(tv0, 0, tv1, 0)
+    CHECK_NOEQUAL(tv0, 1, tv1, 0)
+    CHECK_NOEQUAL(tv0, 0, tv1, 1)
+  }
+
+  /*
+    Test 1 : propagate through reduction and rfactor
+  */
+
+  {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+
+    // [I,I]
+    TensorView* tv0 = makeDummyTensor(2);
+    // [I,I,I]
+    TensorView* tv1 = makeDummyTensor(3);
+
+    //[I,I,R]
+    auto tv2 = sum(tv1, {2});
+
+    auto tv5 = add(tv2, tv0);
+
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
+    fusion.addOutput(tv5);
+
+    // scheduling:
+    //[B,I,R0,R1=128], root = [B,I,R]
+    tv2->split(2, 128);
+
+    // root=[B,I,Irf], rfactor=[B,I,Irf,Rrf]
+    auto tv3 = tv2->rFactor({3});
+
+    CHECK_EQUAL(tv1, 0, tv0, 0);
+    CHECK_EQUAL(tv2, 0, tv0, 0);
+    CHECK_EQUAL(tv3, 0, tv0, 0);
+  }
+
 #undef CHECK_EQUAL
 #undef CHECK_NOEQUAL
 }

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2084,6 +2084,7 @@ void testGPU_FusionComputeAtNoCommonConsumer() {
 }
 
 namespace {
+
 void checkConcretized(
     TensorView* v0,
     int a0,
@@ -2098,6 +2099,7 @@ void checkConcretized(
         !IterDomain::concretizeDomain(v0->axis(a0))->sameAs(v1->axis(a1)));
   }
 }
+
 } // namespace
 
 void testGPU_FusionBCastConcretizeBasic() {
@@ -2163,6 +2165,7 @@ void testGPU_FusionBCastConcretizeRfactor() {
 }
 
 namespace {
+
 void checkIdProvedEquivalent(
     TensorView* v0,
     int a0,
@@ -2175,6 +2178,7 @@ void checkIdProvedEquivalent(
     TORCH_CHECK(!IterDomain::proveEquivalent(v0->axis(a0), v1->axis(a1)));
   }
 }
+
 } // namespace
 
 void testGPU_FusionProveIdEqBasic() {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2160,16 +2160,16 @@ void testGPU_FusionBCastConcretizeRfactor() {
   checkConcretized(tv3, 0, tv5, 0, true);
 }
 
-void checkIdProvedEqual(
+void checkIdProvedEquivalent(
     TensorView* v0,
     int a0,
     TensorView* v1,
     int a1,
     bool should_prove) {
   if (should_prove) {
-    TORCH_CHECK(IterDomain::proveEqual(v0->axis(a0), v1->axis(a1)));
+    TORCH_CHECK(IterDomain::proveEquivalent(v0->axis(a0), v1->axis(a1)));
   } else {
-    TORCH_CHECK(!IterDomain::proveEqual(v0->axis(a0), v1->axis(a1)));
+    TORCH_CHECK(!IterDomain::proveEquivalent(v0->axis(a0), v1->axis(a1)));
   }
 }
 
@@ -2188,14 +2188,14 @@ void testGPU_FusionProveIdEqBasic() {
   auto tv5 = add(tv3, tv4);
   fusion.addOutput(tv5);
 
-  checkIdProvedEqual(tv0, 0, tv4, 1, true);
-  checkIdProvedEqual(tv1, 0, tv4, 0, true);
-  checkIdProvedEqual(tv1, 1, tv0, 1, true);
-  checkIdProvedEqual(tv0, 0, tv5, 1, true);
-  checkIdProvedEqual(tv1, 1, tv5, 2, true);
-  checkIdProvedEqual(tv0, 0, tv1, 0, false);
-  checkIdProvedEqual(tv0, 1, tv1, 0, false);
-  checkIdProvedEqual(tv0, 0, tv1, 1, false);
+  checkIdProvedEquivalent(tv0, 0, tv4, 1, true);
+  checkIdProvedEquivalent(tv1, 0, tv4, 0, true);
+  checkIdProvedEquivalent(tv1, 1, tv0, 1, true);
+  checkIdProvedEquivalent(tv0, 0, tv5, 1, true);
+  checkIdProvedEquivalent(tv1, 1, tv5, 2, true);
+  checkIdProvedEquivalent(tv0, 0, tv1, 0, false);
+  checkIdProvedEquivalent(tv0, 1, tv1, 0, false);
+  checkIdProvedEquivalent(tv0, 0, tv1, 1, false);
 }
 
 void testGPU_FusionProveIdEqRfactor() {
@@ -2223,9 +2223,9 @@ void testGPU_FusionProveIdEqRfactor() {
   // root=[B,I,Irf], rfactor=[B,I,Irf,Rrf]
   auto tv3 = tv2->rFactor({3});
 
-  checkIdProvedEqual(tv1, 0, tv0, 0, true);
-  checkIdProvedEqual(tv2, 0, tv0, 0, true);
-  checkIdProvedEqual(tv3, 0, tv0, 0, true);
+  checkIdProvedEquivalent(tv1, 0, tv0, 0, true);
+  checkIdProvedEquivalent(tv2, 0, tv0, 0, true);
+  checkIdProvedEquivalent(tv3, 0, tv0, 0, true);
 }
 
 void testGPU_FusionScalarInputs() {

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -159,8 +159,10 @@ namespace jit {
   _(GPU_FusionComputeAtCommonConsumer3)             \
   _(GPU_FusionComputeAtNoCommonConsumer)            \
   _(GPU_FusionScalarInputs)                         \
-  _(GPU_FusionBCastConcretize)                      \
-  _(GPU_FusionProveIdEqual)                         \
+  _(GPU_FusionBCastConcretizeBasic)                 \
+  _(GPU_FusionBCastConcretizeRfactor)               \
+  _(GPU_FusionProveIdEqBasic)                       \
+  _(GPU_FusionProveIdEqRfactor)                     \
   _(GPU_FusionRFactorReplay)                        \
   _(GPU_FusionReduction)                            \
   _(GPU_FusionReduction2)                           \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -159,7 +159,8 @@ namespace jit {
   _(GPU_FusionComputeAtCommonConsumer3)             \
   _(GPU_FusionComputeAtNoCommonConsumer)            \
   _(GPU_FusionScalarInputs)                         \
-  _(GPU_FusionRootMapping)                          \
+  _(GPU_FusionBCastConcretize)                      \
+  _(GPU_FusionProveIdEqual)                         \
   _(GPU_FusionRFactorReplay)                        \
   _(GPU_FusionReduction)                            \
   _(GPU_FusionReduction2)                           \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -159,6 +159,7 @@ namespace jit {
   _(GPU_FusionComputeAtCommonConsumer3)             \
   _(GPU_FusionComputeAtNoCommonConsumer)            \
   _(GPU_FusionScalarInputs)                         \
+  _(GPU_FusionRootMapping)                          \
   _(GPU_FusionRFactorReplay)                        \
   _(GPU_FusionReduction)                            \
   _(GPU_FusionReduction2)                           \

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -257,6 +257,12 @@ class TORCH_CUDA_API IterDomain : public Val {
   // directly, users should not be able to use this call
   static std::pair<IterDomain*, IterDomain*> split(IterDomain* in, Val* factor);
 
+  // run concretization pass and return the concretized domain of broadcast id
+  static const IterDomain* concretizeDomain(IterDomain* bcastDom);
+
+  // attempt to prove 2 IterDomains are equal in start and rawExtent
+  static bool proveEqual(IterDomain* a, IterDomain* b);
+
   bool isReduction() const {
     return getIterType() == IterType::Reduction;
   }
@@ -513,10 +519,6 @@ class TORCH_CUDA_API TensorDomain : public Val {
             consumer->getRootDomain().begin(),
             consumer->getRootDomain().end()));
   }
-
-  // runs concretize domain pass and returns the concretized map of
-  // broadcast domain
-  static const IterDomain* ConcretizeDomain(IterDomain* bcastDom);
 
   // Create a map from producer root IterDomains -> consumer root IterDomains.
   // Only those root producer IDs present in producer_maybe_rfactor_dims_to_map

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -261,7 +261,7 @@ class TORCH_CUDA_API IterDomain : public Val {
   static const IterDomain* concretizeDomain(IterDomain* bcast_dom);
 
   // Attempt to prove 2 IterDomains are equal in start and rawExtent
-  static bool proveEqual(IterDomain* a, IterDomain* b);
+  static bool proveEquivalent(IterDomain* a, IterDomain* b);
 
   bool isReduction() const {
     return getIterType() == IterType::Reduction;

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -514,6 +514,10 @@ class TORCH_CUDA_API TensorDomain : public Val {
             consumer->getRootDomain().end()));
   }
 
+  // runs concretize domain pass and returns the concretized map of
+  // broadcast domain
+  static const IterDomain* ConcretizeDomain(IterDomain* bcastDom);
+
   // Create a map from producer root IterDomains -> consumer root IterDomains.
   // Only those root producer IDs present in producer_maybe_rfactor_dims_to_map
   // will be attempted to map to their corresponding consumer IDs.

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -257,10 +257,10 @@ class TORCH_CUDA_API IterDomain : public Val {
   // directly, users should not be able to use this call
   static std::pair<IterDomain*, IterDomain*> split(IterDomain* in, Val* factor);
 
-  // run concretization pass and return the concretized domain of broadcast id
+  // Run concretization pass and return the concretized domain of broadcast id
   static const IterDomain* concretizeDomain(IterDomain* bcast_dom);
 
-  // attempt to prove 2 IterDomains are equal in start and rawExtent
+  // Attempt to prove 2 IterDomains are equal in start and rawExtent
   static bool proveEqual(IterDomain* a, IterDomain* b);
 
   bool isReduction() const {

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -258,7 +258,7 @@ class TORCH_CUDA_API IterDomain : public Val {
   static std::pair<IterDomain*, IterDomain*> split(IterDomain* in, Val* factor);
 
   // run concretization pass and return the concretized domain of broadcast id
-  static const IterDomain* concretizeDomain(IterDomain* bcastDom);
+  static const IterDomain* concretizeDomain(IterDomain* bcast_dom);
 
   // attempt to prove 2 IterDomains are equal in start and rawExtent
   static bool proveEqual(IterDomain* a, IterDomain* b);

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1086,8 +1086,9 @@ class DisjointSet {
   //!          will return false if any of a or b doesn't
   //!          have an equivalent class recorded
   bool areEquivalent(T a, T b) const {
-    if (!entry_map.count(a) || !entry_map.count(b))
+    if (!entry_map.count(a) || !entry_map.count(b)) {
       return false;
+    }
     return fixedPoint(a) == fixedPoint(b);
   }
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1054,6 +1054,7 @@ class DisjointSet {
   //!          will create a new equivalent class if b does
   //!          not belong to any
   void join(T a, T b) {
+    // cases where either of the quiv class doesn't exist
     if (!entry_map.count(a) && !entry_map.count(b)) {
       createPoint(a);
       entry_map[b] = fixedPoint(a);
@@ -1062,6 +1063,7 @@ class DisjointSet {
     } else if (!entry_map.count(b)) {
       entry_map[b] = fixedPoint(a);
     } else {
+      // case where both equiv classes exist and need to join
       const int i0 = fixedPoint(a);
       const int i1 = fixedPoint(b);
       int new_parent = 0;
@@ -1094,12 +1096,11 @@ class DisjointSet {
 
  private:
   // Internal fixed point implementation:
-  //  returns the equivalent class that e belongs to
-  //  does adhoc optimization to speed up future access
+  //  Returns the equivalent class that e belongs to
   int fixedPoint(int e) const {
     TORCH_INTERNAL_ASSERT(set_map.size() > e);
     while (set_map[e] != e) {
-      // chasing to fixed point
+      // Chasing to fixed point
       e = set_map[e];
     }
     return e;
@@ -1107,7 +1108,7 @@ class DisjointSet {
 
   //! Utility to check the class i belongs to:
   //!
-  //! will create a new class if no match seen
+  //! Will create a new class if no match seen
   //! \param e element e to find the equiv class for
   //! \returns the equivalent class that e belongs to
   //!
@@ -1132,14 +1133,14 @@ class DisjointSet {
   // Internal representation of the equivalence class as integers
   // set_map implements the "parent" relationship
   std::vector<int> set_map;
-  // weights is used for preliminary perf optimization
+  // Weights is used for preliminary perf optimization
   std::vector<int> weights;
 
   // Map the input of type T to its equivalence class
   std::unordered_map<T, int> entry_map;
 
   // Running counter for generating new index when
-  // creating new equiv classes
+  // Creating new equiv classes
   int next_index_ = 0;
 };
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1197,19 +1197,19 @@ class ConcretizeDomain : private BackwardVisitor {
   }
 
   void handle(ReductionOp* rop) override {
-    concretizePwOp(rop->asExpr());
+    concretizePwOp(rop);
   }
 
   void handle(UnaryOp* uop) override {
-    concretizePwOp(uop->asExpr());
+    concretizePwOp(uop);
   }
 
   void handle(BinaryOp* bop) override {
-    concretizePwOp(bop->asExpr());
+    concretizePwOp(bop);
   }
 
   void handle(TernaryOp* top) override {
-    concretizePwOp(top->asExpr());
+    concretizePwOp(top);
   };
 
  private:
@@ -1263,10 +1263,12 @@ class ProveValEqual : private IterVisitor {
   //! \returns Boolean representing if they are proven to be
   //!          equal based on scalar check and graph traversal
   bool areEqual(Val* a, Val* b) const {
-    if (ScalarCheck::sameAs(a, b))
+    if (ScalarCheck::sameAs(a, b)) {
       return true;
-    if (eq_set_.areEquivalent(a, b))
+    }
+    if (eq_set_.areEquivalent(a, b)) {
       return true;
+    }
     return false;
   }
 
@@ -1283,8 +1285,9 @@ class ProveValEqual : private IterVisitor {
   //!          equivalent in the sense that they have equal
   //!          start and extent
   bool areEquivalent(IterDomain* a, IterDomain* b) const {
-    if (a->sameAs(b))
+    if (a->sameAs(b)) {
       return true;
+    }
 
     // Abort on un-concretized domains, this can appear once we
     // allow broadcast on fusion output
@@ -1324,19 +1327,19 @@ class ProveValEqual : private IterVisitor {
   }
 
   void handle(ReductionOp* rop) override {
-    provePwOp(rop->asExpr());
+    provePwOp(rop);
   }
 
   void handle(UnaryOp* uop) override {
-    provePwOp(uop->asExpr());
+    provePwOp(uop);
   }
 
   void handle(BinaryOp* bop) override {
-    provePwOp(bop->asExpr());
+    provePwOp(bop);
   }
 
   void handle(TernaryOp* top) override {
-    provePwOp(top->asExpr());
+    provePwOp(top);
   }
 
  private:

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1064,7 +1064,8 @@ class DisjointSet {
     } else {
       const int i0 = fixedPoint(a);
       const int i1 = fixedPoint(b);
-      int new_parent, new_child;
+      int new_parent = 0;
+      int new_child = 0;
 
       // Either order here is correct but joining larger class to smaller class
       // tend to be faster
@@ -1279,7 +1280,7 @@ class ProveValEqual : private IterVisitor {
   //! \returns Boolean representing if they are proven to be
   //!          equivalent in the sense that they have equal
   //!          start and extent
-  bool areEqual(IterDomain* a, IterDomain* b) const {
+  bool areEquivalent(IterDomain* a, IterDomain* b) const {
     if (a->sameAs(b))
       return true;
 
@@ -1351,10 +1352,10 @@ const IterDomain* IterDomain::concretizeDomain(IterDomain* bcast_dom) {
 // API call to check if two IterDomains are equal
 // checks start and extent, contains both scalar check and graph traversal
 // broadcast domains are concretized before comparing
-bool IterDomain::proveEqual(IterDomain* a, IterDomain* b) {
+bool IterDomain::proveEquivalent(IterDomain* a, IterDomain* b) {
   TORCH_INTERNAL_ASSERT(a->fusion() == b->fusion());
   ProveValEqual pve(a->fusion());
-  return pve.areEqual(a, b);
+  return pve.areEquivalent(a, b);
 }
 
 Split::Split(

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1034,7 +1034,7 @@ namespace {
 
 //! Container class DisjointSet models equivalence relationships
 //!
-//! each instance of this class keeps a set of equivalent classes
+//! Each instance of this class keeps a set of equivalent classes
 //! DisjointSet::join(a,b) makes the full class of a and b equivalent
 //! DisjointSet::areEqual(a,b) checks if a and b belong same class
 //!
@@ -1047,10 +1047,10 @@ class DisjointSet {
   //! Joins the equivalent class that a and b belong to
   //! areEqual(a',b') will be true for each a'=a and b'=b
   //!
-  //! \param a an element from a equivalent class
+  //! \param a An element from a equivalent class
   //!          will create a new equivalent class if a does
   //!          not belong to any
-  //! \param b an element from another equivalent class
+  //! \param b An element from another equivalent class
   //!          will create a new equivalent class if b does
   //!          not belong to any
   void join(T a, T b) {
@@ -1066,7 +1066,7 @@ class DisjointSet {
       const int i1 = fixedPoint(b);
       int new_parent, new_child;
 
-      // either order here is correct but joining larger class to smaller class
+      // Either order here is correct but joining larger class to smaller class
       // tend to be faster
       std::tie(new_parent, new_child) = (weights[i0] < weights[i1])
           ? std::make_pair(i0, i1)
@@ -1078,9 +1078,9 @@ class DisjointSet {
 
   //! Checks if a and b belong to the same equivalent class
   //!
-  //! \param a an element from a equivalent class
-  //! \param b an element from another equivalent class
-  //! \returns boolean value representing if a and b are
+  //! \param a An element from a equivalent class
+  //! \param b An element from another equivalent class
+  //! \returns Boolean value representing if a and b are
   //!          recorded to be in the same equivalent class
   //!          will return false if any of a or b doesn't
   //!          have an equivalent class recorded
@@ -1104,7 +1104,8 @@ class DisjointSet {
   // creating new equiv classes
   int next_index_ = 0;
 
-  // internal fixed point implementation:
+ private:
+  // Internal fixed point implementation:
   //  returns the equivalent class that e belongs to
   //  does adhoc optimization to speed up future access
   int fixedPoint(int e) const {
@@ -1116,23 +1117,23 @@ class DisjointSet {
     return e;
   }
 
-  //! utility to check the class i belongs to:
+  //! Utility to check the class i belongs to:
   //!
   //! will create a new class if no match seen
   //! \param i element i to find the equiv class for
   //! \returns the equivalent class that e belongs to
   //!
   int fixedPoint(T i) const {
-    // handles case when i doesn't have an equivalence class
+    // Handles case when i doesn't have an equivalence class
     TORCH_INTERNAL_ASSERT(entry_map.count(i));
 
-    // use fixed point as a representation for the equiv class
+    // Use fixed point as a representation for the equiv class
     return fixedPoint(entry_map.at(i));
   }
 
-  //! utility to create a new equiv class for i
+  //! Utility to create a new equiv class for i
   //
-  //! \param i element i to create the equiv class for
+  //! \param i Element i to create the equiv class for
   void createPoint(T i) {
     entry_map[i] = next_index_;
     set_map.push_back(next_index_++);
@@ -1147,12 +1148,12 @@ class DisjointSet {
 //! inspecting pointwise ops, e.g. : T2 [i0,i1] = T1[i0,B0] + T0[i0,i1]
 //! will concretize axis B0 to i1
 //!
-class ConcretizeDomain : public BackwardVisitor {
+class ConcretizeDomain : private BackwardVisitor {
  public:
-  //! traverses the graph backward from outputs
+  //! Traverses the graph backward from outputs
   //! to identify all concretizing opportunities
   //!
-  ConcretizeDomain(Fusion* fusion) {
+  explicit ConcretizeDomain(Fusion* fusion) {
     traverseFrom(fusion, fusion->outputs(), false);
   }
 
@@ -1162,18 +1163,18 @@ class ConcretizeDomain : public BackwardVisitor {
   static const IterDomain* getConcreteDomain(IterDomain* bcast_dom) {
     ConcretizeDomain cd(bcast_dom->fusion());
 
-    // remove this assertion once we support broadcast on output
+    // Remove this assertion once we support broadcast on output
     TORCH_INTERNAL_ASSERT(cd.canConcretize(bcast_dom));
     return cd.concretized(bcast_dom);
   }
 
-  // returns true if either id is not a broadcast or
+  // Returns true if either id is not a broadcast or
   // the traversal has found a concretized axis for id
   bool canConcretize(IterDomain* id) const {
     return !id->isBroadcast() || bcast_domain_map_.count(id);
   }
 
-  // returns the concretized id recorded from traversal
+  // Returns the concretized id recorded from traversal
   IterDomain* concretized(IterDomain* id) const {
     TORCH_INTERNAL_ASSERT(canConcretize(id));
     if (!id->isBroadcast())
@@ -1185,11 +1186,12 @@ class ConcretizeDomain : public BackwardVisitor {
   using MapType = std::unordered_map<IterDomain*, IterDomain*>;
   MapType bcast_domain_map_;
 
-  // utility to inspect a pointwise operator and
+ private:
+  // Utility to inspect a pointwise operator and
   // record concretize opportunities
   void concretizePwOp(Expr* e);
 
-  // utility to record new concretize opportunity
+  // Utility to record new concretize opportunity
   void concretizeTo(IterDomain* id, IterDomain* To) {
     TORCH_INTERNAL_ASSERT(id->isBroadcast() && !To->isBroadcast());
     bcast_domain_map_[id] = concretized(To);
@@ -1215,7 +1217,6 @@ class ConcretizeDomain : public BackwardVisitor {
 void ConcretizeDomain::concretizePwOp(Expr* e) {
   TensorView* tv = *ir_utils::filterByType<TensorView>(e->outputs()).begin();
 
-  // won't use this function on a reduction op, so root domain only
   std::vector<IterDomain*> io = tv->getRootDomain();
 
   for (auto* i : ir_utils::filterByType<TensorView>(e->inputs())) {
@@ -1231,7 +1232,7 @@ void ConcretizeDomain::concretizePwOp(Expr* e) {
         concretizeTo(ii[it], concretized(io[it]));
     }
   }
-} // ConcretizeDomain::pointWiseOpMap
+}
 
 //! Models equality provable by the graph
 //!
@@ -1242,21 +1243,21 @@ void ConcretizeDomain::concretizePwOp(Expr* e) {
 //!    i2.start = i4.start, i2.extent = i4.extent
 //! Depends on ConcretizeDomain, and equalities involving
 //! broadcast domains are defined based on the concretized version
-class ProveValEqual : public IterVisitor {
+class ProveValEqual : private IterVisitor {
  public:
-  ProveValEqual(Fusion* fusion) : cd_(fusion) {
+  explicit ProveValEqual(Fusion* fusion) : cd_(fusion) {
     traverseFrom(fusion, fusion->outputs(), false);
   }
 
-  //! checks if two scalars are equal
+  //! Checks if two scalars are equal
   //!
-  //! first checks if ScalarCheck has them equal,
+  //! First checks if ScalarCheck has them equal,
   //! next try to prove them equal from
   //! the graph_traversal result
   //!
-  //! \param a a symbolic value
-  //! \param b another value from the same fusion
-  //! \returns boolean representing if they are proven to be
+  //! \param a A symbolic value
+  //! \param b Another value from the same fusion
+  //! \returns Boolean representing if they are proven to be
   //!          equal based on scalar check and graph traversal
   bool areEqual(Val* a, Val* b) const {
     if (ScalarCheck::sameAs(a, b))
@@ -1266,53 +1267,52 @@ class ProveValEqual : public IterVisitor {
     return false;
   }
 
-  //! checks if two iterdomains are equal
+  //! Checks if two iterdomains are equal
   //!
-  //! equality defined as equal start and equal extent
+  //! Equality defined as equal start and equal extent
   //! true means a and b are equal
   //! false only means that they cannot be proven equal based
   //! on scalar check and graph traversal
   //!
-  //! \param a an iterdomain
-  //! \param b another iterdomain from the same fusion
-  //! \returns boolean representing if they are proven to be
+  //! \param a An iterdomain
+  //! \param b Another iterdomain from the same fusion
+  //! \returns Boolean representing if they are proven to be
   //!          equivalent in the sense that they have equal
   //!          start and extent
   bool areEqual(IterDomain* a, IterDomain* b) const {
     if (a->sameAs(b))
       return true;
 
-    // abort on un-concretized domains, this can appear once we
+    // Abort on un-concretized domains, this can appear once we
     // allow broadcast on fusion output
     if (!cd_.canConcretize(a) || !cd_.canConcretize(b))
       return false;
 
     auto ac = cd_.concretized(a);
     auto bc = cd_.concretized(b);
-    return (
-        areEqual(ac->start(), bc->start()) &&
-        areEqual(ac->rawExtent(), bc->rawExtent()));
+    return areEqual(ac->start(), bc->start()) &&
+        areEqual(ac->rawExtent(), bc->rawExtent());
   }
 
  private:
   ConcretizeDomain cd_;
   DisjointSet<const Val*> eq_set_;
 
-  // utility class to record new equality found
+ private:
+  // Utility class to record new equality found
   void proveId(IterDomain* a, IterDomain* b) {
-    // assertions ?
     if (!a->sameAs(b)) {
       eq_set_.join(a->start(), b->start());
       eq_set_.join(a->rawExtent(), b->rawExtent());
     }
   }
 
-  // inspect a pointwise op and record the identified equality
+  // Inspect a pointwise op and record the identified equality
   void provePwOp(Expr* e) {
     TensorView* tv = *ir_utils::filterByType<TensorView>(e->outputs()).begin();
     std::vector<IterDomain*> io = tv->getRootDomain();
 
-    // record equalities from output to all the inputs
+    // Record equalities from output to all the inputs
     // ignores un-concretizable broadcasts
     for (auto* i : ir_utils::filterByType<TensorView>(e->inputs())) {
       std::vector<IterDomain*> ii =

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -2,11 +2,10 @@
 #include <torch/csrc/jit/codegen/cuda/ir_cloner.h>
 #include <torch/csrc/jit/codegen/cuda/ir_interface_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_ir.h>
 #include <torch/csrc/jit/codegen/cuda/transform_iter.h>
 #include <torch/csrc/jit/codegen/cuda/transform_rfactor.h>
-
-#include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 
 #include <sstream>
 
@@ -1031,98 +1030,277 @@ std::pair<TensorDomain*, TensorDomain*> TensorDomain::rFactor(
       TransformRFactor::runReplay2(this, axes)};
 }
 
-namespace{
-class ConcretizeDomain : public BackwardVisitor  {
+namespace {
+
+/** \brief Container class DisjointSet models equivalence relationships
+ *  \details each instance of this class keeps a set of equivalent classes
+ *           DisjointSet::join(a,b) makes the full class of a and b equivalent
+ *           DisjointSet::areEqual(a,b) checks if a and b belong same class
+ *
+ */
+template <typename T>
+class DisjointSet {
+ protected:
+  // Internal representation of the equivalence class as integers
+  // SetMap implements the "parent" relationship
+  // Weights is used for preliminary perf optimization
+  std::vector<int> SetMap, Weights;
+
+  // Map the input of type T to its equivalence class
+  std::unordered_map<T, int> EntryMap;
+
+  // Utility for generating new class
+  int count = 0;
 
  public:
- ConcretizeDomain(Fusion* fusion){
-   buildMap(fusion);
- }
+  DisjointSet() = default;
 
- static const IterDomain* getConcreteDomain(IterDomain* bcastDom){
-  ConcretizeDomain CD(bcastDom->fusion());
-  TORCH_INTERNAL_ASSERT(CD.canConcretize(bcastDom));
-  return CD.concretized(bcastDom);
- }
+  /** \brief Joins the equivalent class that a and b belong to
+   *         areEqual(a',b') will be true for each a'=a and b'=b
+   */
+  void join(T a, T b) {
+    int i0 = fixedPoint(a), i1 = fixedPoint(b);
+    int new_parent, new_child;
+
+    // either order here is correct but joining larger class to smaller class
+    // tend to be faster
+    std::tie(new_parent, new_child) = (Weights[i0] < Weights[i1])
+        ? std::make_pair(i0, i1)
+        : std::make_pair(i1, i0);
+    Weights[new_parent] += Weights[new_child];
+    SetMap[new_child] = new_parent;
+  }
+
+  /** \brief Checks if a and b belong to the same equivalent class */
+  bool areEqual(T a, T b) {
+    if (!EntryMap.count(a) || !EntryMap.count(b))
+      return false;
+    return (fixedPoint(a) == fixedPoint(b));
+  }
+
+ private:
+  // internal fixed point implementation:
+  //  returns the equivalent class that e belongs to
+  //  does adhoc optimization to speed up future access
+  int fixedPoint(int e) {
+    TORCH_INTERNAL_ASSERT(SetMap.size() > e);
+    while (SetMap[e] != e)
+      e = SetMap[e] = SetMap[SetMap[e]];
+    return e;
+  }
+
+  // utility to check the class I belongs to:
+  //  returns the equivalent class that e belongs to
+  //  will create a new class if no match seen
+  int fixedPoint(T I) {
+    if (!EntryMap.count(I))
+      createPoint(I);
+    return fixedPoint(EntryMap[I]);
+  }
+
+  // utility to create a new equiv class for I
+  void createPoint(T I) {
+    EntryMap[I] = count;
+    SetMap.push_back(count++);
+    Weights.push_back(1);
+  }
+}; // class DisjoinSet
+
+/** \brief Concretize broadcast axes, i.e. identifying a non-broadcast
+ * IterDomain that the broadcast IterDomain can map to.
+ *  \details This traversal
+ * processes root domains only, concretization works by inspecting pointwise
+ * ops, e.g. : T2 [i0,i1] = T1[i0,B0] + T0[i0,i1] will concretize axis B0 to i1
+ */
+class ConcretizeDomain : public BackwardVisitor {
+ public:
+  /** \brief traverses the graph backward from outputs
+   *         to identify all concretizing opportunities
+   */
+  ConcretizeDomain(Fusion* fusion) {
+    traverseFrom(fusion, fusion->outputs(), true);
+  }
+
+  /** \brief API call to run the concretize pass and return the
+   *        axis that bcastDom concretizes to
+   */
+  static const IterDomain* getConcreteDomain(IterDomain* bcastDom) {
+    ConcretizeDomain CD(bcastDom->fusion());
+
+    // remove this assertion once we support broadcast on output
+    TORCH_INTERNAL_ASSERT(CD.canConcretize(bcastDom));
+    return CD.concretized(bcastDom);
+  }
+
+  // returns true if either id is not a broadcast or
+  // the traversal has found a concretized axis for id
+  bool canConcretize(IterDomain* id) {
+    return !id->isBroadcast() || BcastDomainMap_.count(id);
+  }
+
+  // returns the concretized id recorded from traversal
+  IterDomain* concretized(IterDomain* id) {
+    TORCH_INTERNAL_ASSERT(canConcretize(id));
+    if (!id->isBroadcast())
+      return id;
+    return BcastDomainMap_.at(id);
+  }
 
  protected:
- using MapType = std::unordered_map<IterDomain*,IterDomain*>;
- using EqKeyType = std::pair<Val*,Val*>;
- using EqType = std::unordered_set<EqKeyType>;
- MapType BcastDomainMap_;
- EqType  EqRelation_;
+  using MapType = std::unordered_map<IterDomain*, IterDomain*>;
+  MapType BcastDomainMap_;
 
- void buildMap(Fusion* fusion){
-  traverseFrom(fusion->outputs());
- };
+  // utility to inspect a pointwise operator and
+  // record concretize opportunities
+  void concretizePwOp(Expr* e);
 
- void pointWiseOpMap(Expr* e);
-
- inline bool canConcretize(IterDomain* id){
-  return !id->isBroadcast() || BcastDomainMap_.count(id);
- }
-
- IterDomain* concretized(IterDomain* id){
-  TORCH_INTERNAL_ASSERT(canConcretize(id));
-  if(!id->isBroadcast()) return id;
-  return BcastDomainMap_.at(id);
- }
- 
- IterDomain* concretizeTo(IterDomain* id,IterDomain* To){
-  TORCH_INTERNAL_ASSERT(id->isBroadcast() && !To->isBroadcast());
-  return !id->isBroadcast() || BcastDomainMap_.count(id);
- }
-
- void addEquality(IterDomain* a,IterDomain* b){
-   if(a==b) return;
-    EqRelation_.insert({a->start(),b->start()});
-    EqRelation_.insert({a->extent(),b->extent()});
- };
-
- inline bool canProveEqual(const Val* a,const Val* b){
-  return EqRelation_.count({a,b})|| 
-         EqRelation_.count({b,a});
- }
-
- 
- void handle(BinaryOp* bop) override{
-   pointWiseOpMap(bop->asExpr());
- }
-
- void handle(TernaryOp* top) override{
-  pointWiseOpMap(top->asExpr());
- };
-
-} //class ConcretizeDomain
-
-void ConcretizeDomain::pointWiseOpMap(Expr *e){ 
- TensorView* TVo  = *ir_utils::filterByType<TensorView>(e->outputs()).begin();
-
- //won't use this function on a reduction op, so root domain only
- std::vector<IterDomain*> Io = TVo->getRootDomain();
-
- for(auto i* : ir_utils::filterByType<TensorView>(e->inputs())){
-  std::vector<IterDomain*> Ii = i->getRootDomain();
-  TORCH_INTERNAL_ASSERT(Ii.size()==Io.size());
-
-  for(size_t it=0;it<Ii.size();it++){
-   if(!canConcretize(Io[it])) continue;
-
-   if(!canConcretize(Ii[it]) 
-    concretizeTo(Ii[it],concretized(Io[it]));
-   else(canConcretize(Ii[it] && canConcretize(Io[it])) {
-     auto cIi = concretized(Ii[it]);
-     auto cIo = concretized(Io[it]);
-     if(!cIi->sameAs(cIo)) addEquality(cIi,cIo);
-   }
+  // utility to record new concretize opportunity
+  void concretizeTo(IterDomain* id, IterDomain* To) {
+    TORCH_INTERNAL_ASSERT(id->isBroadcast() && !To->isBroadcast());
+    BcastDomainMap_[id] = concretized(To);
   }
- }
-} //ConcretizeDomain::pointWiseOpMap
+
+  void handle(UnaryOp* uop) override {
+    concretizePwOp(uop->asExpr());
+  }
+
+  void handle(BinaryOp* bop) override {
+    concretizePwOp(bop->asExpr());
+  }
+
+  void handle(TernaryOp* top) override {
+    concretizePwOp(top->asExpr());
+  };
+}; // class ConcretizeDomain
+
+void ConcretizeDomain::concretizePwOp(Expr* e) {
+  TensorView* TVo = *ir_utils::filterByType<TensorView>(e->outputs()).begin();
+
+  // won't use this function on a reduction op, so root domain only
+  std::vector<IterDomain*> Io = TVo->getRootDomain();
+
+  for (auto* i : ir_utils::filterByType<TensorView>(e->inputs())) {
+    std::vector<IterDomain*> Ii = i->getRootDomain();
+    TORCH_INTERNAL_ASSERT(Ii.size() == Io.size());
+
+    for (size_t it = 0; it < Ii.size(); it++) {
+      if (!canConcretize(Io[it]))
+        continue;
+
+      if (!canConcretize(Ii[it]))
+        concretizeTo(Ii[it], concretized(Io[it]));
+    }
+  }
+} // ConcretizeDomain::pointWiseOpMap
+
+/** \brief Models equality provable by the graph
+ *  \details This traversal processes root domains only,
+ *           equalities , e.g. :
+ *           T2 [i0,i1] = T1[i2,i3] + T0[i4,i5]
+ *           will prove that i2 and i4 are equal in the sense that
+ *             i2.start = i4.start, i2.extent = i4.extent
+ *
+ *           Depends on ConcretizeDomain, and equalities involving
+ *           broadcast domains are defined based on the concretized version
+ */
+
+class ProveValEqual : public IterVisitor {
+ public:
+  ProveValEqual(Fusion* fusion) : CD_(fusion) {
+    traverse(fusion, false);
+  }
+
+  /** \brief checks if two scalars are equal
+   *  \details first checks if ScalarCheck has them equal,
+   *           next try to prove them equal from
+   *           the graph_traversal result
+   */
+  bool areEqual(Val* a, Val* b) {
+    if (ScalarCheck::sameAs(a, b))
+      return true;
+    if (EqSet_.areEqual(a, b))
+      return true;
+    return false;
+  }
+
+  /** \brief checks if two iterdomains are equal
+   *  \details equality defined as equal start and equal extent
+   *           true means a and b are equal
+   *           false only means that they cannot be proven equal based
+   *           on scalar check and graph traversal
+   */
+  bool areEqual(IterDomain* a, IterDomain* b) {
+    if (a->sameAs(b))
+      return true;
+
+    // abort on un-concretized domains, this can appear once we
+    // allow broadcast on fusion output
+    if (!CD_.canConcretize(a) || !CD_.canConcretize(b))
+      return false;
+
+    auto ac = CD_.concretized(a);
+    auto bc = CD_.concretized(b);
+    return (
+        areEqual(ac->start(), bc->start()) &&
+        areEqual(ac->rawExtent(), bc->rawExtent()));
+  }
+
+ protected:
+  ConcretizeDomain CD_;
+  DisjointSet<Val*> EqSet_;
+
+  // utility class to record new equality found
+  void proveId(IterDomain* a, IterDomain* b) {
+    // assertions ?
+    if (!a->sameAs(b)) {
+      EqSet_.join(a->start(), b->start());
+      EqSet_.join(a->rawExtent(), b->rawExtent());
+    }
+  }
+
+  // inspect a pointwise op and record the identified equality
+  void provePwOp(Expr* e) {
+    TensorView* TVo = *ir_utils::filterByType<TensorView>(e->outputs()).begin();
+    std::vector<IterDomain*> Io = TVo->getRootDomain();
+
+    // record equalities from output to all the inputs
+    // ignores un-concretizable broadcasts
+    for (auto* i : ir_utils::filterByType<TensorView>(e->inputs())) {
+      std::vector<IterDomain*> Ii = i->getRootDomain();
+
+      for (size_t it = 0; it < Ii.size(); it++)
+        if (CD_.canConcretize(Ii[it]) && CD_.canConcretize(Io[it]))
+          proveId(CD_.concretized(Ii[it]), CD_.concretized(Io[it]));
+    }
+  }
+
+  void handle(UnaryOp* uop) override {
+    provePwOp(uop->asExpr());
+  }
+
+  void handle(BinaryOp* bop) override {
+    provePwOp(bop->asExpr());
+  }
+
+  void handle(TernaryOp* top) override {
+    provePwOp(top->asExpr());
+  }
+}; // class ProveValEqual
 
 } // namespace
 
-const IterDomain* TensorDomain::ConcretizeDomain(IterDomain* bcastDom){
+// API call to return the concretized axis of a broadcast axis
+const IterDomain* IterDomain::concretizeDomain(IterDomain* bcastDom) {
   return ConcretizeDomain::getConcreteDomain(bcastDom);
+}
+
+// API call to check if two IterDomains are equal
+// checks start and extent, contains both scalar check and graph traversal
+// broadcast domains are concretized before comparing
+bool IterDomain::proveEqual(IterDomain* a, IterDomain* b) {
+  TORCH_INTERNAL_ASSERT(a->fusion() == b->fusion());
+  ProveValEqual PVE(a->fusion());
+  return PVE.areEqual(a, b);
 }
 
 Split::Split(

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1100,8 +1100,9 @@ class DisjointSet {
   // Map the input of type T to its equivalence class
   std::unordered_map<T, int> entry_map;
 
-  // Utility for generating new class
-  int count = 0;
+  // Running counter for generating new index when
+  // creating new equiv classes
+  int next_index_ = 0;
 
   // internal fixed point implementation:
   //  returns the equivalent class that e belongs to
@@ -1133,8 +1134,8 @@ class DisjointSet {
   //
   //! \param i element i to create the equiv class for
   void createPoint(T i) {
-    entry_map[i] = count;
-    set_map.push_back(count++);
+    entry_map[i] = next_index_;
+    set_map.push_back(next_index_++);
     weights.push_back(1);
   }
 };

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1134,7 +1134,7 @@ class ConcretizeDomain : public BackwardVisitor {
   // returns true if either id is not a broadcast or
   // the traversal has found a concretized axis for id
   bool canConcretize(IterDomain* id) {
-    return !id->isBroadcast() || BcastDomainMap_.count(id);
+    return !id->isBroadcast() || bCastDomainMap_.count(id);
   }
 
   // returns the concretized id recorded from traversal
@@ -1142,12 +1142,12 @@ class ConcretizeDomain : public BackwardVisitor {
     TORCH_INTERNAL_ASSERT(canConcretize(id));
     if (!id->isBroadcast())
       return id;
-    return BcastDomainMap_.at(id);
+    return bCastDomainMap_.at(id);
   }
 
  private:
   using MapType = std::unordered_map<IterDomain*, IterDomain*>;
-  MapType BcastDomainMap_;
+  MapType bCastDomainMap_;
 
   // utility to inspect a pointwise operator and
   // record concretize opportunities
@@ -1156,7 +1156,7 @@ class ConcretizeDomain : public BackwardVisitor {
   // utility to record new concretize opportunity
   void concretizeTo(IterDomain* id, IterDomain* To) {
     TORCH_INTERNAL_ASSERT(id->isBroadcast() && !To->isBroadcast());
-    BcastDomainMap_[id] = concretized(To);
+    bCastDomainMap_[id] = concretized(To);
   }
 
   void handle(UnaryOp* uop) override {

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1180,8 +1180,9 @@ class ConcretizeDomain : private BackwardVisitor {
   // Returns the concretized id recorded from traversal
   IterDomain* concretized(IterDomain* id) const {
     TORCH_INTERNAL_ASSERT(canConcretize(id));
-    if (!id->isBroadcast())
+    if (!id->isBroadcast()) {
       return id;
+    }
     return bcast_domain_map_.at(id);
   }
 
@@ -1291,8 +1292,9 @@ class ProveValEqual : private IterVisitor {
 
     // Abort on un-concretized domains, this can appear once we
     // allow broadcast on fusion output
-    if (!cd_.canConcretize(a) || !cd_.canConcretize(b))
+    if (!cd_.canConcretize(a) || !cd_.canConcretize(b)) {
       return false;
+    }
 
     auto ac = cd_.concretized(a);
     auto bc = cd_.concretized(b);


### PR DESCRIPTION
This PR adds two utilities under IterDomain: `IterDomain::concretizeDomain` and `IterDomain::proveEqual`. Both are analysis traversals that process the root domains of fusion tensorviews.

**concretizeDomain**

`IterDomain::concretizeDomain` enables mapping from a broadcast axis to a non-broadcast axis, where start and extent variables can be retrieved. The utility traverses the fusion graph backwards and records the concretized version of each broadcast in a map. 

**proveEqual**

`IterDomain::proveEqual` tries to prove 2 IterDomains are equal in the sense that they have the same start and extent.  proveEqual also uses concretizeDomain, when broadcast axes are involved in the comparison.

The start and extent variables are proved equal when 

- ScalarCheck proves them equal i.e. they are either equal constants or the same symbolic variable
- They are used in a point-wise op that requires them to be equal

To establish the equality for the second case, the function traverses the fusion graph and gathers variable equality information into a disjoint set.

