### PR TITLE
[WIP] Persistent Kernel Examples - Old

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5788,8 +5788,6 @@ void testGPU_FusionSmemDynamicPersistentSoftmax2D() {
     tensor->axis(-1)->parallelize(ParallelType::TIDx);
   }
   exp_tv1->setMemoryType(MemoryType::Shared);
-  fusion.printMath();
-  fusion.printKernel();
 
   const size_t dimx = 1024;
   const size_t dimy = 4096;
@@ -5798,7 +5796,7 @@ void testGPU_FusionSmemDynamicPersistentSoftmax2D() {
 
   torch::jit::fuser::cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
-  auto outputs = fe.runFusion({t0});
+  auto outputs = fe.runFusion({t0, 128});
 
   auto t1 = at::_softmax(t0, -1, false);
   TORCH_CHECK(

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5752,6 +5752,75 @@ void testGPU_FusionSmemBlockGemmCache() {
   TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs.size() == 0);
 }
 
+void testGPU_FusionSmemDynamicPersistentSoftmax2D() {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  const size_t tidx = 128;
+
+  // Set up your input tensor views
+  TensorView* input_tv0 = makeDummyTensor(2);
+  fusion.addInput(input_tv0);
+  TensorView* exp_tv1 = unaryOp(UnaryOpType::Exp, input_tv0); // (M, N)
+  TensorView* sum_exp_tv2 = sum(exp_tv1, {-1}); // (M, R)
+  TensorView* bcast_sum_tv3 = broadcast(sum_exp_tv2, {false, true}); // (M, B)
+
+  // Read Input into Shared Memory
+  TensorView* cache_tv4 = exp_tv1->cache_before();
+  cache_tv4->setMemoryType(MemoryType::Shared);
+
+  // Direct read from shared memory cache
+  TensorView* cache_tv5 = unaryOp(UnaryOpType::Set, cache_tv4);
+
+  TensorView* output_tv6 =
+      div(cache_tv5, bcast_sum_tv3); // (M, N) = (M, N) / (M, B)
+  fusion.addOutput(output_tv6);
+
+  // M, N/128, 128
+  exp_tv1->split(-1, tidx);
+  sum_exp_tv2->split(-1, tidx);
+  bcast_sum_tv3->split(-1, tidx);
+  cache_tv4->split(-1, tidx);
+  cache_tv5->split(-1, tidx);
+  output_tv6->split(-1, tidx);
+
+  TensorView* sum_exp_rf_tv6 = sum_exp_tv2->rFactor({1});
+
+  cache_tv4->computeAt(exp_tv1, 1);
+  exp_tv1->computeAt(sum_exp_rf_tv6, -1);
+  sum_exp_rf_tv6->computeAt(sum_exp_tv2, 1);
+  cache_tv5->computeAt(output_tv6, -1);
+
+  TensorView* tensors_to_parallelize[] = {exp_tv1,
+                                          cache_tv4,
+                                          sum_exp_tv2,
+                                          bcast_sum_tv3,
+                                          cache_tv5,
+                                          output_tv6,
+                                          sum_exp_rf_tv6};
+  for (auto tv : tensors_to_parallelize) {
+    tv->axis(0)->parallelize(ParallelType::BIDx);
+    tv->axis(-1)->parallelize(ParallelType::TIDx);
+  }
+
+  const size_t dimx = 1024;
+  const size_t dimy = 4096;
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({dimx, dimy}, options);
+  at::Tensor t3_output = at::empty({dimx, dimy}, options);
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto outputs = fe.runFusion({t0});
+
+  auto t2 = at::_softmax(t0, -1, false);
+  TORCH_CHECK(
+      t2.allclose(outputs[0], 1e-5, 1e-5),
+      "Error of: ",
+      t2.sub(outputs[0]).abs().max());
+}
+
 void testGPU_FusionSmemDynamicReductionSymbolic() {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -207,6 +207,7 @@ namespace jit {
   _(GPU_FusionSmemBlockGemm)                        \
   _(GPU_FusionSmemBlockGemmCache)                   \
   _(GPU_FusionSmemDynamicPersistentSoftmax2D)       \
+  _(GPU_FusionSmemDynamicPersistentBatchNorm)       \
   _(GPU_FusionSmemDynamicReductionSymbolic)         \
   _(GPU_FusionSmemDynamicReductionSymbolicArg)      \
   _(GPU_FusionSmemDynamicPwiseMulSymbolicArgWAR)    \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -206,6 +206,7 @@ namespace jit {
   _(GPU_FusionSmemReduce)                           \
   _(GPU_FusionSmemBlockGemm)                        \
   _(GPU_FusionSmemBlockGemmCache)                   \
+  _(GPU_FusionSmemDynamicPersistentSoftmax2D)       \
   _(GPU_FusionSmemDynamicReductionSymbolic)         \
   _(GPU_FusionSmemDynamicReductionSymbolicArg)      \
   _(GPU_FusionSmemDynamicPwiseMulSymbolicArgWAR)    \

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -637,7 +637,8 @@ void reorderExprsForComputeAt(std::vector<Expr*>& exprs) {
   for (auto& group : computed_at_exprs) {
     sortGroup(group.first, group.second, scores);
     // Reorder expressions in a breadth-first order
-    reorderGroupBreadthFirst(group.second, scores);
+    // Investigate: Disabled for Persistent BatchNorm Kernel
+    // reorderGroupBreadthFirst(group.second, scores);
   }
 
   // 3. Merge non-root loop-nests into root loop-nests


### PR DESCRIPTION
Related  #389 

- [x] Create Persistent Softmax Kernel
- [x] Create Persistent Batch Norm Kernel

**Issue:**
- Disabled [reorderGroupBreadthFirst](https://github.com/csarofeen/pytorch/blob/20_8_18_devel/torch/csrc/jit/codegen/cuda/lower_loops.cpp#L639-L640) because it incorrectly ordered the kernels operations