### PR TITLE
Print all expressions when requested

### DIFF
--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -351,12 +351,13 @@ void Fusion::printKernel() {
   std::cout << codegen::generateCudaKernel(GpuLower(this).kernel());
 }
 
-void Fusion::printMath() {
+void Fusion::printMath(bool from_outputs_only) {
   FUSER_PERF_SCOPE("Fusion::printMath");
 
   FusionGuard fg(this);
-  for (auto expr : exprs(true))
+  for (auto expr : exprs(from_outputs_only)) {
     std::cout << expr;
+  }
 }
 
 void Fusion::printTransforms() {

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -125,7 +125,7 @@ class TORCH_CUDA_API Fusion final {
 
   //! Print Arith exprs
   //! \param from_outputs_only Only print exprs reachable from outputs
-  void printMath(bool from_outputs_only=true);
+  void printMath(bool from_outputs_only = true);
 
   // Print transformations used in fusion (can be very verbose)
   void printTransforms();

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -123,8 +123,9 @@ class TORCH_CUDA_API Fusion final {
   // Print this fusion to cout.
   void print();
 
-  // Print Arith exprs used in outputs
-  void printMath();
+  //! Print Arith exprs
+  //! \param from_outputs_only Only print exprs reachable from outputs
+  void printMath(bool from_outputs_only=true);
 
   // Print transformations used in fusion (can be very verbose)
   void printTransforms();


### PR DESCRIPTION
Sometimes debugging requires examining all expressions, whether they are used for outputs or not.