### PR TITLE
Latency improvement

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -7490,7 +7490,7 @@ TEST(NVFuserTest, FusionInputsIdLookup_CUDA) {
   at::Tensor t2 = at::randn({6, 4}, options);
 
   // create a cache with max size 2;
-  auto inputs_id_lookup = InputsIdLookup(2);
+  torch::jit::fuser::cuda::InputsIdLookup inputs_id_lookup(2);
 
   // testing basic function, same encoding for identical inputs
   auto id_0 = inputs_id_lookup.lookupId({t0, t1, 5.0});

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -182,10 +182,7 @@ RegisterOperators reg_fusion({
         prim::CudaFusionGroup,
         [](const Node* node) -> Operation {
           return [node](Stack* stack) {
-            auto start = std::chrono::high_resolution_clock::now();
             fuser::cuda::runFusionGroup(node, *stack);
-            auto t_duration = std::chrono::high_resolution_clock::now() - start;
-            std::cout << "\n CudaFusionGroup time: " << std::chrono::duration_cast<std::chrono::microseconds>(t_duration).count() << " us" << std::endl;
           };
         },
         aliasAnalysisSpecialCase()),
@@ -200,7 +197,6 @@ RegisterOperators reg_guard({
         // analysis, we should update aliasdb pass.
         [](const Node* node) -> Operation {
           return [node](Stack* stack) {
-            auto start = std::chrono::high_resolution_clock::now();
             // TODO: check latency here!!!!
             std::vector<TypePtr> types = node->tys(attr::types);
             const auto num_inputs = types.size();
@@ -229,8 +225,6 @@ RegisterOperators reg_guard({
             // TODO: check type and return the right flag
             // naively return true;
             push(stack, IValue(true));
-            auto t_duration = std::chrono::high_resolution_clock::now() - start;
-            std::cout << "\n CudaFusionGuard time: " << std::chrono::duration_cast<std::chrono::microseconds>(t_duration).count() << " us" << std::endl;
             return;
           };
         },

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -182,7 +182,10 @@ RegisterOperators reg_fusion({
         prim::CudaFusionGroup,
         [](const Node* node) -> Operation {
           return [node](Stack* stack) {
+            auto start = std::chrono::high_resolution_clock::now();
             fuser::cuda::runFusionGroup(node, *stack);
+            auto t_duration = std::chrono::high_resolution_clock::now() - start;
+            std::cout << "\n CudaFusionGroup time: " << std::chrono::duration_cast<std::chrono::microseconds>(t_duration).count() << " us" << std::endl;
           };
         },
         aliasAnalysisSpecialCase()),
@@ -197,6 +200,7 @@ RegisterOperators reg_guard({
         // analysis, we should update aliasdb pass.
         [](const Node* node) -> Operation {
           return [node](Stack* stack) {
+            auto start = std::chrono::high_resolution_clock::now();
             // TODO: check latency here!!!!
             std::vector<TypePtr> types = node->tys(attr::types);
             const auto num_inputs = types.size();
@@ -225,6 +229,8 @@ RegisterOperators reg_guard({
             // TODO: check type and return the right flag
             // naively return true;
             push(stack, IValue(true));
+            auto t_duration = std::chrono::high_resolution_clock::now() - start;
+            std::cout << "\n CudaFusionGuard time: " << std::chrono::duration_cast<std::chrono::microseconds>(t_duration).count() << " us" << std::endl;
             return;
           };
         },

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -266,8 +266,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   }
 
   ret.id = id_iter_pair.id;
-  id_iter_pair.lru_iter =
-      used_entry_.insert(used_entry_.begin(), encoding_);
+  id_iter_pair.lru_iter = used_entry_.insert(used_entry_.begin(), encoding_);
   return ret;
 }
 
@@ -279,17 +278,15 @@ FusionExecutorCache::FusionExecutorCache(std::unique_ptr<Fusion>&& fusion)
 
   if (has_reduction_) {
     FusionGuard fg(fusion_.get());
-    
+
     // Use dependency check to find the reduction tv as it returns used values
     // instead of exprs.
-    
+
     // The call is relatively heavy weight, consider caching
     auto used_vals = DependencyCheck::getAllValsBetween(
         {fusion_->inputs().begin(), fusion_->inputs().end()},
         fusion_->outputs());
-    
-    // TODO(JIE): cache the reduction node.
-    
+
     // Find the reduction tensor view, make sure there's only one
     for (auto val : used_vals) {
       if (val->getValType().value() == ValType::TensorView) {
@@ -302,7 +299,7 @@ FusionExecutorCache::FusionExecutorCache(std::unique_ptr<Fusion>&& fusion)
         }
       }
     }
-    
+
     TORCH_INTERNAL_ASSERT(
         reduction_tv_ != nullptr,
         "Could not find the reduction tensor view in the fusion.");

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -220,6 +220,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
     const at::ArrayRef<IValue>& inputs) {
   IdLookupReturn ret;
 
+  std::lock_guard<std::mutex> guard(mutex_);
   encoding_.clear();
   for (const auto& input : inputs) {
     if (input.isTensor()) {

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -55,7 +55,7 @@ class TORCH_CUDA_API InputsIdLookup : public NonCopyable {
  private:
   // string to store encoded input meta information. Reuse the buffer instead of
   // stringtream gives few us perf gain.
-  std::string encoding_;
+  std::string encoding_; // Note: shared state, guarded by mutex_
 
   // mutex_ used to guard reused encoding_
   std::mutex mutex_;

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -158,7 +158,8 @@ class FusionExecutorCache {
   // is controled by the order of declaration instead of their order in the list
   //
   //! cache fusion->hasReduction() because it's expensive;
-  bool has_reduction_;
+  bool has_reduction_ = false;
+  TensorView* reduction_tv_ = nullptr;
 
   //! TODO: ugly logic for now. We should integrate the hashing of cache for
   //!       different kernels. (alternatively we could do so in scheduler).

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -55,7 +55,8 @@ class TORCH_CUDA_API InputsIdLookup {
   }
 
  private:
-  // TODO: mutex guard this guy;
+  // string to store encoded input meta information. Reuse the buffer instead of
+  // stringtream gives few us perf gain.
   std::string encoding_;
   std::mutex mutex_;
 
@@ -166,6 +167,8 @@ class FusionExecutorCache {
   //
   //! cache fusion->hasReduction() because it's expensive;
   bool has_reduction_ = false;
+
+  //! cache reduction_tv_ to avoid searching repetitively at runtime
   TensorView* reduction_tv_ = nullptr;
 
   //! TODO: ugly logic for now. We should integrate the hashing of cache for

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -7,6 +7,7 @@
 #include <c10/util/ArrayRef.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
+#include <mutex>
 #include <type_traits>
 #include <unordered_map>
 
@@ -32,6 +33,8 @@ class TORCH_CUDA_API InputsIdLookup {
   explicit InputsIdLookup(size_t max_cache_size = 10)
       : max_cache_size_(max_cache_size){};
 
+  InputsIdLookup(const InputsIdLookup&) = delete;
+
   //! struct to hold return value for lookupId.
   struct IdLookupReturn {
     size_t id = 0;
@@ -54,6 +57,7 @@ class TORCH_CUDA_API InputsIdLookup {
  private:
   // TODO: mutex guard this guy;
   std::string encoding_;
+  std::mutex mutex_;
 
   //! entry stored in `encoding_lookup_` to implement LRU
   struct EncodingEntry {

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -27,13 +27,11 @@ namespace cuda {
 //! \note the uniqueness of the ide generated for a given input set is only
 //!   local to the instance of `InputsIdLookup`.
 //!
-class TORCH_CUDA_API InputsIdLookup {
+class TORCH_CUDA_API InputsIdLookup : public NonCopyable {
  public:
   //! constructor where maximum cache size is fixed during init
   explicit InputsIdLookup(size_t max_cache_size = 10)
       : max_cache_size_(max_cache_size){};
-
-  InputsIdLookup(const InputsIdLookup&) = delete;
 
   //! struct to hold return value for lookupId.
   struct IdLookupReturn {
@@ -58,6 +56,8 @@ class TORCH_CUDA_API InputsIdLookup {
   // string to store encoded input meta information. Reuse the buffer instead of
   // stringtream gives few us perf gain.
   std::string encoding_;
+
+  // mutex_ used to guard reused encoding_
   std::mutex mutex_;
 
   //! entry stored in `encoding_lookup_` to implement LRU

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -52,6 +52,9 @@ class TORCH_CUDA_API InputsIdLookup {
   }
 
  private:
+  // TODO: mutex guard this guy;
+  std::string encoding_;
+
   //! entry stored in `encoding_lookup_` to implement LRU
   struct EncodingEntry {
     size_t id;

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -88,8 +88,8 @@ bool scheduleFusion(Fusion* fusion, const at::ArrayRef<c10::IValue> inputs) {
   FusionGuard fg(fusion);
   // maybe has_reduction for scheudling should be done on a per output tensor
   // basis.
-  //TORCH_INTERNAL_ASSERT(
-  //    !fusion->hasReduction(), "This scheduler only handles pointwise ops.");
+  TORCH_INTERNAL_ASSERT(
+      !fusion->hasReduction(), "This scheduler only handles pointwise ops.");
   const bool disable_unroll = fusion->isStochastic();
 
   for (auto out_val : fusion->outputs()) {
@@ -296,20 +296,12 @@ TORCH_CUDA_API c10::optional<ReductionParams> getReductionHeuristics(
 
   FusionGuard fg(fusion);
 
-  //if (!fusion->hasReduction()) {
-  //  return c10::nullopt;
-  //}
-
   auto red_root_dom = red_tv->getRootDomain();
   const bool red_on_fastest_dim =
       red_root_dom[red_root_dom.size() - 1]->isReduction();
 
   TORCH_INTERNAL_ASSERT(
       red_tv != nullptr, "Reduction TensorView wasn't found.");
-
-  //if (!fusion->hasReduction()) {
-  //  return c10::nullopt;
-  //}
 
   TORCH_INTERNAL_ASSERT(
       red_tv->hasReduction(), "TensorView doesn't have a reduction.");

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -88,8 +88,8 @@ bool scheduleFusion(Fusion* fusion, const at::ArrayRef<c10::IValue> inputs) {
   FusionGuard fg(fusion);
   // maybe has_reduction for scheudling should be done on a per output tensor
   // basis.
-  TORCH_INTERNAL_ASSERT(
-      !fusion->hasReduction(), "This scheduler only handles pointwise ops.");
+  //TORCH_INTERNAL_ASSERT(
+  //    !fusion->hasReduction(), "This scheduler only handles pointwise ops.");
   const bool disable_unroll = fusion->isStochastic();
 
   for (auto out_val : fusion->outputs()) {
@@ -292,13 +292,13 @@ TORCH_CUDA_API c10::optional<ReductionParams> getReductionHeuristics(
     Fusion* fusion,
     const at::ArrayRef<c10::IValue>& fusion_inputs,
     TensorView* red_tv) {
-  FUSER_PERF_SCOPE("scheduleReduction");
+  FUSER_PERF_SCOPE("getReductionHeuristics");
 
   FusionGuard fg(fusion);
 
-  if (!fusion->hasReduction()) {
-    return c10::nullopt;
-  }
+  //if (!fusion->hasReduction()) {
+  //  return c10::nullopt;
+  //}
 
   auto red_root_dom = red_tv->getRootDomain();
   const bool red_on_fastest_dim =
@@ -307,9 +307,9 @@ TORCH_CUDA_API c10::optional<ReductionParams> getReductionHeuristics(
   TORCH_INTERNAL_ASSERT(
       red_tv != nullptr, "Reduction TensorView wasn't found.");
 
-  if (!fusion->hasReduction()) {
-    return c10::nullopt;
-  }
+  //if (!fusion->hasReduction()) {
+  //  return c10::nullopt;
+  //}
 
   TORCH_INTERNAL_ASSERT(
       red_tv->hasReduction(), "TensorView doesn't have a reduction.");
@@ -346,6 +346,7 @@ void scheduleReduction(
     const ReductionParams& rparams,
     TensorView* red_tv,
     std::vector<TensorView*> outs_of_red) {
+  FUSER_PERF_SCOPE("scheduleReduction");
   FusionGuard fg(fusion);
 
   // We coalesc all reduction axes to the right;


### PR DESCRIPTION
1. removes some redundant check of `Fusion::hasReduction` on reduction heuristics;
2. caches reduction_tv_ in `FusionExecutorCache` to avoid repetitive lookup at runtime;
3. improves `InputsIdLookup::lookupId` performance by reusing string buffer instead of using stringstream;