### PR TITLE
type_as parser pr

### DIFF
--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -166,6 +166,15 @@ class NaiveTypePropagator {
             unary_reduce_type(out_type, dims->vec(), keepdim.value()));
         break;
       }
+      case aten::type_as: {
+        const auto type0 = node->input(0)->type()->cast<TensorType>();
+        const auto type1 = node->input(1)->type()->cast<TensorType>();
+        TORCH_CHECK(
+            type0 != nullptr && type1 != nullptr,
+            "input to type_as needs to be a tensor");
+        node->output()->setType(type0->withScalarType(type1->scalarType()));
+        break;
+      }
       default:
         TORCH_CHECK(
             false,

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -355,6 +355,8 @@ static const char* supported_casts2string(
       return "__float2half";
     case supported_switch_pair(DataType::Half, DataType::Float):
       return "__half2float";
+    case supported_switch_pair(DataType::Bool, DataType::Float):
+      return "float";
     default:
       return nullptr;
   }


### PR DESCRIPTION
This PR is needed to fuse expanded dropout, which unfortunately exposed issue regarding missing complete tensor type with profiling executor:
https://github.com/csarofeen/pytorch/blob/63b7e29f69514f5ce611769756df0f19e247d107/torch/csrc/jit/runtime/symbolic_script.cpp#L1083-L1102

By fusing `dropout` as a whole we can temporarily work around it as we push upstream for a proper fix.

Also smuggled some `GRAPH_DUMP` in graph_fuser.cpp to facilitate future debugging.