### PR TITLE
fix extent propagation in index_compute

### DIFF
--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -431,9 +431,7 @@ IndexCompute IndexCompute::updateIndexCompute(
       updated_index_map[new_id] = index_map_.at(prev_id);
     }
 
-    if (extent_map_.find(prev_id) != extent_map_.end()) {
-      updated_extent_map[new_id] = extent_map_.at(prev_id);
-    }
+    updated_extent_map[new_id] = getExtent(prev_id);
 
     if (zero_merged_in_.find(prev_id) != zero_merged_in_.end()) {
       updated_zero_merged_in.emplace(new_id);


### PR DESCRIPTION
Fixes [#456](https://github.com/csarofeen/pytorch/issues/456)

- Added repro in the test. 

- Fixed extent propagation in index compute.

A brief explanation for the fix:

```cpp
T2[I0,I1,I2] = T1[B0,I1,I2]+T0[I0,I1,I2]; (compute at T3)
T3[R0,I1,I2] = sum(T2,0); (compute at T4)
T4[R1,I2] = sum(T3,0);
```

Index compute has a forward and a backward pass. 

When we propagate backward to compute the index into T1, we should have the T2.size(0) bound to the extent of B0. Otherwise the index cannot be right in the current implementation.

We process the extents only at backward pass. When processing T4, we do not really see anything about R0. So in `updateIndexCompute`, the transition function, we need to forward both the already computed extent binding and the extent of the new axis R0. With introducing extent of R0, the rest of the mapping in this example all works out.
