### PR TITLE
[DO NOT MERGE] Te benchmark extension nv

### DIFF
--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -245,48 +245,49 @@ class DynamicShape(object):
     Pre-computes input with random shapes and also computes
     with random shapes
     '''
-    
+
     # number of random inputs in an instance
     SAMPLE_SIZE = 100
-    
+
     def __init__(self, dynamic_range=1.2):
         self._input_samples = []
         self._input_sample_index = 0
-        self._dynamic_range = 1./dynamic_range if dynamic_range>1.0 else dynamic_range
+        self._dynamic_range = 1. / dynamic_range if dynamic_range > 1.0 else dynamic_range
 
-    # returns the input test case that current index points to 
+    # returns the input test case that current index points to
     @property
     def inputs(self):
         return self._input_samples[self._input_sample_index]
 
     # an inputs assignment actually adds a test case in the class buffer
     @inputs.setter
-    def inputs(self,val):
+    def inputs(self, val):
         self._input_samples.append(val)
-    
+
     # runs normal compute while increment test case index
     def compute(self):
         super().compute()
-        self._input_sample_index = (self._input_sample_index +1) % self.SAMPLE_SIZE
-    
+        self._input_sample_index = (self._input_sample_index + 1) % self.SAMPLE_SIZE
+
     # defined by benchmark
     def instantiate_input(self):
         raise NotImplementedError
 
     # pre-compute inputs so the creations
     def load_inputs(self):
-        for i in range(self.SAMPLE_SIZE-1):
+        for i in range(self.SAMPLE_SIZE - 1):
             self.instantiate_input()
 
     # returns a randomized shape
     def rand_shape(self, shape):
         if 'PYTORCH_CUDA_FUSER_NO_DYNSHAPE' in os.environ:
             return shape
-        ratios = np.random.uniform(self._dynamic_range,1.0,len(shape))
+        ratios = np.random.uniform(self._dynamic_range, 1.0, len(shape))
         dyn_shape = list(
-            np.multiply(shape,ratios).astype(int)
+            np.multiply(shape, ratios).astype(int)
         )
         return dyn_shape
+
 
 benchmark_classes = []
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -237,6 +237,54 @@ def cuda_pointwise_context(loop_levels, block_count, block_size):
     if block_size:
         torch._C._jit_set_te_cuda_pointwise_block_size(old_block_size)
 
+# Auxiliary class to facilitate dynamic input shape
+class DynamicShape(object):
+    r'''
+    An Auxiliary class for dynamic shape benchmarks
+
+    Pre-computes input with random shapes and also computes
+    with random shapes
+    '''
+    
+    # number of random inputs in an instance
+    SAMPLE_SIZE = 100
+    
+    def __init__(self, dynamic_range=1.2):
+        self._input_samples = []
+        self._input_sample_index = 0
+        self._dynamic_range = 1./dynamic_range if dynamic_range>1.0 else dynamic_range
+
+    # returns the input test case that current index points to 
+    @property
+    def inputs(self):
+        return self._input_samples[self._input_sample_index]
+
+    # an inputs assignment actually adds a test case in the class buffer
+    @inputs.setter
+    def inputs(self,val):
+        self._input_samples.append(val)
+    
+    # runs normal compute while increment test case index
+    def compute(self):
+        super().compute()
+        self._input_sample_index = (self._input_sample_index +1) % self.SAMPLE_SIZE
+    
+    # defined by benchmark
+    def instantiate_input(self):
+        raise NotImplementedError
+
+    # pre-compute inputs so the creations
+    def load_inputs(self):
+        for i in range(self.SAMPLE_SIZE-1):
+            self.instantiate_input()
+
+    # returns a randomized shape
+    def rand_shape(self, shape):
+        ratios = np.random.uniform(self._dynamic_range,1.0,len(shape))
+        dyn_shape = list(
+            np.multiply(shape,ratios).astype(int)
+        )
+        return dyn_shape
 
 benchmark_classes = []
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -242,8 +242,9 @@ class DynamicShape(object):
     r'''
     An Auxiliary class for dynamic shape benchmarks
 
