### PR TITLE
Check allocations of dynamic local memory just before compilation

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -157,6 +157,10 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
         "The static shared memory allocation is larger than available memory.");
   }
 
+  TORCH_INTERNAL_ASSERT(
+      !kernel_summary.has_dynamic_local_memory_allocations,
+      "Allocations must be based on constant integers for local memory.");
+
   compiled_kernel_ = executor_utils::nvrtcCompile(
       structured_code,
       (kernelNamespace() + "::" + kernelName()).c_str(),

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -50,6 +50,8 @@ class KernelIrScanner : private kir::IrVisitor {
         }
         break;
       case MemoryType::Local:
+        summary_.has_dynamic_local_memory_allocations |=
+            !ExpressionEvaluator::isConst(allocate->size());
         break;
     }
   }

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -43,6 +43,9 @@ struct KernelSummary {
 
   //! Largest shared memory buffer base type
   DataType largest_smem_data_type = DataType::Null;
+
+  //! Do we have allocations of dynamic local memory?
+  bool has_dynamic_local_memory_allocations = false;
 };
 
 //! Container for a lowered Kernel IR

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -387,14 +387,6 @@ Allocate::Allocate(
       size_ = ir_builder.mulExpr(size_, domain->axis(i)->extent());
     }
   }
-
-  if (memory_type_ == MemoryType::Local) {
-    TORCH_INTERNAL_ASSERT(
-        ExpressionEvaluator::isConst(size_),
-        "Allocations must be based on constant integers for the memory type ",
-        memory_type_);
-  }
-
   addInput(size_);
 }
 


### PR DESCRIPTION
`fusion.printKernel()` works even with local memories with dynamic sizes. Error checking is done just before compilation.