### PR TITLE
Just set a compute-at view rather than doing computeAt transformations

### DIFF
--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -522,7 +522,7 @@ TensorView* TensorView::cache_after() {
     auto this_ca_pos = getThisComputeAtAxis();
     auto this_ca_view = getComputeAtView();
 
-    computeAt(consumer, this_ca_pos);
+    setComputeAt(consumer, this_ca_pos);
     consumer->setComputeAt(this_ca_view, rel_ca_pos);
   } else {
     // Check users of this TV for computeAt for cache_after on inputs


### PR DESCRIPTION
`consumer` is already transformed as it should be, so `this->computeAt(consumer)` should not be necessary. In fact, since `computeAt` doesn't actually change the `compute-at-view` field when no position change is done, `this->compute_at_view` isn't updated, whereas it should be actually updated to point to `consumer`.