-    Pre-computes input with random shapes and also computes
-    with random shapes
+    Pre-computes input with random shapes and also 
+    modifies the compute method so in each call the
+    fuser sees a different input tensor shape
     '''
 
     # number of random inputs in an instance
@@ -269,11 +270,14 @@ class DynamicShape(object):
         super().compute()
         self._input_sample_index = (self._input_sample_index + 1) % self.SAMPLE_SIZE
 
-    # defined by benchmark
+    # defined by benchmark, the benchmark needs to specify the input
+    # tensor construction in this method, essentially the same way
+    # a benchmark creates the inputs list in the initializer
     def instantiate_input(self):
         raise NotImplementedError
 
-    # pre-compute inputs so the creations
+    # pre-compute inputs so the creations of random tensors
+    # do not add to the compute time
     def load_inputs(self):
         for i in range(self.SAMPLE_SIZE - 1):
             self.instantiate_input()

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -280,6 +280,8 @@ class DynamicShape(object):
 
     # returns a randomized shape
     def rand_shape(self, shape):
+        if os.environ['PYTORCH_CUDA_FUSER_NO_DYNSHAPE'] =='1':
+            return shape
         ratios = np.random.uniform(self._dynamic_range,1.0,len(shape))
         dyn_shape = list(
             np.multiply(shape,ratios).astype(int)

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -280,7 +280,7 @@ class DynamicShape(object):
 
     # returns a randomized shape
     def rand_shape(self, shape):
-        if os.environ['PYTORCH_CUDA_FUSER_NO_DYNSHAPE'] =='1':
+        if 'PYTORCH_CUDA_FUSER_NO_DYNSHAPE' in os.environ:
             return shape
         ratios = np.random.uniform(self._dynamic_range,1.0,len(shape))
         dyn_shape = list(

--- a/benchmarks/tensorexpr/elementwise.py
+++ b/benchmarks/tensorexpr/elementwise.py
@@ -159,6 +159,7 @@ def register_element_ops():
 # benchmark.register_benchmark_class(ElementMulBench)
 register_element_ops()
 
+
 class SimpleElementBench(benchmark.Benchmark):
     def __init__(self, mode, device, dtype, N):
         super().__init__(mode, device, dtype)
@@ -207,22 +208,25 @@ class SimpleElementBench(benchmark.Benchmark):
     def default_configs():
         return [[1 << 25]]
 
+
 benchmark.register_benchmark_class(SimpleElementBench)
 
-class DynamicSimpleElementBench(benchmark.DynamicShape,SimpleElementBench):
+
+class DynamicSimpleElementBench(benchmark.DynamicShape, SimpleElementBench):
     def __init__(self, mode, device, dtype, N):
         benchmark.DynamicShape.__init__(self)
-        SimpleElementBench.__init__(self,mode, device, dtype, N)
-        
+        SimpleElementBench.__init__(self, mode, device, dtype, N)
+
         self.load_inputs()
-    
+
     @classmethod
     def module(cls):
         return "dynamic_simple_element"
-    
+
     def instantiate_input(self):
         N, = self.rand_shape([self.N])
         data = self.rand([N], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad)
         self.inputs = [data]
+
 
 benchmark.register_benchmark_class(DynamicSimpleElementBench)

--- a/benchmarks/tensorexpr/elementwise.py
+++ b/benchmarks/tensorexpr/elementwise.py
@@ -208,3 +208,21 @@ class SimpleElementBench(benchmark.Benchmark):
         return [[1 << 25]]
 
 benchmark.register_benchmark_class(SimpleElementBench)
+
+class DynamicSimpleElementBench(benchmark.DynamicShape,SimpleElementBench):
+    def __init__(self, mode, device, dtype, N):
+        benchmark.DynamicShape.__init__(self)
+        SimpleElementBench.__init__(self,mode, device, dtype, N)
+        
+        self.load_inputs()
+    
+    @classmethod
+    def module(cls):
+        return "dynamic_simple_element"
+    
+    def instantiate_input(self):
+        N, = self.rand_shape([self.N])
+        data = self.rand([N], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad)
+        self.inputs = [data]
+
+benchmark.register_benchmark_class(DynamicSimpleElementBench)

--- a/benchmarks/tensorexpr/reduction.py
+++ b/benchmarks/tensorexpr/reduction.py
@@ -156,26 +156,28 @@ benchmark.register_benchmark_class(Reduce2DInnerBench)
 benchmark.register_benchmark_class(Reduce2DOuterBench)
 
 
-class DynamicReduce2DBench(benchmark.DynamicShape,Reduce2DBench):
+class DynamicReduce2DBench(benchmark.DynamicShape, Reduce2DBench):
     '''
     A benchmark class to validate 2 dimensional reduction performance.
     Only a simple add is fused to induce the fuser and isolate reduction perf.
     '''
+
     def __init__(self, mode, device, dtype, red_dim, dim0, dim1):
         benchmark.DynamicShape.__init__(self)
-        Reduce2DBench.__init__(self,mode,device, dtype, red_dim, dim0, dim1)
+        Reduce2DBench.__init__(self, mode, device, dtype, red_dim, dim0, dim1)
         self.load_inputs()
 
     def instantiate_input(self):
-        dim0,dim1 = self.rand_shape([self.dim0,self.dim1])
+        dim0, dim1 = self.rand_shape([self.dim0, self.dim1])
 
         self.inputs = [self.randn(
-                [dim0, dim1], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
-            )]
+            [dim0, dim1], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+        )]
 
     @staticmethod
     def module():
         return "dynamic_reduce2d"
+
 
 class DynamicReduce2DInnerBench(DynamicReduce2DBench):
     def __init__(self, mode, device, dtype, dim0, dim1):
@@ -184,6 +186,7 @@ class DynamicReduce2DInnerBench(DynamicReduce2DBench):
     @staticmethod
     def module():
         return "dynamic_reduce2d_inner"
+
 
 class DynamicReduce2DOuterBench(DynamicReduce2DBench):
     def __init__(self, mode, device, dtype, dim0, dim1):

--- a/benchmarks/tensorexpr/reduction.py
+++ b/benchmarks/tensorexpr/reduction.py
@@ -149,9 +149,49 @@ class Reduce2DOuterBench(Reduce2DBench):
     @staticmethod
     def module():
         return "reduce2d_outer"
-
 benchmark.register_benchmark_class(ReduceRowBench)
 benchmark.register_benchmark_class(ReduceMidBench)
 benchmark.register_benchmark_class(ReduceColBench)
 benchmark.register_benchmark_class(Reduce2DInnerBench)
 benchmark.register_benchmark_class(Reduce2DOuterBench)
+
+
+class DynamicReduce2DBench(benchmark.DynamicShape,Reduce2DBench):
+    '''
+    A benchmark class to validate 2 dimensional reduction performance.
+    Only a simple add is fused to induce the fuser and isolate reduction perf.
+    '''
+    def __init__(self, mode, device, dtype, red_dim, dim0, dim1):
+        benchmark.DynamicShape.__init__(self)
+        Reduce2DBench.__init__(self,mode,device, dtype, red_dim, dim0, dim1)
+        self.load_inputs()
+
+    def instantiate_input(self):
+        dim0,dim1 = self.rand_shape([self.dim0,self.dim1])
+
+        self.inputs = [self.randn(
+                [dim0, dim1], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+            )]
+
+    @staticmethod
+    def module():
+        return "dynamic_reduce2d"
+
+class DynamicReduce2DInnerBench(DynamicReduce2DBench):
+    def __init__(self, mode, device, dtype, dim0, dim1):
+        super().__init__(mode, device, dtype, 1, dim0, dim1)
+
+    @staticmethod
+    def module():
+        return "dynamic_reduce2d_inner"
+
+class DynamicReduce2DOuterBench(DynamicReduce2DBench):
+    def __init__(self, mode, device, dtype, dim0, dim1):
+        super().__init__(mode, device, dtype, 0, dim0, dim1)
+
+    @staticmethod
+    def module():
+        return "dynamic_reduce2d_outer"
+
+benchmark.register_benchmark_class(DynamicReduce2DInnerBench)
+benchmark.register_benchmark_class(DynamicReduce2DOuterBench)

--- a/benchmarks/tensorexpr/rnn_eltwise.py
+++ b/benchmarks/tensorexpr/rnn_eltwise.py
@@ -65,3 +65,44 @@ class RNNEltwise(benchmark.Benchmark):
         return [[64, 512]]
 
 benchmark.register_benchmark_class(RNNEltwise)
+
+
+
+class DynamicLSTM(benchmark.DynamicShape,RNNEltwise):
+    def __init__(self, mode, device, dtype, b, hs):
+        benchmark.DynamicShape.__init__(self)
+        RNNEltwise.__init__(self,mode, device, dtype, b, hs)
+        
+        self.load_inputs()
+        
+    def instantiate_input(self):
+        b,hs = self.rand_shape([self.b,self.hs])
+
+        self.input = self.rand(
+            [b, 4 * hs], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+        )
+        self.hx = self.rand(
+            [b, 4 * hs], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+        )
+        self.cx = self.rand(
+            [b, hs], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+        )
+        self.b_ih = self.rand(
+            [b, 4 * hs], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+        )
+        self.b_hh = self.rand(
+            [b, 4 * hs], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad
+        )
+        self.inputs = [
+            self.input,
+            self.hx,
+            self.cx,
+            self.b_ih,
+            self.b_hh,
+        ]
+
+    @staticmethod
+    def module():
+        return "dynamic_lstm"
+
+benchmark.register_benchmark_class(DynamicLSTM)

--- a/benchmarks/tensorexpr/rnn_eltwise.py
+++ b/benchmarks/tensorexpr/rnn_eltwise.py
@@ -67,16 +67,15 @@ class RNNEltwise(benchmark.Benchmark):
 benchmark.register_benchmark_class(RNNEltwise)
 
 
-
-class DynamicLSTM(benchmark.DynamicShape,RNNEltwise):
+class DynamicLSTM(benchmark.DynamicShape, RNNEltwise):
     def __init__(self, mode, device, dtype, b, hs):
         benchmark.DynamicShape.__init__(self)
-        RNNEltwise.__init__(self,mode, device, dtype, b, hs)
-        
+        RNNEltwise.__init__(self, mode, device, dtype, b, hs)
+
         self.load_inputs()
-        
+
     def instantiate_input(self):
-        b,hs = self.rand_shape([self.b,self.hs])
+        b, hs = self.rand_shape([self.b, self.hs])
 
         self.input = self.rand(
             [b, 4 * hs], device=self.device, dtype=self.dtype, requires_grad=self.requires_grad


### PR DESCRIPTION
This PR is draft for enabling dynamic shapes on tensor expression benchmarks.

This PR enables benchmarking with dynamic shapes. In a dynamic shaped benchmark, each iteration the input **shape** to the graph is randomized around the configured value and the fuser and executor should be able to re-used the cached kernel and configs without significant performance overhead. 

A helper class is introduced to facilitate creating dynamic shaped bench from all existing tests. The helper class creates a pool of input sets at initialization time and switches the input every time compute is called.

Major Changes:
- Added dynamic shape class to enable creating dynamic shape bench from any regular TE bench.
- Created dynamic bench from simple_element, LSTM, and reduction inner/outer.
