### PR TITLE
Remove Stream Synchronization from runFusion

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -529,7 +529,6 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         stream,
         kernel_arguments.getBuffer(),
         nullptr));
-    AT_CUDA_CHECK(cudaStreamSynchronize(stream));
   }
 
   return allocated_outputs;

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -23,7 +23,7 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-int FusionExecutor::fusion_id_counter_ = 0;
+int FusionExecutor::fusion_id_counter_ = 0; // NOLINT
 
 std::string FusionExecutor::getStructuredCode(const std::string& kernel) {
   // generating cuda code;


### PR DESCRIPTION
This is a perf problem to have a sync as it doesn't allow for CPU time overlap.