### PR TITLE
Fix issue #363

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8860,11 +8860,13 @@ TEST(NVFuserTest, FusionIssue367_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::manual_seed(0);
+
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
 
   torch::jit::fuser::cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
+
   auto outputs = fe.runFusion({t0, t1, 2, 2, 3});
 
   at::Tensor aten_output = mul(t0.unsqueeze(2), t1.unsqueeze(0)).sum(1);
@@ -8904,6 +8906,62 @@ TEST(NVFuserTest, FusionIssue468_CUDA) {
       "Error of: ",
       aten_output.sub(outputs[0]).abs().max());
 }
+
+TEST(NVFuserTest, FusionIssue363_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Symbolic 2D tensors TV0[M, K], TV1[K, N]
+  TensorView* tv0 = makeSymbolicTensor(2);
+  TensorView* tv1 = makeSymbolicTensor(2);
+
+  // Broadcast tv0 to [M, K, *]
+  TensorView* tv2 = broadcast(tv0, {false, false, true});
+  // Broadcast tv1 to [*, K, N]
+  TensorView* tv3 = broadcast(tv1, {true, false, false});
+
+  // Pointwise multiplication resulting in tv3[M, K, N]
+  TensorView* tv4 = mul(tv2, tv3);
+
+  // Sum the K-dim
+  TensorView* tv5 = sum(tv4, {1});
+
+  // Register inputs and outputs
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  fusion.addOutput(tv5);
+
+  tv2->setMemoryType(MemoryType::Global);
+  tv3->setMemoryType(MemoryType::Global);
+  tv4->setMemoryType(MemoryType::Global);
+
+  tv0->computeAt(tv5, -1);
+  tv1->computeAt(tv5, -1);
+
+  tv5->axis(0)->parallelize(ParallelType::BIDz);
+  tv5->axis(1)->parallelize(ParallelType::BIDy);
+
+  tv5->axis(2)->parallelize(ParallelType::BIDx);
+
+  constexpr int M = 3, K = 6, N = 16;
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::manual_seed(0);
+
+  at::Tensor t0 = at::randn({M, K}, options);
+  at::Tensor t1 = at::randn({K, N}, options);
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto outputs = fe.runFusion({t0, t1});
+
+  at::Tensor aten_output = mul(t0.unsqueeze(2), t1.unsqueeze(0)).sum(1);
+  TORCH_CHECK(
+      aten_output.allclose(outputs[0]),
+      "Error of: ",
+      aten_output.sub(outputs[0]).abs().max());
+}
+
 
 TEST(NVFuserTest, FusionIssue477_CUDA) {
   Fusion fusion;

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8860,13 +8860,11 @@ TEST(NVFuserTest, FusionIssue367_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::manual_seed(0);
-
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
 
   torch::jit::fuser::cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
-
   auto outputs = fe.runFusion({t0, t1, 2, 2, 3});
 
   at::Tensor aten_output = mul(t0.unsqueeze(2), t1.unsqueeze(0)).sum(1);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8985,29 +8985,24 @@ TEST(NVFuserTest, FusionIssue484_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  TensorView* tv0 = makeSymbolicTensor(2);
+  auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
-  //auto tv1 = sum(tv0, {1, 2, 3});
   auto tv1 = sum(tv0, {1});
   auto tv2 = add(tv1, new Float(0));
   fusion.addOutput(tv2);
 
   tv1->setMemoryType(MemoryType::Global);
 
-  fusion.printKernel();
-
   constexpr int M = 100;
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::manual_seed(0);
-  //at::Tensor t0 = at::randn({M, M, M, M}, options);
   at::Tensor t0 = at::randn({M, M}, options);
 
   torch::jit::fuser::cuda::FusionExecutor fe;
   fe.compileFusion(&fusion);
   auto outputs = fe.runFusion({t0});
 
-  //at::Tensor aten_output = t0.sum({1, 2, 3});
   at::Tensor aten_output = t0.sum({1});
   TORCH_CHECK(
       aten_output.allclose(outputs[0], 1e-5, 1e-5),

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -184,7 +184,11 @@ at::Tensor inferAndAlloc(
   const auto maybe_rfactor_domain =
       domain->hasRFactor() ? domain->rfactorDomain() : domain->rootDomain();
 
-  for (auto id : kir::TensorDomain::noReductions(maybe_rfactor_domain)) {
+  for (const auto id : maybe_rfactor_domain) {
+    if (id->isReduction() ||
+        id->iterType() == IterType::BroadcastWithoutStride) {
+      continue;
+    }
     const auto inferred_val = expr_eval.evaluate(id->rawExtent());
     TORCH_INTERNAL_ASSERT(
         inferred_val.has_value(),

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -821,9 +821,10 @@ kir::TensorIndex* Index::getGlobalProducerIndex(
   int64_t stride_i = 0;
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
-    if (root_dom[i]->isReduction()) {
+    if (root_dom[i]->isReduction() ||
+        root_dom[i]->getIterType() == IterType::BroadcastWithoutStride) {
       continue;
-    } else if (root_dom[i]->isBroadcast()) {
+    } else if (root_dom[i]->getIterType() == IterType::BroadcastWithStride) {
       stride_i++;
       continue;
     }
@@ -1047,9 +1048,10 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
   int64_t stride_i = 0;
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
-    if (root_dom[i]->isReduction()) {
+    if (root_dom[i]->isReduction() ||
+        root_dom[i]->getIterType() == IterType::BroadcastWithoutStride) {
       continue;
-    } else if (root_dom[i]->isBroadcast()) {
+    } else if (root_dom[i]->getIterType() == IterType::BroadcastWithStride) {
       stride_i++;
       continue;
     }

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -821,10 +821,9 @@ kir::TensorIndex* Index::getGlobalProducerIndex(
   int64_t stride_i = 0;
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
-    if (root_dom[i]->isReduction() ||
-        root_dom[i]->getIterType() == IterType::BroadcastWithoutStride) {
+    if (root_dom[i]->isReduction()) {
       continue;
-    } else if (root_dom[i]->getIterType() == IterType::BroadcastWithStride) {
+    } else if (root_dom[i]->isBroadcast()) {
       stride_i++;
       continue;
     }
@@ -1048,10 +1047,9 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
   int64_t stride_i = 0;
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
-    if (root_dom[i]->isReduction() ||
-        root_dom[i]->getIterType() == IterType::BroadcastWithoutStride) {
+    if (root_dom[i]->isReduction()) {
       continue;
-    } else if (root_dom[i]->getIterType() == IterType::BroadcastWithStride) {
+    } else if (root_dom[i]->isBroadcast()) {
       stride_i++;
       continue;
     }


### PR DESCRIPTION
Fixes #363 

Striding tensors allocated global memory has a problem with broadcast dimensions with no stride. I assume here that such tensors only appear when intermediate tensors are allocated on global memory. Gmem-allocated intermediate tensors have strides for all dimensions except for reduction dimensions, traversal of the stride list should skip broadcast axes.

In the original issue, it was reported that validation failures happened randomly. I ran the reproducer 100 times with this change and didn't see any failure even with the default validation threshold.
