### PR TITLE
Reduction keepdim and sum_to operator support

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5115,6 +5115,58 @@ TEST(NVFuserTest, FusionBCastAfterReduce_CUDA) {
   TORCH_CHECK(t5.allclose(outputs[0], 1e-5, 1e-5));
 }
 
+TEST(NVFuserTest, FusionReductionKeepDimScheduler_CUDA) {
+  constexpr int bid_x = 80;
+  constexpr int tid_x = 4096;
+  constexpr int red_dim = 1;
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeConcreteTensor({bid_x,tid_x});
+  fusion.addInput(tv0);
+
+  /* original test case */
+  //TensorView* tv1 =
+  //    reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0, /*keepdim=*/true);
+
+  //TensorView* red_tv = fusion.origin(tv1)->inputs()[0]->as<TensorView>();
+  
+  //fusion.addOutput(red_tv); //whole test passes with this
+
+  // ---------------------------------------------------
+  
+  /* equivalent test case */
+  TensorView* red_tv=reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0);
+  TensorView* tv1 = broadcast(red_tv,{false,true});
+
+  fusion.addOutput(tv1);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::randn({bid_x, tid_x}, options);
+
+  // Apply reduction heuristic
+  auto reduction_params = getReductionHeuristics(&fusion, {input}, red_tv);
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  scheduleReduction(&fusion, reduction_params.value(), red_tv, {});
+    fusion.printMath();
+    fusion.printKernel();
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+    
+  auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
+  auto aten_output = input.sum({red_dim});
+
+  TORCH_CHECK(
+      aten_output.allclose(outputs[0].squeeze(), 1e-04, 1e-04),
+      "Error of: ",
+      aten_output.sub(outputs[0].squeeze()).abs().max());
+}
+
+
 TEST(NVFuserTest, FusionReductionScheduler_CUDA) {
   constexpr int bid_x = 80;
   constexpr int tid_x = 4096;

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5254,11 +5254,11 @@ TEST(NVFuserTest, FusionSumToBasic_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  std::vector<int> tensor_shape {2,3,4,5,6};
-  std::vector<int> sum_to_shape {1,5,6};
+  std::vector<int> tensor_shape{2, 3, 4, 5, 6};
+  std::vector<int> sum_to_shape{1, 5, 6};
 
-  c10::IntArrayRef tensor_shape_ref  {2,3,4,5,6};
-  c10::IntArrayRef sum_to_shape_ref {1,5,6};
+  c10::IntArrayRef tensor_shape_ref{2, 3, 4, 5, 6};
+  c10::IntArrayRef sum_to_shape_ref{1, 5, 6};
 
   TensorView* tv0 = makeConcreteTensor(tensor_shape);
   fusion.addInput(tv0);
@@ -5274,10 +5274,10 @@ TEST(NVFuserTest, FusionSumToBasic_CUDA) {
   fe.compileFusion(&fusion);
 
   auto outputs = fe.runFusion({input});
-  auto aten_output = at::sum_to(input,sum_to_shape_ref);
-  
+  auto aten_output = at::sum_to(input, sum_to_shape_ref);
+
   TORCH_CHECK(
-      outputs[0].dim()==sum_to_shape.size(),
+      outputs[0].dim() == sum_to_shape.size(),
       "sum_to not keeping the final dimension");
 
   TORCH_CHECK(
@@ -5290,19 +5290,22 @@ TEST(NVFuserTest, FusionSumToSymbolic_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  std::vector<int> tensor_shape {2,3,4,5,6};
-  std::vector<int> sum_to_shape {1,5,6};
+  std::vector<int> tensor_shape{2, 3, 4, 5, 6};
+  std::vector<int> sum_to_shape{1, 5, 6};
 
-  c10::IntArrayRef tensor_shape_ref  {2,3,4,5,6};
-  c10::IntArrayRef sum_to_shape_ref {1,5,6};
+  c10::IntArrayRef tensor_shape_ref{2, 3, 4, 5, 6};
+  c10::IntArrayRef sum_to_shape_ref{1, 5, 6};
 
   std::vector<Val*> sum_to_symb;
-  std::transform(sum_to_shape.begin(),sum_to_shape.end(),std::back_inserter(sum_to_symb),
-                  [](int s)->Val* {return new Int(s);});
+  std::transform(
+      sum_to_shape.begin(),
+      sum_to_shape.end(),
+      std::back_inserter(sum_to_symb),
+      [](int s) -> Val* { return new Int(s); });
 
   TensorView* tv0 = makeConcreteTensor(tensor_shape);
   fusion.addInput(tv0);
-  
+
   TensorView* tv1 = sum_to(tv0, sum_to_symb);
   fusion.addOutput(tv1);
 
@@ -5315,10 +5318,10 @@ TEST(NVFuserTest, FusionSumToSymbolic_CUDA) {
   fe.compileFusion(&fusion);
 
   auto outputs = fe.runFusion({input});
-  auto aten_output = at::sum_to(input,sum_to_shape_ref);
-  
+  auto aten_output = at::sum_to(input, sum_to_shape_ref);
+
   TORCH_CHECK(
-      outputs[0].dim()==sum_to_shape.size(),
+      outputs[0].dim() == sum_to_shape.size(),
       "sum_to not keeping the final dimension");
 
   TORCH_CHECK(
@@ -5326,7 +5329,6 @@ TEST(NVFuserTest, FusionSumToSymbolic_CUDA) {
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
 }
-
 
 TEST(NVFuserTest, FusionReductionScheduler_CUDA) {
   constexpr int bid_x = 80;

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5135,12 +5135,12 @@ TEST(NVFuserTest, FusionOutputBroadcast_CUDA) {
   fe.compileFusion(&fusion);
 
   auto outputs = fe.runFusion({input});
-  auto aten_output = input;
+  auto aten_output = input.unsqueeze(2).unsqueeze(1).unsqueeze(0);
 
   TORCH_CHECK(
-      aten_output.allclose(outputs[0].squeeze(), 1e-04, 1e-04),
+      aten_output.allclose(outputs[0], 1e-04, 1e-04),
       "Error of: ",
-      aten_output.sub(outputs[0].squeeze()).abs().max());
+      aten_output.sub(outputs[0]).abs().max());
 }
 
 TEST(NVFuserTest, FusionReductionKeepDimBasic_CUDA) {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5115,6 +5115,40 @@ TEST(NVFuserTest, FusionBCastAfterReduce_CUDA) {
   TORCH_CHECK(t5.allclose(outputs[0], 1e-5, 1e-5));
 }
 
+TEST(NVFuserTest, FusionReductionKeepDimBasic_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeConcreteTensor({2, 3, 4, 5, 6});
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = sum(tv0, {0, 2, 4}, /*keep_dim=*/true);
+
+  fusion.addOutput(tv1);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  at::Tensor input = at::randn({2, 3, 4, 5, 6}, options);
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+
+  auto outputs = fe.runFusion({input});
+  auto aten_output = input.sum({0, 2, 4});
+
+  fusion.printKernel();
+  fusion.printMath();
+
+  std::cout << outputs[0].squeeze() << std::endl;
+  std::cout << aten_output << std::endl;
+
+  TORCH_CHECK(
+      aten_output.allclose(outputs[0].squeeze(), 1e-04, 1e-04),
+      "Error of: ",
+      aten_output.sub(outputs[0].squeeze()).abs().max());
+}
+
 TEST(NVFuserTest, FusionReductionKeepDimScheduler_CUDA) {
   constexpr int bid_x = 80;
   constexpr int tid_x = 4096;
@@ -5127,21 +5161,10 @@ TEST(NVFuserTest, FusionReductionKeepDimScheduler_CUDA) {
   TensorView* tv0 = makeConcreteTensor({bid_x, tid_x});
   fusion.addInput(tv0);
 
-  /* original test case */
-  // TensorView* tv1 =
-  //    reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0,
-  //    /*keepdim=*/true);
+  TensorView* tv1 = reductionOp(
+      BinaryOpType::Add, {red_dim}, new Float(0), tv0, /*keep_dim=*/true);
 
-  // TensorView* red_tv = fusion.origin(tv1)->inputs()[0]->as<TensorView>();
-
-  // fusion.addOutput(red_tv); //whole test passes with this
-
-  // ---------------------------------------------------
-
-  /* equivalent test case */
-  TensorView* red_tv =
-      reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0);
-  TensorView* tv1 = broadcast(red_tv, {false, true});
+  TensorView* red_tv = fusion.origin(tv1)->inputs()[0]->as<TensorView>();
 
   fusion.addOutput(tv1);
 
@@ -5154,19 +5177,55 @@ TEST(NVFuserTest, FusionReductionKeepDimScheduler_CUDA) {
   TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, reduction_params.value(), red_tv, {tv1});
 
-  fusion.printMath();
-  fusion.printKernel();
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+
+  auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
+  auto aten_output = input.sum({red_dim});
+
+  TORCH_CHECK(
+      aten_output.allclose(outputs[0].squeeze(), 1e-04, 1e-04),
+      "Error of: ",
+      aten_output.sub(outputs[0].squeeze()).abs().max());
+}
+
+TEST(NVFuserTest, FusionSumKeepDimScheduler_CUDA) {
+  constexpr int bid_x = 80;
+  constexpr int tid_x = 4096;
+  constexpr int red_dim = 1;
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeConcreteTensor({bid_x, tid_x});
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = sum(tv0, {red_dim}, /*keep_dim=*/true);
+
+  TensorView* red_tv = fusion.origin(tv1)->inputs()[0]->as<TensorView>();
+
+  fusion.addOutput(tv1);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::randn({bid_x, tid_x}, options);
+
+  // Apply reduction heuristic
+  auto reduction_params = getReductionHeuristics(&fusion, {input}, red_tv);
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  scheduleReduction(&fusion, reduction_params.value(), red_tv, {tv1});
 
   FusionExecutor fe;
   fe.compileFusion(&fusion);
 
   auto outputs = fe.runFusion({input}, reduction_params.value().lparams);
-  auto aten_output = input.sum({red_dim}, true);
+  auto aten_output = input.sum({red_dim});
 
   TORCH_CHECK(
-      aten_output.allclose(outputs[0], 1e-04, 1e-04),
+      aten_output.allclose(outputs[0].squeeze(), 1e-04, 1e-04),
       "Error of: ",
-      aten_output.sub(outputs[0]).abs().max());
+      aten_output.sub(outputs[0].squeeze()).abs().max());
 }
 
 TEST(NVFuserTest, FusionReductionScheduler_CUDA) {

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -748,62 +748,53 @@ TensorView* clamp(TensorView* in, Val* min_val, Val* max_val) {
 
 // sum_to operator
 
-inline bool shouldReduceSumTo(const int shape, const Val* root_id_extent){
-  return shape==1 && !root_id_extent->isOneInt();
+inline bool shouldReduceSumTo(const int shape, const Val* root_id_extent) {
+  return shape == 1 && !root_id_extent->isOneInt();
 }
 
-inline bool shouldReduceSumTo(const Val* shape, const Val* root_id_extent){
+inline bool shouldReduceSumTo(const Val* shape, const Val* root_id_extent) {
   return shape->isOneInt() && !root_id_extent->isOneInt();
 }
 
-//Name of sum_to is different from NV fuser naming, 
-// this is to align with the operator name 
-template<typename T>
-TensorView* sum_to_impl(
-    TensorView* v1,
-    const std::vector<T>& shape){
+// Name of sum_to is different from NV fuser naming,
+// this is to align with the operator name
+template <typename T>
+TensorView* sum_to_impl(TensorView* v1, const std::vector<T>& shape) {
+  TensorView* v2 = v1;
 
-      TensorView* v2 = v1;
+  const auto& v1_root = TensorDomain::noReductions(v1->getRootDomain());
 
-      const auto& v1_root = TensorDomain::noReductions(v1->getRootDomain());
+  const int64_t leading_dims = v1_root.size() - shape.size();
 
-      const int64_t leading_dims = v1_root.size() - shape.size();
+  // Reduce left most dims without keep_dim
+  if (leading_dims) {
+    std::vector<int> outer_red_dims(leading_dims);
+    std::iota(outer_red_dims.begin(), outer_red_dims.end(), 0);
+    v2 = sum(v1, outer_red_dims);
+  }
 
-      //Reduce left most dims without keep_dim
-      if(leading_dims){
-        std::vector<int> outer_red_dims(leading_dims);
-        std::iota(outer_red_dims.begin(),outer_red_dims.end(),0);
-        v2 = sum(v1,outer_red_dims);
-      }
-      
-      std::vector<int> inner_red_dims;
-      //Reduce rest of the dims with keep_dim
-      for(int i=leading_dims;i<v1_root.size();i++){
-        if(shouldReduceSumTo(shape[i-leading_dims],v1_root[i]->rawExtent())){
-          inner_red_dims.push_back(i-leading_dims);
-        }
-      }
-
-      if(!inner_red_dims.empty()){
-        v2 = sum(v2,inner_red_dims,/*keep_dim=*/true);
-      }
-
-      return v2;
+  std::vector<int> inner_red_dims;
+  // Reduce rest of the dims with keep_dim
+  for (int i = leading_dims; i < v1_root.size(); i++) {
+    if (shouldReduceSumTo(shape[i - leading_dims], v1_root[i]->rawExtent())) {
+      inner_red_dims.push_back(i - leading_dims);
     }
+  }
 
-TensorView* sum_to(
-    TensorView* v1,
-    const std::vector<Val*>& shape){
-      return sum_to_impl(v1,shape);
+  if (!inner_red_dims.empty()) {
+    v2 = sum(v2, inner_red_dims, /*keep_dim=*/true);
+  }
 
-    }
+  return v2;
+}
 
-TensorView* sum_to(
-    TensorView* v1,
-    const std::vector<int>& shape){
-      return sum_to_impl(v1,shape);
-    }
+TensorView* sum_to(TensorView* v1, const std::vector<Val*>& shape) {
+  return sum_to_impl(v1, shape);
+}
 
+TensorView* sum_to(TensorView* v1, const std::vector<int>& shape) {
+  return sum_to_impl(v1, shape);
+}
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -754,11 +754,11 @@ TensorView* sum_to(TensorView* v1, const std::vector<Int*>& shape) {
   const auto& v1_root = TensorDomain::noReductions(v1->getRootDomain());
 
   TORCH_CHECK(
-      shape.size() <= v1_root.size(),
+      v1_root.size() >= shape.size(),
       "sum_to: Error trying to reduce",
       v1,
       "into a shape of size",
-      v1_root.size());
+      shape.size());
 
   // If no reduction is needed sum_to returns the input tv
   TensorView* v2 = v1;

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -445,7 +445,7 @@ TensorView* reductionOp(
     const std::vector<int>& axes,
     Val* init,
     TensorView* tv,
-    c10::optional<bool> keep_dim /*=c10::nullopt*/) {
+    bool keep_dim /*=false*/) {
   TORCH_CHECK(
       init->isConstScalar(),
       "Cannot create a reduction operation where the initial value is not a const scalar.");
@@ -479,7 +479,7 @@ TensorView* reductionOp(
     init = castOp(tv->getDataType().value(), init);
   new ReductionOp(reduction_op_type, init, out, tv);
 
-  if (keep_dim.has_value() && keep_dim.value()) {
+  if (keep_dim) {
     auto tv_root = TensorDomain::noReductions(tv->getRootDomain());
     std::vector<bool> is_broadcast(tv_root.size(), false);
     for (int axis : axes) {
@@ -494,7 +494,7 @@ TensorView* reductionOp(
 TensorView* sum(
     TensorView* v1,
     const std::vector<int>& axes,
-    c10::optional<bool> keep_dim) {
+    bool keep_dim /*=false*/) {
   Val* init;
   switch (v1->getDataType().value()) {
     case (DataType::Float):

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -748,32 +748,32 @@ TensorView* clamp(TensorView* in, Val* min_val, Val* max_val) {
 
 // sum_to operator
 
-TensorView* sum_to(TensorView* in, const std::vector<Int*>& shape) {
+TensorView* sum_to(TensorView* in, const std::vector<Int*>& sum_to_size) {
   const auto& root = TensorDomain::noReductions(in->getRootDomain());
 
   TORCH_CHECK(
-      root.size() >= shape.size(),
+      root.size() >= sum_to_size.size(),
       "sum_to: Error trying to reduce",
       in,
       "into a shape of size",
-      shape.size());
+      sum_to_size.size());
 
   // If no reduction is needed sum_to returns the input tv
   TensorView* out = in;
 
-  const int64_t leading_dims = root.size() - shape.size();
+  const int64_t leading_dims = root.size() - sum_to_size.size();
 
   // Generate reduction axes for leading dims
   std::vector<int> reduce_dims(leading_dims);
   std::iota(reduce_dims.begin(), reduce_dims.end(), 0);
 
-  // Generate reduction axes for dims within shape
-  std::vector<bool> inner_red_dims(shape.size(), false);
+  // Generate reduction axes for dims within sum_to_size
+  std::vector<bool> inner_red_dims(sum_to_size.size(), false);
   bool reduction_within_shape = false;
 
   // Reduce rest of the dims with keep_dim
   for (int i = leading_dims; i < root.size(); i++) {
-    if (shape[i - leading_dims]->isOneInt() &&
+    if (sum_to_size[i - leading_dims]->isOneInt() &&
         !root[i]->rawExtent()->isOneInt()) {
       inner_red_dims[i - leading_dims] = true;
       reduce_dims.push_back(i);

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -495,7 +495,7 @@ TensorView* sum(
     TensorView* v1,
     const std::vector<int>& axes,
     bool keep_dim /*=false*/) {
-  Val* init;
+  Val* init = nullptr;
   switch (v1->getDataType().value()) {
     case (DataType::Float):
       init = new Float(0.0);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -195,11 +195,7 @@ TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 //
 TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
-    const std::vector<int>& shape);
-
-TORCH_CUDA_API TensorView* sum_to(
-    TensorView* v1,
-    const std::vector<Val*>& shape);
+    const std::vector<Int*>& shape);
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -43,7 +43,8 @@ TORCH_CUDA_API TensorView* reductionOp(
     BinaryOpType reduction_op_type,
     const std::vector<int>& axes,
     Val* init,
-    TensorView* v1);
+    TensorView* v1,
+    c10::optional<bool> keep_dim = c10::nullopt);
 
 // UNARY OPERATIONS
 TORCH_CUDA_API Val* neg(Val* v);
@@ -107,7 +108,8 @@ TORCH_CUDA_API TensorView* andOp(TensorView* v1, TensorView* v2);
 // REDUCTION OPERATIONS
 TORCH_CUDA_API TensorView* sum(
     TensorView* v1,
-    const std::vector<int>& reduction_axes);
+    const std::vector<int>& reduction_axes,
+    c10::optional<bool> keep_dim = c10::nullopt);
 
 // COMPOUND OPERATIONS
 // add_alpha

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -186,14 +186,18 @@ TORCH_CUDA_API TensorView* threshold(TensorView* in, Val* thresh, Val* value);
 TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val);
 TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 
-// Internal operator for supporting backward graphs
-//
-// example:
-//   v1 = T1 [I0(10),I1(20),I2(30),I3(40)]
-//   v2 = sum_to(v1,{30,1}) ------> v2 = T2[I2,R3 (keep_dim)]
-//
-//  This operator will return v1* directly if sizes of v1 root domain
-//  is already the same as shape.
+//! Internal operator for supporting backward graphs
+//!
+//! example:
+//!   v1 = T1 [I0(10),I1(20),I2(30),I3(40)]
+//!   v2 = sum_to(v1,{30,1}) ------> v2 = T2[I2,R3 (keep_dim)]
+//!
+//!  This operator will return v1* directly if sizes of v1 root domain
+//!  is already the same as shape.
+//!
+//!  Name of sum_to is different from NV fuser naming,
+//!  this is to align with the operator name of at::sum_to.
+
 TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
     const std::vector<Int*>& shape);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -186,6 +186,22 @@ TORCH_CUDA_API TensorView* threshold(TensorView* in, Val* thresh, Val* value);
 TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val);
 TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 
+// Internal operator for supporting backward graphs
+// 
+// example:
+//   v1 = T1 [I0(10),I1(20),I2(30),I3(40)]
+//   v2 = sum_to(v1,{30,1}) ------> v2 = T2[I2,R3 (keep_dim)]
+//      
+//
+TORCH_CUDA_API TensorView* sum_to(
+    TensorView* v1,
+    const std::vector<int>& shape);
+
+TORCH_CUDA_API TensorView* sum_to(
+    TensorView* v1,
+    const std::vector<Val*>& shape);
+
+
 } // namespace cuda
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -187,11 +187,11 @@ TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val);
 TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 
 // Internal operator for supporting backward graphs
-// 
+//
 // example:
 //   v1 = T1 [I0(10),I1(20),I2(30),I3(40)]
 //   v2 = sum_to(v1,{30,1}) ------> v2 = T2[I2,R3 (keep_dim)]
-//      
+//
 //
 TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
@@ -200,7 +200,6 @@ TORCH_CUDA_API TensorView* sum_to(
 TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
     const std::vector<Val*>& shape);
-
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -44,7 +44,7 @@ TORCH_CUDA_API TensorView* reductionOp(
     const std::vector<int>& axes,
     Val* init,
     TensorView* v1,
-    c10::optional<bool> keep_dim = c10::nullopt);
+    bool keep_dim = false);
 
 // UNARY OPERATIONS
 TORCH_CUDA_API Val* neg(Val* v);
@@ -109,7 +109,7 @@ TORCH_CUDA_API TensorView* andOp(TensorView* v1, TensorView* v2);
 TORCH_CUDA_API TensorView* sum(
     TensorView* v1,
     const std::vector<int>& reduction_axes,
-    c10::optional<bool> keep_dim = c10::nullopt);
+    bool keep_dim = false);
 
 // COMPOUND OPERATIONS
 // add_alpha
@@ -192,7 +192,8 @@ TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 //   v1 = T1 [I0(10),I1(20),I2(30),I3(40)]
 //   v2 = sum_to(v1,{30,1}) ------> v2 = T2[I2,R3 (keep_dim)]
 //
-//
+//  This operator will return v1* directly if sizes of v1 root domain
+//  is already the same as shape.
 TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
     const std::vector<Int*>& shape);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -200,7 +200,7 @@ TORCH_CUDA_API TensorView* clamp(TensorView* in, Val* min_val, Val* max_val);
 
 TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
-    const std::vector<Int*>& shape);
+    const std::vector<Int*>& sum_to_size);
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -1053,15 +1053,6 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
     } else if (ind->isZeroInt()) {
       stride_i++;
     } else {
-      while (stride_i < root_dom.size() && root_dom[stride_i]->isBroadcast()) {
-        stride_i++;
-      }
-
-      TORCH_INTERNAL_ASSERT(
-          stride_i < root_dom.size(),
-          "GlobalConsumerIndex: invalid loop nest for",
-          consumer_tv);
-
       std::stringstream ss;
       ss << "T" << consumer_tv->name() << ".stride[" << stride_i++ << "]";
       strided_inds.push_back(ir_builder.mulExpr(

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -1053,6 +1053,15 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
     } else if (ind->isZeroInt()) {
       stride_i++;
     } else {
+      while (stride_i < root_dom.size() && root_dom[stride_i]->isBroadcast()) {
+        stride_i++;
+      }
+
+      TORCH_INTERNAL_ASSERT(
+          stride_i < root_dom.size(),
+          "GlobalConsumerIndex: invalid loop nest for",
+          consumer_tv);
+
       std::stringstream ss;
       ss << "T" << consumer_tv->name() << ".stride[" << stride_i++ << "]";
       strided_inds.push_back(ir_builder.mulExpr(

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -319,6 +319,15 @@ class TORCH_CUDA_API IterDomain : public Val {
     return (isBlockDim() || isThreadDim());
   }
 
+  // Convert to strided broadcast, used for supporting broadcast on output
+  void toStridedBroadcast(){
+    TORCH_INTERNAL_ASSERT(
+          isBroadcast(),
+          "toStridedBroadCast: converting an non-broadcast iterdomain",
+          this);
+    iter_type_ = IterType::BroadcastWithStride;
+  }
+
   void parallelize(ParallelType t) {
     parallel_type_ = t;
 

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -320,11 +320,11 @@ class TORCH_CUDA_API IterDomain : public Val {
   }
 
   // Convert to strided broadcast, used for supporting broadcast on output
-  void toStridedBroadcast(){
+  void toStridedBroadcast() {
     TORCH_INTERNAL_ASSERT(
-          isBroadcast(),
-          "toStridedBroadCast: converting an non-broadcast iterdomain",
-          this);
+        isBroadcast(),
+        "toStridedBroadCast: converting an non-broadcast iterdomain",
+        this);
     iter_type_ = IterType::BroadcastWithStride;
   }
 

--- a/torch/csrc/jit/codegen/cuda/lower_validation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_validation.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/codegen/cuda/lower_utils.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 #include <torch/csrc/jit/codegen/cuda/type.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 
 namespace torch {
 namespace jit {
@@ -65,6 +66,15 @@ void validateIr(Fusion* fusion) {
                 "Cannot generate a kernel where a root broadcast dimension is input to both IterDomains outside and within the computeAt point.");
           }
         }
+      }
+    }
+  }
+
+  // Convert all output broadcast iterdomains to strided
+  for(auto tv: ir_utils::filterByType<TensorView>(fusion->outputs())){
+    for(auto id: tv->getMaybeRFactorDomain()){
+      if(id->isBroadcast()){
+        id->toStridedBroadcast();
       }
     }
   }

--- a/torch/csrc/jit/codegen/cuda/lower_validation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_validation.cpp
@@ -1,10 +1,10 @@
 #include <torch/csrc/jit/codegen/cuda/lower_validation.h>
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 #include <torch/csrc/jit/codegen/cuda/iter_visitor.h>
 #include <torch/csrc/jit/codegen/cuda/lower_utils.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 #include <torch/csrc/jit/codegen/cuda/type.h>
-#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 
 namespace torch {
 namespace jit {
@@ -71,9 +71,9 @@ void validateIr(Fusion* fusion) {
   }
 
   // Convert all output broadcast iterdomains to strided
-  for(auto tv: ir_utils::filterByType<TensorView>(fusion->outputs())){
-    for(auto id: tv->getMaybeRFactorDomain()){
-      if(id->isBroadcast()){
+  for (auto tv : ir_utils::filterByType<TensorView>(fusion->outputs())) {
+    for (auto id : tv->getMaybeRFactorDomain()) {
+      if (id->isBroadcast()) {
         id->toStridedBroadcast();
       }
     }


### PR DESCRIPTION
This PR adds a few operator supports including:

- adds keepdim option in reduction operators, that is originally supported in at library. e.g.:
```cpp
T1 = makeConcreteTensor({2, 3, 4});    //T1[2,3,4]
T2 = sum(T1,{0,1},/*keep_dim=*/true); //T2[1,1,4]
```
where in fusion `T2` is implemented as `T2[B,B,I]`

- adds sum_to operator for supporting backward graphs of bias operator. The semantic should be equivalent to at::sum_to in the torch operators library

e.g:
```cpp
T1 = makeConcreteTensor({2, 3, 4, 5, 6});       //T1[2,3,4,5,6]

// sum_to reduces axis 0,1,2 and keeps dimension 2
T2 = sum_to(T1,{1, 5, 6},/*keep_dim=*/true); //T2[1,5,6]  
```
Where `T2` in fusion is implemented as `T2[B,I,I]`

- adds broadcast conversion in lower_validation pass.
This converts all output broadcast axes to strided broadcast to ensure correct index compute.