### PR TITLE
Add double support

### DIFF
--- a/test/cpp/jit/test_gpu_validator.h
+++ b/test/cpp/jit/test_gpu_validator.h
@@ -48,7 +48,10 @@ std::pair<double, double> getTolerance(
     int64_t reduction_size,
     const ValidationConstants& tolerances) {
   switch (dtype) {
-    case DataType::Float: {
+    case DataType::Float:
+    // TODO: Pull new tolerances for Double, for now we will just use float
+    // tolerances as it should be no worse.
+    case DataType::Double: {
       const auto& sum_tolerance_entry = tolerances.sum_tolerances_float;
       const auto& base_abs = tolerances.base_float_abs_tol;
       const auto& base_rel = tolerances.base_float_rel_tol;
@@ -331,9 +334,7 @@ void testValidate(
           line_number,
           " in file ",
           file_name,
-          ".\n  Detected abs error in output ",
-          i,
-          " of: ",
+          ".\n  Detected abs error of: ",
           aten_output_tensor.sub(fusion_output_tensor)
               .abs()
               .max()

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -155,15 +155,10 @@ class TestCudaFuser(JitTestCase):
             return o
         t_jit = torch.jit.script(t)
 
-        prev_fallback = os.environ['PYTORCH_NVFUSER_DISABLE_FALLBACK']
-        os.environ['PYTORCH_NVFUSER_DISABLE_FALLBACK'] = '0'
-
         x = torch.randn(8, 4, 16, dtype=torch.double, device="cuda")
         jit_o = t_jit(x)
         jit_o = t_jit(x)
         o = t(x)
-
-        os.environ['PYTORCH_NVFUSER_DISABLE_FALLBACK'] = prev_fallback
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -19,6 +19,8 @@ Val* newScalar(ValType vtype, DataType dtype) {
       switch (dtype) {
         case DataType::Bool:
           return new Bool();
+        case DataType::Double:
+          return new Float();
         case DataType::Float:
           return new Float();
         case DataType::Half:
@@ -498,6 +500,9 @@ TensorView* sum(
     bool keep_dim /*=false*/) {
   Val* init = nullptr;
   switch (v1->getDataType().value()) {
+    case (DataType::Double):
+      init = new Double(0.0);
+      break;
     case (DataType::Float):
       init = new Float(0.0);
       break;
@@ -520,6 +525,9 @@ TensorView* max(
     bool keep_dim /*=false*/) {
   Val* init = nullptr;
   switch (v1->getDataType().value()) {
+    case (DataType::Double):
+      init = new Double(DBL_MIN);
+      break;
     case (DataType::Float):
       init = new Float(FLT_MIN);
       break;
@@ -542,6 +550,9 @@ TensorView* min(
     bool keep_dim /*=false*/) {
   Val* init = nullptr;
   switch (v1->getDataType().value()) {
+    case (DataType::Double):
+      init = new Double(DBL_MAX);
+      break;
     case (DataType::Float):
       init = new Float(FLT_MAX);
       break;

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -243,62 +243,22 @@ TensorView* arithOpOverloads(
              vals[3]->template as<Val>())
       ->template as<TensorView>();
 }
-
-DataType getOutputType(BinaryOpType type, DataType v1_type, DataType v2_type) {
-  bool floating_input =
-      isFloatingPointType(v1_type) || isFloatingPointType(v2_type);
-  bool integer_input = isIntegralType(v1_type) || isIntegralType(v2_type);
-
-  if (isIntegerOp(type)) {
-    if (integer_input && !floating_input) {
-      return isIntegralType(v1_type) ? v1_type : v2_type;
-    } else {
-      // When we add more integer types we should return type promoted int
-      return DataType::Int;
-    }
-  } else if (isLogicalOp(type)) {
-    return DataType::Bool;
-  } else if (maybeBooleanOperator(type)) {
-    TORCH_CHECK(
-        !floating_input,
-        "Operator ",
-        type,
-        " not supported with floating point inputs.");
-    if (integer_input) {
-      // When we add more integer types we should return type promoted int
-      return DataType::Int;
-    } else {
-      return DataType::Bool;
-    }
-  } else {
-    return promote_type(v1_type, v2_type);
-  }
-}
-
 } // namespace
 
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
   auto vals = maybeBroadcast({v1, v2});
-  ValType val_type =
-      promote_type(v1->getValType().value(), v2->getValType().value());
-
-  DataType dtype =
-      getOutputType(type, v1->getDataType().value(), v2->getDataType().value());
-
-  Val* out = nullptr;
-  if (val_type == ValType::TensorView) {
-    out = newOutputTV(vals, dtype);
-  } else {
-    out = newScalar(val_type, dtype);
+  Val* out = newOutputVal({vals[0], vals[1]});
+  if (is_logical_op(type)) {
+    if (out->getDataType().value() != DataType::Bool)
+      out = newValLike(out, DataType::Bool);
+  } else if (type >= BinaryOpType::Mod) {
+    if (out->getDataType().value() != DataType::Int)
+      out = newValLike(out, DataType::Int);
   }
 
-  TORCH_INTERNAL_ASSERT(
-      out != nullptr,
-      "Something went wrong in type promotion, output is not valid.");
   new BinaryOp(type, out, vals[0], vals[1]);
   return out;
 }
-
 TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2) {
   return arithOpOverloads(type, v1, v2);
 }

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -20,7 +20,6 @@ Val* newScalar(ValType vtype, DataType dtype) {
         case DataType::Bool:
           return new Bool();
         case DataType::Double:
-          return new Float();
         case DataType::Float:
           return new Float();
         case DataType::Half:

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -65,16 +65,11 @@ class CudaKernelGenerator : private kir::IrVisitor {
         TORCH_INTERNAL_ASSERT(val->isScalar());
         // All floating point arguments come in as double, all int arguments
         // come in as int64
-        bool isFloatingPoint;
+        bool isFloatingPoint = true;
         switch (val->dtype()) {
           case (DataType::Double):
-            isFloatingPoint = true;
-            break;
           case (DataType::Float):
-            isFloatingPoint = true;
-            break;
           case (DataType::Half):
-            isFloatingPoint = true;
             break;
           case (DataType::Int):
             isFloatingPoint = false;

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -60,10 +60,42 @@ class CudaKernelGenerator : private kir::IrVisitor {
               << TensorDomain::noReductions(
                      tv->fuserTv()->getMaybeRFactorDomain())
                      .size()
-              << "> " << varName(tv, "T");
+              << "> " << varName(tv);
       } else {
         TORCH_INTERNAL_ASSERT(val->isScalar());
-        code_ << val->dtype() << " " << gen(val);
+        // All floating point arguments come in as double, all int arguments
+        // come in as int64
+        bool isFloatingPoint;
+        switch (val->dtype()) {
+          case (DataType::Double):
+            isFloatingPoint = true;
+            break;
+          case (DataType::Float):
+            isFloatingPoint = true;
+            break;
+          case (DataType::Half):
+            isFloatingPoint = true;
+            break;
+          case (DataType::Int):
+            isFloatingPoint = false;
+            break;
+          default:
+            TORCH_INTERNAL_ASSERT(
+                false,
+                "Scalar type of ",
+                val->dtype(),
+                " is not currently supported as a scalar argument to kernels.");
+        }
+        if (isFloatingPoint) {
+          code_ << DataType::Double;
+        } else {
+          code_ << DataType::Int;
+        }
+        if (val->definition() != nullptr) {
+          code_ << " " << gen(val);
+        } else {
+          code_ << " " << varName(val);
+        }
       }
 
       if (val != params.back()) {
@@ -86,7 +118,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
                 id->iterType() != IterType::BroadcastWithoutStride;
           });
       code_ << ", Tensor<" << tv->dtype() << ", " << nDims << "> "
-            << varName(tv, "T");
+            << varName(tv);
     }
 
     // Kernels generating random numbers take extra (seed, offset) arguments
@@ -177,7 +209,14 @@ class CudaKernelGenerator : private kir::IrVisitor {
   }
 
   // TODO(kir): consider automatic var naming
-  std::string varName(const kir::Val* val, const char* prefix) {
+  std::string varName(const kir::Val* val) {
+    std::string prefix = "";
+    if (val->isA<kir::TensorView>()) {
+      prefix = "T";
+    } else {
+      prefix = typePrefix(val->dtype());
+    }
+
     std::stringstream value_name;
     if (val->name() != kInvalidStmName) {
       value_name << prefix << val->name();
@@ -202,7 +241,21 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else if (node->isConst()) {
       code_ << *node->value();
     } else {
-      code_ << varName(node, "b");
+      code_ << varName(node);
+    }
+  }
+
+  void visit(const kir::Double* node) final {
+    const auto def = node->definition();
+    if (print_inline_ && def != nullptr) {
+      code_ << "(" << gen(def) << ")";
+    } else if (node->isConst()) {
+      const int digits = std::numeric_limits<Double::ScalarType>::max_digits10;
+      code_ << "double(" << std::setprecision(digits) << *node->value() << ")";
+    } else if (def == nullptr) {
+      code_ << "(double)" << varName(node);
+    } else {
+      code_ << varName(node);
     }
   }
 
@@ -213,8 +266,10 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else if (node->isConst()) {
       const int digits = std::numeric_limits<Float::ScalarType>::max_digits10;
       code_ << "float(" << std::setprecision(digits) << *node->value() << ")";
+    } else if (def == nullptr) {
+      code_ << "(float) " << varName(node);
     } else {
-      code_ << varName(node, "f");
+      code_ << varName(node);
     }
   }
 
@@ -225,7 +280,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else if (node->isConst()) {
       code_ << "__float2half(" << *node->value() << ")";
     } else {
-      code_ << varName(node, "h");
+      code_ << varName(node);
     }
   }
 
@@ -236,7 +291,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else if (node->isConst()) {
       code_ << *node->value();
     } else {
-      code_ << varName(node, "i");
+      code_ << varName(node);
     }
   }
 
@@ -245,7 +300,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
   }
 
   void visit(const kir::TensorIndex* node) final {
-    code_ << varName(node->view(), "T") << "[";
+    code_ << varName(node->view()) << "[";
 
     bool first = true;
     for (auto* ind : node->indices()) {
@@ -296,6 +351,10 @@ class CudaKernelGenerator : private kir::IrVisitor {
         code_ << cast_str.value();
       } else {
         code_ << node->operation();
+        if (needFloatSuffix(node->operation()) &&
+            node->out()->dtype() == DataType::Float) {
+          code_ << "f";
+        }
       }
 
       code_ << "(";
@@ -314,13 +373,18 @@ class CudaKernelGenerator : private kir::IrVisitor {
 
   std::string genBinaryOp(
       BinaryOpType op_type,
+      kir::Val* out,
       const std::string& lhs,
       const std::string& rhs) {
     std::stringstream expr;
     if (auto op = inline_op_str(op_type)) {
       expr << lhs << " " << *op << " " << rhs;
     } else {
-      expr << op_type << "(" << lhs << ", " << rhs << ")";
+      expr << op_type;
+      if (needFloatSuffix(op_type) && out->dtype() == DataType::Float) {
+        expr << "f";
+      }
+      expr << "(" << lhs << ", " << rhs << ")";
     }
     return expr.str();
   }
@@ -329,13 +393,15 @@ class CudaKernelGenerator : private kir::IrVisitor {
     const auto op_type = node->operation();
     if (print_inline_) {
       // Inline expression: `lhs op rhs`
-      code_ << genBinaryOp(op_type, gen(node->lhs()), gen(node->rhs()));
+      code_ << genBinaryOp(
+          op_type, node->out(), gen(node->lhs()), gen(node->rhs()));
     } else {
       indent() << gen(node->out());
       if (node->out()->isScalar()) {
         // Single line: `out = lhs op rhs;`
         code_ << " = "
-              << genBinaryOp(op_type, gen(node->lhs()), gen(node->rhs()));
+              << genBinaryOp(
+                     op_type, node->out(), gen(node->lhs()), gen(node->rhs()));
       } else {
         // Split TensorView expressions across multiple lines:
         //
@@ -375,10 +441,11 @@ class CudaKernelGenerator : private kir::IrVisitor {
     }
   }
 
-  std::string genReductionOp(BinaryOpType op_type, DataType data_type) {
+  std::string genReductionOp(BinaryOpType op_type, kir::Val* out) {
     std::stringstream lambda;
+    DataType data_type = out->dtype();
     lambda << "[](" << data_type << " &a, " << data_type << " b) "
-           << "{ a = " << genBinaryOp(op_type, "a", "b") << "; }";
+           << "{ a = " << genBinaryOp(op_type, out, "a", "b") << "; }";
     return lambda.str();
   }
 
@@ -430,7 +497,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
       const auto gen_out = gen(out);
       const auto op_type = node->operation();
       indent() << gen_out << " = "
-               << genBinaryOp(op_type, gen_out, gen(node->in())) << ";\n";
+               << genBinaryOp(op_type, out, gen_out, gen(node->in())) << ";\n";
       return;
     }
 
@@ -458,7 +525,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
         indent() << kTab << gen(node->out()) << ",\n";
       }
       indent() << kTab << gen(node->in()) << ",\n";
-      indent() << kTab << genReductionOp(op_type, data_type) << ",\n";
+      indent() << kTab << genReductionOp(op_type, node->out()) << ",\n";
       indent() << kTab << "threadIdx,\n";
       indent() << kTab << "blockDim,\n";
       indent() << kTab << "static_cast<" << data_type << "*>(shared_mem),\n";
@@ -540,9 +607,9 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else {
       indent() << kTab << gen(rop->in()) << ",\n";
     }
-    indent() << kTab << genReductionOp(op_type, data_type) << ",\n";
-    indent() << kTab << "&" << varName(work_buffer, "T") << "[0],\n";
-    indent() << kTab << varName(sync_buffer, "T") << ",\n";
+    indent() << kTab << genReductionOp(op_type, out) << ",\n";
+    indent() << kTab << "&" << varName(work_buffer) << "[0],\n";
+    indent() << kTab << varName(sync_buffer) << ",\n";
     indent() << kTab << "static_cast<" << data_type << "*>(shared_mem),\n";
     if (node->predicate() == nullptr) {
       indent() << kTab << "true,\n";
@@ -612,25 +679,25 @@ class CudaKernelGenerator : private kir::IrVisitor {
       // Allocate alias another Allocate node
       const auto alias_tv = node->alias()->buffer()->as<kir::TensorView>();
       indent() << "// Alias Allocation - " << node->memoryType() << "\n";
-      indent() << buffer_dtype << "* " << varName(tv, "T") << " = "
-               << varName(alias_tv, "T") << ";\n";
+      indent() << buffer_dtype << "* " << varName(tv) << " = "
+               << varName(alias_tv) << ";\n";
     } else {
       // Standard Memory Allocation
       switch (tv->memoryType()) {
         case MemoryType::Global:
-          indent() << "// Allocate global tensor " << varName(tv, "T") << "\n";
+          indent() << "// Allocate global tensor " << varName(tv) << "\n";
           break;
         case MemoryType::Shared:
           if (kir::ExpressionEvaluator::isConst(size)) {
             // Static shared memory
-            indent() << "__shared__ " << buffer_dtype << " " << varName(tv, "T")
+            indent() << "__shared__ " << buffer_dtype << " " << varName(tv)
                      << "[" << genInline(size) << "];\n";
           } else {
             // Align Offset Position
             indent() << "offset = alignBufferSize(offset,"
                      << dataTypeSize(buffer_dtype) << ");\n";
             // Shared Memory Pointer
-            indent() << buffer_dtype << "* " << varName(tv, "T")
+            indent() << buffer_dtype << "* " << varName(tv)
                      << " = reinterpret_cast<" << buffer_dtype << "*>"
                      << "(array + offset);\n";
             // Increment Offset Position
@@ -639,7 +706,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
           }
           break;
         case MemoryType::Local:
-          indent() << buffer_dtype << " " << varName(tv, "T") << "["
+          indent() << buffer_dtype << " " << varName(tv) << "["
                    << genInline(size) << "];\n";
           break;
         default:

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -48,6 +48,9 @@ void Val::dispatch(T handler, Val* val) {
         case DataType::Bool:
           ptr(handler)->handle(val->as<Bool>());
           return;
+        case DataType::Double:
+          ptr(handler)->handle(val->as<Double>());
+          return;
         case DataType::Float:
           ptr(handler)->handle(val->as<Float>());
           return;
@@ -125,6 +128,9 @@ void Val::constDispatch(T handler, const Val* val) {
       switch (*(val->getDataType())) {
         case DataType::Bool:
           ptr(handler)->handle(val->as<Bool>());
+          return;
+        case DataType::Double:
+          ptr(handler)->handle(val->as<Double>());
           return;
         case DataType::Float:
           ptr(handler)->handle(val->as<Float>());
@@ -214,6 +220,8 @@ Statement* Val::mutatorDispatch(T mutator, Val* val) {
       switch (*(val->getDataType())) {
         case DataType::Bool:
           return ptr(mutator)->mutate(val->as<Bool>());
+        case DataType::Double:
+          return ptr(mutator)->mutate(val->as<Double>());
         case DataType::Float:
           return ptr(mutator)->mutate(val->as<Float>());
         case DataType::Half:

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -61,6 +61,7 @@ class IterDomain;
 class TensorDomain;
 class TensorView;
 class Bool;
+class Double;
 class Float;
 class Half;
 class Int;
@@ -89,6 +90,7 @@ class TORCH_CUDA_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const TensorDomain*) {}
   virtual void handle(const TensorView*) {}
   virtual void handle(const Bool*) {}
+  virtual void handle(const Double*) {}
   virtual void handle(const Float*) {}
   virtual void handle(const Half*) {}
   virtual void handle(const Int*) {}
@@ -116,6 +118,7 @@ class TORCH_CUDA_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(TensorDomain*) {}
   virtual void handle(TensorView*) {}
   virtual void handle(Bool*) {}
+  virtual void handle(Double*) {}
   virtual void handle(Float*) {}
   virtual void handle(Half*) {}
   virtual void handle(Int*) {}
@@ -150,6 +153,9 @@ class TORCH_CUDA_API OptInConstDispatch : public PolymorphicBase {
   }
   virtual void handle(const Bool*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Bool.");
+  }
+  virtual void handle(const Double*) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Double.");
   }
   virtual void handle(const Float*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
@@ -207,6 +213,9 @@ class TORCH_CUDA_API OptInDispatch : public PolymorphicBase {
   }
   virtual void handle(Bool*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Bool.");
+  }
+  virtual void handle(Double*) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Double.");
   }
   virtual void handle(Float*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
@@ -280,6 +289,7 @@ class TORCH_CUDA_API OptOutMutator : public PolymorphicBase {
   virtual Statement* mutate(TensorDomain*);
   virtual Statement* mutate(TensorView*);
   virtual Statement* mutate(Bool*);
+  virtual Statement* mutate(Double*);
   virtual Statement* mutate(Float*);
   virtual Statement* mutate(Half*);
   virtual Statement* mutate(Int*);

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -14,6 +14,8 @@ std::unique_ptr<TensorArgAbstract> getTensorArg(
     c10::ScalarType dtype,
     int nDims) {
   switch (dtype) {
+    case c10::ScalarType::Double:
+      return getTensorArg<double>(nDims);
     case c10::ScalarType::Float:
       return getTensorArg<float>(nDims);
     case c10::ScalarType::Half:
@@ -53,12 +55,13 @@ void KernelArgumentHolder::push(const IValue& val) {
       val.isScalar(),
       "Tried to push an arg to run in a fused kernel, expected a scalar but got, ",
       val);
-  switch (val.toScalar().type()) {
+  auto scalar_val = val.toScalar();
+  switch (scalar_val.type()) {
     case c10::ScalarType::Double:
-      arguments_.push_back(std::make_unique<FloatArg>((float)val.toDouble()));
+      arguments_.push_back(std::make_unique<DoubleArg>(scalar_val.toDouble()));
       return;
     case c10::ScalarType::Long:
-      arguments_.push_back(std::make_unique<LongArg>(val.toInt()));
+      arguments_.push_back(std::make_unique<LongArg>(scalar_val.toInt()));
       return;
     default:
       TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
@@ -53,6 +53,7 @@ struct ArgAbstract {
   virtual void* arg() = 0;
 };
 
+// Explicitly for philox seed, not a supported type by any other mechanism
 struct ULongArg : public ArgAbstract {
   uint64_t val_;
   ULongArg(uint64_t _val) : val_(_val){};
@@ -69,17 +70,9 @@ struct LongArg : public ArgAbstract {
   }
 };
 
-struct IntArg : public ArgAbstract {
-  int val_;
-  IntArg(int _val) : val_(_val){};
-  void* arg() {
-    return &val_;
-  }
-};
-
-struct FloatArg : public ArgAbstract {
-  float val_;
-  FloatArg(float _val) : val_(_val){};
+struct DoubleArg : public ArgAbstract {
+  double val_;
+  DoubleArg(double _val) : val_(_val){};
   void* arg() {
     return &val_;
   }

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -69,6 +69,10 @@ class ConstCheck : OptOutConstDispatch {
     is_const_ = is_const_ && b->isConst();
   }
 
+  void handle(const Double* d) override {
+    is_const_ = is_const_ && d->isConst();
+  }
+
   void handle(const Float* f) override {
     is_const_ = is_const_ && f->isConst();
   }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
@@ -66,6 +66,10 @@ void IrCloner::handle(const Bool* b) {
   clone_ = new Bool(b, this);
 }
 
+void IrCloner::handle(const Double* d) {
+  clone_ = new Double(d, this);
+}
+
 void IrCloner::handle(const Float* f) {
   clone_ = new Float(f, this);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -53,6 +53,7 @@ class TORCH_CUDA_API IrCloner : private OptInConstDispatch {
   void handle(const IterDomain*) override;
 
   void handle(const Bool*) override;
+  void handle(const Double*) override;
   void handle(const Float*) override;
   void handle(const Half*) override;
   void handle(const Int*) override;

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -42,6 +42,17 @@ class IrNodeLabel : private OptInConstDispatch {
     }
   }
 
+  void handle(const Double* d) override {
+    if (d->isSymbolic()) {
+      label_ << "d" << d->name();
+    } else {
+      if (detail_level_ >= DetailLevel::Explicit) {
+        label_ << "d" << d->name() << "=";
+      }
+      label_ << *d->value();
+    }
+  }
+
   void handle(const Float* f) override {
     if (f->isSymbolic()) {
       label_ << "f" << f->name();
@@ -335,6 +346,10 @@ void IrGraphGenerator::handle(const IterDomain* id) {
 
 void IrGraphGenerator::handle(const Bool* b) {
   printValue(b, IrNodeLabel::gen(b, detail_level_));
+}
+
+void IrGraphGenerator::handle(const Double* d) {
+  printValue(d, IrNodeLabel::gen(d, detail_level_));
 }
 
 void IrGraphGenerator::handle(const Float* f) {

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -68,6 +68,7 @@ class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
   void handle(const IterDomain*) override;
 
   void handle(const Bool*) override;
+  void handle(const Double*) override;
   void handle(const Float*) override;
   void handle(const Half*) override;
   void handle(const Int*) override;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -46,6 +46,37 @@ class TORCH_CUDA_API Bool : public Val {
   const c10::optional<bool> maybe_value_;
 };
 
+//! A Float64 value. For now we don't have any other type besides
+//! Float64. This value can be a symbolic value (defined after the kernel
+//! is compiled) or a constant value (inlined into the kernel definition).
+class TORCH_CUDA_API Double : public Val {
+ public:
+  using ScalarType = double;
+
+  Double()
+      : Val(ValType::Scalar, DataType::Double), maybe_value_{c10::nullopt} {}
+
+  explicit Double(ScalarType value)
+      : Val(ValType::Scalar, DataType::Double), maybe_value_{value} {}
+
+  Double(const Double* src, IrCloner* ir_cloner);
+
+  bool isSymbolic() const {
+    return !(maybe_value_.has_value());
+  }
+  bool isConst() const {
+    return maybe_value_.has_value();
+  }
+  c10::optional<ScalarType> value() const {
+    return maybe_value_;
+  }
+
+  bool sameAs(const Double* const other) const;
+
+ private:
+  const c10::optional<ScalarType> maybe_value_;
+};
+
 //! A Float32 value. For now we don't have any other type besides
 //! Float32. This value can be a symbolic value (defined after the kernel
 //! is compiled) or a constant value (inlined into the kernel definition).

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -199,23 +199,30 @@ void IrPrinter::handle(const UnaryOp* uop) {
     checkInlineable(uop);
   }
 
-  if (auto inline_uop = inline_op_str(uop->getUnaryOpType())) {
+  auto op_type = uop->getUnaryOpType();
+
+  if (auto inline_uop = inline_op_str(op_type)) {
     os_ << inline_uop.value();
     handle(uop->in());
   } else {
-    if (uop->getUnaryOpType() == UnaryOpType::Cast) {
+    if (op_type == UnaryOpType::Cast) {
       c10::optional<std::string> cast_str = cast_func_str(std::make_pair(
           uop->in()->getDataType().value(), uop->out()->getDataType().value()));
       TORCH_INTERNAL_ASSERT(cast_str != c10::nullopt, "Unsupported Cast");
       os_ << cast_str.value();
     } else {
-      os_ << uop->getUnaryOpType();
-      if (needFloatSuffix(uop->getUnaryOpType()) &&
-          uop->out()->getDataType().value() == DataType::Float) {
+      if (maybeBooleanOperator(op_type) &&
+          uop->out()->getDataType().value() == DataType::Bool) {
+        os_ << stringifyBooleanOp(op_type);
+      } else {
+        os_ << op_type;
+      }
+      if (uop->out()->getDataType().value() == DataType::Float &&
+          needFloatSuffix(op_type)) {
         os_ << "f";
       }
     }
-    if (uop->getUnaryOpType() == UnaryOpType::RandLike) {
+    if (op_type == UnaryOpType::RandLike) {
       os_ << "(";
       os_ << "rnd";
     } else {
@@ -250,7 +257,8 @@ void IrPrinter::handle(const BinaryOp* bop) {
     checkInlineable(bop);
   }
 
-  if (auto inline_bop = inline_op_str(bop->getBinaryOpType())) {
+  auto op_type = bop->getBinaryOpType();
+  if (auto inline_bop = inline_op_str(op_type)) {
     handle(bop->lhs());
     if (istvop) {
       os_ << "\n";
@@ -259,9 +267,14 @@ void IrPrinter::handle(const BinaryOp* bop) {
     os_ << " " << inline_bop.value() << " ";
     handle(bop->rhs());
   } else {
-    os_ << bop->getBinaryOpType();
-    if (needFloatSuffix(bop->getBinaryOpType()) &&
-        bop->out()->getDataType().value() == DataType::Float) {
+    if (maybeBooleanOperator(op_type) &&
+        bop->out()->getDataType().value() == DataType::Bool) {
+      os_ << stringifyBooleanOp(op_type);
+    } else {
+      os_ << op_type;
+    }
+    if (bop->out()->getDataType().value() == DataType::Float &&
+        needFloatSuffix(op_type)) {
       os_ << "f";
     }
     os_ << "(";

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -57,6 +57,7 @@ class TORCH_CUDA_API IrPrinter : public OptInConstDispatch {
   void handle(const IterDomain*) override;
 
   void handle(const Bool*) override;
+  void handle(const Double*) override;
   void handle(const Float*) override;
   void handle(const Half*) override;
   void handle(const Int*) override;

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -39,6 +39,10 @@ class ScalarCheck : OptInConstDispatch {
     same_ = v1_->as<Bool>()->sameAs(v2_->as<Bool>());
   }
 
+  void handle(const Double* d) override {
+    same_ = v1_->as<Double>()->sameAs(v2_->as<Double>());
+  }
+
   void handle(const Float* f) override {
     same_ = v1_->as<Float>()->sameAs(v2_->as<Float>());
   }
@@ -75,6 +79,15 @@ Bool::Bool(const Bool* src, IrCloner* ir_cloner)
     : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
 
 bool Bool::sameAs(const Bool* const other) const {
+  if (isConst() && other->isConst())
+    return *value() == *(other->value());
+  return this == other;
+}
+
+Double::Double(const Double* src, IrCloner* ir_cloner)
+    : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
+
+bool Double::sameAs(const Double* const other) const {
   if (isConst() && other->isConst())
     return *value() == *(other->value());
   return this == other;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -34,6 +34,7 @@ class Expr;
 // Values
 class NamedScalar;
 class Bool;
+class Double;
 class Float;
 class Half;
 class Int;
@@ -88,6 +89,9 @@ class TORCH_CUDA_API IrVisitor : public PolymorphicBase {
     unhandled(named_scalar);
   }
   virtual void visit(const Bool* value) {
+    unhandled(value);
+  }
+  virtual void visit(const Double* value) {
     unhandled(value);
   }
   virtual void visit(const Float* value) {
@@ -347,6 +351,38 @@ class TORCH_CUDA_API Bool final : public Val {
 
  private:
   const c10::optional<bool> maybe_value_;
+};
+
+class TORCH_CUDA_API Double final : public Val {
+ public:
+  using ScalarType = double;
+
+  explicit Double(Passkey passkey, const c10::optional<ScalarType>& value)
+      : Val(passkey, DataType::Double), maybe_value_(value) {}
+
+  explicit Double(Passkey passkey, const fuser::cuda::Double* node)
+      : Val(passkey, DataType::Double), maybe_value_(node->value()) {
+    setName(node->name());
+  }
+
+  void accept(IrVisitor* visitor) const override {
+    visitor->visit(this);
+  }
+
+  bool isScalar() const override {
+    return true;
+  }
+
+  bool isConst() const override {
+    return maybe_value_.has_value();
+  }
+
+  c10::optional<ScalarType> value() const {
+    return maybe_value_;
+  }
+
+ private:
+  const c10::optional<ScalarType> maybe_value_;
 };
 
 class TORCH_CUDA_API Float final : public Val {

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
@@ -10,6 +10,8 @@ Val* IrBuilder::newResult(DataType dtype) {
   switch (dtype) {
     case DataType::Bool:
       return create<Bool>(c10::nullopt);
+    case DataType::Double:
+      return create<Double>(c10::nullopt);
     case DataType::Float:
       return create<Float>(c10::nullopt);
     case DataType::Half:

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -159,6 +159,15 @@ void IrPrinter::visit(const kir::Bool* node) {
   }
 }
 
+void IrPrinter::visit(const kir::Double* node) {
+  if (node->isConst()) {
+    const int digits = std::numeric_limits<Double::ScalarType>::max_digits10;
+    ir_str_ << "double(" << std::setprecision(digits) << *node->value() << ")";
+  } else {
+    ir_str_ << varName(node, "d");
+  }
+}
+
 void IrPrinter::visit(const kir::Float* node) {
   if (node->isConst()) {
     const int digits = std::numeric_limits<Float::ScalarType>::max_digits10;
@@ -229,12 +238,16 @@ void IrPrinter::visit(const kir::UnaryOp* node) {
       ir_str_ << cast_str.value();
     } else {
       ir_str_ << node->operation();
+      if (needFloatSuffix(node->operation()) &&
+        node->out()->dtype() == DataType::Float) {
+        ir_str_ << "f";
+      }
     }
 
-    ir_str_ << "(";
     if (node->operation() == UnaryOpType::RandLike) {
-      ir_str_ << "RND";
+      ir_str_ << "(RND";
     } else {
+      ir_str_ << "(";
       ir_str_ << use(node->in());
     }
     ir_str_ << ")";
@@ -253,7 +266,12 @@ void IrPrinter::visit(const kir::BinaryOp* node) {
   if (auto op = inline_op_str(operation)) {
     ir_str_ << lhs << " " << *op << " " << rhs;
   } else {
-    ir_str_ << operation << "(" << lhs << ", " << rhs << ")";
+    ir_str_ << operation;
+    if (needFloatSuffix(operation) &&
+        node->out()->dtype() == DataType::Float) {
+      ir_str_ << "f";
+    }
+    ir_str_ << "(" << lhs << ", " << rhs << ")";
   }
 
   ir_str_ << "\n";

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -239,7 +239,7 @@ void IrPrinter::visit(const kir::UnaryOp* node) {
     } else {
       ir_str_ << node->operation();
       if (needFloatSuffix(node->operation()) &&
-        node->out()->dtype() == DataType::Float) {
+          node->out()->dtype() == DataType::Float) {
         ir_str_ << "f";
       }
     }
@@ -267,8 +267,7 @@ void IrPrinter::visit(const kir::BinaryOp* node) {
     ir_str_ << lhs << " " << *op << " " << rhs;
   } else {
     ir_str_ << operation;
-    if (needFloatSuffix(operation) &&
-        node->out()->dtype() == DataType::Float) {
+    if (needFloatSuffix(operation) && node->out()->dtype() == DataType::Float) {
       ir_str_ << "f";
     }
     ir_str_ << "(" << lhs << ", " << rhs << ")";

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
@@ -53,6 +53,7 @@ class TORCH_CUDA_API IrPrinter : private kir::IrVisitor {
   void handleBlock(const kir::Scope& scope);
 
   void visit(const kir::Bool*) final;
+  void visit(const kir::Double*) final;
   void visit(const kir::Float*) final;
   void visit(const kir::Half*) final;
   void visit(const kir::Int*) final;

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -219,6 +219,11 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
   }
 
+  void handle(const Double* node) final {
+    const auto lowered_node = ir_builder_.create<kir::Double>(node);
+    TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
+  }
+
   void handle(const Float* node) final {
     const auto lowered_node = ir_builder_.create<kir::Float>(node);
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -87,6 +87,10 @@ Statement* OptOutMutator::mutate(Bool* b) {
   return b;
 }
 
+Statement* OptOutMutator::mutate(Double* d) {
+  return d;
+}
+
 Statement* OptOutMutator::mutate(Float* f) {
   return f;
 }

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -20,8 +20,8 @@ typedef Node JitOp;
 namespace fuser {
 namespace cuda {
 
-constexpr auto kNumUnaryOps = 32;
-constexpr auto kNumBinaryOps = 29;
+constexpr auto kNumUnaryOps = 31;
+constexpr auto kNumBinaryOps = 24;
 constexpr auto kNumBinaryOpsWithAlpha = 4;
 constexpr auto kNumLerpOps = 2;
 
@@ -226,11 +226,6 @@ class IrParser {
         "aten::pow(Scalar self, Tensor exponent) -> Tensor",
         "aten::remainder(Tensor self, Tensor other) -> Tensor",
         "aten::fmod(Tensor self, Tensor other) -> Tensor",
-        "aten::__and__(Tensor self, Tensor other) -> Tensor",
-        "aten::__or__(Tensor self, Tensor other) -> Tensor",
-        "aten::__xor__(Tensor self, Tensor other) -> Tensor",
-        "aten::__lshift__(Tensor self, Tensor other) -> Tensor",
-        "aten::__rshift__(Tensor self, Tensor other) -> Tensor",
         "aten::eq(Tensor self, Tensor other) -> Tensor",
         "aten::eq(Tensor self, Scalar other) -> Tensor",
         "aten::ne(Tensor self, Tensor other) -> Tensor",
@@ -265,12 +260,7 @@ class IrParser {
                  {aten::gt, BinaryOpType::GT},
                  {aten::ge, BinaryOpType::GE},
                  {aten::ne, BinaryOpType::NE},
-                 {aten::eq, BinaryOpType::Eq},
-                 {aten::__and__, BinaryOpType::And},
-                 {aten::__or__, BinaryOpType::Or},
-                 {aten::__xor__, BinaryOpType::Xor},
-                 {aten::__lshift__, BinaryOpType::Lshift},
-                 {aten::__rshift__, BinaryOpType::Rshift}});
+                 {aten::eq, BinaryOpType::Eq}});
             auto lhs = value_map[node->inputs()[0]->unique()];
             auto rhs = value_map[node->inputs()[1]->unique()];
 
@@ -307,7 +297,6 @@ class IrParser {
         "aten::floor(Tensor self) -> Tensor",
         "aten::round(Tensor self) -> Tensor",
         "aten::trunc(Tensor self) -> Tensor",
-        "aten::bitwise_not(Tensor self) -> Tensor",
         "aten::frac(Tensor self) -> Tensor",
         "aten::reciprocal(Tensor self) -> Tensor",
         "aten::relu(Tensor self) -> Tensor",
@@ -347,7 +336,6 @@ class IrParser {
                 {aten::floor, UnaryOpType::Floor},
                 {aten::round, UnaryOpType::Round},
                 {aten::trunc, UnaryOpType::Trunc},
-                {aten::bitwise_not, UnaryOpType::Not},
                 {aten::frac, UnaryOpType::Frac},
                 {aten::reciprocal, UnaryOpType::Reciprocal},
                 {aten::relu, UnaryOpType::Relu},

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -20,8 +20,8 @@ typedef Node JitOp;
 namespace fuser {
 namespace cuda {
 
-constexpr auto kNumUnaryOps = 31;
-constexpr auto kNumBinaryOps = 24;
+constexpr auto kNumUnaryOps = 32;
+constexpr auto kNumBinaryOps = 29;
 constexpr auto kNumBinaryOpsWithAlpha = 4;
 constexpr auto kNumLerpOps = 2;
 
@@ -226,6 +226,11 @@ class IrParser {
         "aten::pow(Scalar self, Tensor exponent) -> Tensor",
         "aten::remainder(Tensor self, Tensor other) -> Tensor",
         "aten::fmod(Tensor self, Tensor other) -> Tensor",
+        "aten::__and__(Tensor self, Tensor other) -> Tensor",
+        "aten::__or__(Tensor self, Tensor other) -> Tensor",
+        "aten::__xor__(Tensor self, Tensor other) -> Tensor",
+        "aten::__lshift__(Tensor self, Tensor other) -> Tensor",
+        "aten::__rshift__(Tensor self, Tensor other) -> Tensor",
         "aten::eq(Tensor self, Tensor other) -> Tensor",
         "aten::eq(Tensor self, Scalar other) -> Tensor",
         "aten::ne(Tensor self, Tensor other) -> Tensor",
@@ -260,7 +265,12 @@ class IrParser {
                  {aten::gt, BinaryOpType::GT},
                  {aten::ge, BinaryOpType::GE},
                  {aten::ne, BinaryOpType::NE},
-                 {aten::eq, BinaryOpType::Eq}});
+                 {aten::eq, BinaryOpType::Eq},
+                 {aten::__and__, BinaryOpType::And},
+                 {aten::__or__, BinaryOpType::Or},
+                 {aten::__xor__, BinaryOpType::Xor},
+                 {aten::__lshift__, BinaryOpType::Lshift},
+                 {aten::__rshift__, BinaryOpType::Rshift}});
             auto lhs = value_map[node->inputs()[0]->unique()];
             auto rhs = value_map[node->inputs()[1]->unique()];
 
@@ -297,6 +307,7 @@ class IrParser {
         "aten::floor(Tensor self) -> Tensor",
         "aten::round(Tensor self) -> Tensor",
         "aten::trunc(Tensor self) -> Tensor",
+        "aten::bitwise_not(Tensor self) -> Tensor",
         "aten::frac(Tensor self) -> Tensor",
         "aten::reciprocal(Tensor self) -> Tensor",
         "aten::relu(Tensor self) -> Tensor",
@@ -336,6 +347,7 @@ class IrParser {
                 {aten::floor, UnaryOpType::Floor},
                 {aten::round, UnaryOpType::Round},
                 {aten::trunc, UnaryOpType::Trunc},
+                {aten::bitwise_not, UnaryOpType::Not},
                 {aten::frac, UnaryOpType::Frac},
                 {aten::reciprocal, UnaryOpType::Reciprocal},
                 {aten::relu, UnaryOpType::Relu},

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -702,10 +702,11 @@ class IrParser {
             // TODO: support cast of output types yet;
             if (!node->inputs()[3]->type()->isSubtypeOf(
                     static_cast<c10::TypePtr>(NoneType::get()))) {
-              // We can only handle output as half and float;
+              // We can only handle output as half, float, and double;
               if (const auto opt_ivalue = toIValue(node->input(3))) {
                 const auto scalar_type = opt_ivalue->toScalarType();
-                if (scalar_type == at::ScalarType::Float ||
+                if (scalar_type == at::ScalarType::Double ||
+                    scalar_type == at::ScalarType::Float ||
                     scalar_type == at::ScalarType::Half) {
                   return true;
                 }

--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -50,7 +50,6 @@ class NaiveTypePropagator {
       }
       // unary operations that forward meta info:
       case aten::neg:
-      case aten::bitwise_not:
       case aten::abs:
       case aten::log:
       case aten::log10:
@@ -118,30 +117,7 @@ class NaiveTypePropagator {
         node->output()->setType(promoted_type);
         break;
       }
-      // Type can be int or bool for "and" and "or", if both are bool should be
-      // bool, if both int should be int, otherwise would have errored
-      case aten::__and__:
-      case aten::__or__: {
-        const auto promoted_type = binary_broadcast_type(
-            node->input(0)->type()->cast<TensorType>(),
-            node->input(1)->type()->cast<TensorType>(),
-            node->input(0)->type()->cast<TensorType>()->scalarType() ==
-                    at::ScalarType::Bool
-                ? at::ScalarType::Bool
-                : at::ScalarType::Int);
-        break;
-      }
-      // Real int ops
-      case aten::__xor__:
-      case aten::__lshift__:
-      case aten::__rshift__: {
-        const auto promoted_type = binary_broadcast_type(
-            node->input(0)->type()->cast<TensorType>(),
-            node->input(1)->type()->cast<TensorType>(),
-            at::ScalarType::Int);
-        node->output()->setType(promoted_type);
-        break;
-      }
+      // TODO: double check type casting logic for operations commented out.
       case aten::lt:
       case aten::le:
       case aten::gt:

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -8,62 +8,6 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-bool isFloatingPointType(DataType dtype) {
-  switch (dtype) {
-    case DataType::Bool:
-      return false;
-    case DataType::Double:
-      return true;
-    case DataType::Float:
-      return true;
-    case DataType::Half:
-      return true;
-    case DataType::Int:
-      return false;
-    case DataType::Null:
-      TORCH_CHECK(
-          false, "Null type is not a valid argument to isFloatingPoint");
-    default:
-      TORCH_CHECK(false, "Type not supported in isFloatingPoint");
-  }
-}
-
-bool isIntegralType(DataType dtype) {
-  switch (dtype) {
-    case DataType::Bool:
-      return false;
-    case DataType::Double:
-      return false;
-    case DataType::Float:
-      return false;
-    case DataType::Half:
-      return false;
-    case DataType::Int:
-      return true;
-    case DataType::Null:
-      TORCH_CHECK(
-          false, "Null type is not a valid argument to isFloatingPoint");
-    default:
-      TORCH_CHECK(false, "Type not supported in isFloatingPoint");
-  }
-}
-
-bool isIntegerOp(const BinaryOpType bopt) {
-  return bopt >= BinaryOpType::Mod && bopt <= BinaryOpType::Xor;
-}
-
-bool isLogicalOp(const BinaryOpType bopt) {
-  return bopt >= BinaryOpType::Eq && bopt <= BinaryOpType::NE;
-}
-
-bool maybeBooleanOperator(const BinaryOpType bopt) {
-  return bopt >= BinaryOpType::And && bopt <= BinaryOpType::Or;
-}
-
-bool maybeBooleanOperator(const UnaryOpType uopt) {
-  return uopt >= UnaryOpType::Not && uopt <= UnaryOpType::Not;
-}
-
 // Return highest on list (smallest enum val)
 DataType promote_type(const DataType& t1, const DataType& t2) {
   TORCH_CHECK(
@@ -252,8 +196,6 @@ static const char* unary_op_type2string(UnaryOpType t) {
       return "log2";
     case UnaryOpType::Neg:
       return "neg";
-    case UnaryOpType::Not:
-      return "not";
     case UnaryOpType::RandLike:
       return "randLike";
     case UnaryOpType::Reciprocal:
@@ -285,18 +227,10 @@ static const char* unary_op_type2string(UnaryOpType t) {
   }
 }
 
-std::string stringifyBooleanOp(const UnaryOpType uopt) {
-  TORCH_INTERNAL_ASSERT(
-      uopt == UnaryOpType::Not, uopt, " is not a boolean operator.");
-  return "!";
-}
-
 static const char* unary_op_type_inline_op2string(UnaryOpType t) {
   switch (t) {
     case UnaryOpType::Neg:
       return "-";
-    case UnaryOpType::Not:
-      return "~";
     case UnaryOpType::Set:
       return "";
     default:
@@ -377,21 +311,16 @@ static const char* binary_op_type_inline_op2string(BinaryOpType t) {
       return "+";
     case BinaryOpType::Div:
       return "/";
+    case BinaryOpType::Mod:
+      return "%";
     case BinaryOpType::Mul:
       return "*";
     case BinaryOpType::Sub:
       return "-";
 
-    // Integer ops
-    case BinaryOpType::Mod:
-      return "%";
-    case BinaryOpType::Lshift:
-      return "<<";
-    case BinaryOpType::Rshift:
-      return ">>";
-    case BinaryOpType::Xor:
-      return "^";
     // Logical Ops
+    case BinaryOpType::And:
+      return "&&";
     case BinaryOpType::Eq:
       return "==";
     case BinaryOpType::GE:
@@ -404,26 +333,10 @@ static const char* binary_op_type_inline_op2string(BinaryOpType t) {
       return "<";
     case BinaryOpType::NE:
       return "!=";
-    // Assume bitwise, otherwise use stringifyBooleanOp
-    case BinaryOpType::And:
-      return "&";
-    case BinaryOpType::Or:
-      return "|";
     default:
       break;
   }
   return nullptr;
-}
-
-std::string stringifyBooleanOp(const BinaryOpType bopt) {
-  switch (bopt) {
-    case BinaryOpType::And:
-      return "&&";
-    case BinaryOpType::Or:
-      return "||";
-    default:
-      TORCH_INTERNAL_ASSERT(false, bopt, " is not a boolean operator.")
-  }
 }
 
 static const char* ternary_op_type2string(TernaryOpType t) {
@@ -526,6 +439,21 @@ static const char* supported_casts2string(
       return "float";
     default:
       return nullptr;
+  }
+}
+
+bool is_logical_op(const BinaryOpType& bot) {
+  switch (bot) {
+    case BinaryOpType::And:
+    case BinaryOpType::Eq:
+    case BinaryOpType::GE:
+    case BinaryOpType::GT:
+    case BinaryOpType::LE:
+    case BinaryOpType::LT:
+    case BinaryOpType::NE:
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -93,67 +93,25 @@ static const char* expr_type2string(ExprType t) {
 
 bool needFloatSuffix(UnaryOpType t) {
   switch (t) {
-    case UnaryOpType::Acos:
-      return true;
-    case UnaryOpType::Asin:
-      return true;
-    case UnaryOpType::Atan:
-      return true;
-    case UnaryOpType::Atanh:
-      return true;
-    case UnaryOpType::Ceil:
-      return true;
-    case UnaryOpType::Cos:
-      return true;
-    case UnaryOpType::Cosh:
-      return true;
-    case UnaryOpType::Exp:
-      return true;
-    case UnaryOpType::Expm1:
-      return true;
-    case UnaryOpType::Erf:
-      return true;
-    case UnaryOpType::Erfc:
-      return true;
-    case UnaryOpType::Floor:
-      return true;
-    case UnaryOpType::Lgamma:
-      return true;
-    case UnaryOpType::Log:
-      return true;
-    case UnaryOpType::Log10:
-      return true;
-    case UnaryOpType::Log1p:
-      return true;
-    case UnaryOpType::Log2:
-      return true;
-    case UnaryOpType::RandLike:
-      return true;
-    case UnaryOpType::Rsqrt:
-      return true;
-    case UnaryOpType::Round:
-      return true;
-    case UnaryOpType::Sin:
-      return true;
-    case UnaryOpType::Sinh:
-      return true;
-    case UnaryOpType::Sqrt:
-      return true;
-    case UnaryOpType::Tan:
-      return true;
-    case UnaryOpType::Tanh:
-      return true;
-    case UnaryOpType::Trunc:
-      return true;
-    default:
+    case UnaryOpType::Abs:
+    case UnaryOpType::Cast:
+    case UnaryOpType::Frac:
+    case UnaryOpType::Gelu:
+    case UnaryOpType::Neg:
+    case UnaryOpType::Relu:
+    case UnaryOpType::Reciprocal:
+    case UnaryOpType::Set:
+    case UnaryOpType::Sigmoid:
       return false;
+    default:
+      return true;
   }
 }
 
 static const char* unary_op_type2string(UnaryOpType t) {
   switch (t) {
     case UnaryOpType::Abs:
-      return "fabs";
+      return "abs";
     case UnaryOpType::Acos:
       return "acos";
     case UnaryOpType::Asin:
@@ -242,15 +200,10 @@ static const char* unary_op_type_inline_op2string(UnaryOpType t) {
 bool needFloatSuffix(BinaryOpType t) {
   switch (t) {
     case BinaryOpType::Atan2:
-      return true;
     case BinaryOpType::Div:
-      return true;
     case BinaryOpType::Fmod:
-      return true;
     case BinaryOpType::Max:
-      return true;
     case BinaryOpType::Min:
-      return true;
     case BinaryOpType::Pow:
       return true;
     default:
@@ -555,7 +508,6 @@ std::string typePrefix(const DataType data_type) {
     case DataType::Double:
       return "d";
     case DataType::Float:
-      return "f";
     case DataType::Half:
       return "f";
     case DataType::Int:
@@ -591,13 +543,13 @@ size_t dataTypeSize(DataType type) {
     case DataType::Bool:
       return sizeof(bool);
     case DataType::Double:
-      return 8;
+      return sizeof(double);
     case DataType::Float:
-      return 4;
+      return sizeof(float);
     case DataType::Half:
-      return 2;
+      return sizeof(at::Half);
     case DataType::Int:
-      return 4;
+      return sizeof(uint64_t);
     default:
       TORCH_INTERNAL_ASSERT(false, "Size undefined for data type, ", type);
   }

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -36,6 +36,8 @@ static const char* data_type2string(DataType t) {
   switch (t) {
     case DataType::Bool:
       return "bool";
+    case DataType::Double:
+      return "double";
     case DataType::Float:
       return "float";
     case DataType::Half:
@@ -89,50 +91,109 @@ static const char* expr_type2string(ExprType t) {
   }
 }
 
+bool needFloatSuffix(UnaryOpType t) {
+  switch (t) {
+    case UnaryOpType::Acos:
+      return true;
+    case UnaryOpType::Asin:
+      return true;
+    case UnaryOpType::Atan:
+      return true;
+    case UnaryOpType::Atanh:
+      return true;
+    case UnaryOpType::Ceil:
+      return true;
+    case UnaryOpType::Cos:
+      return true;
+    case UnaryOpType::Cosh:
+      return true;
+    case UnaryOpType::Exp:
+      return true;
+    case UnaryOpType::Expm1:
+      return true;
+    case UnaryOpType::Erf:
+      return true;
+    case UnaryOpType::Erfc:
+      return true;
+    case UnaryOpType::Floor:
+      return true;
+    case UnaryOpType::Lgamma:
+      return true;
+    case UnaryOpType::Log:
+      return true;
+    case UnaryOpType::Log10:
+      return true;
+    case UnaryOpType::Log1p:
+      return true;
+    case UnaryOpType::Log2:
+      return true;
+    case UnaryOpType::RandLike:
+      return true;
+    case UnaryOpType::Rsqrt:
+      return true;
+    case UnaryOpType::Round:
+      return true;
+    case UnaryOpType::Sin:
+      return true;
+    case UnaryOpType::Sinh:
+      return true;
+    case UnaryOpType::Sqrt:
+      return true;
+    case UnaryOpType::Tan:
+      return true;
+    case UnaryOpType::Tanh:
+      return true;
+    case UnaryOpType::Trunc:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static const char* unary_op_type2string(UnaryOpType t) {
   switch (t) {
     case UnaryOpType::Abs:
       return "fabs";
     case UnaryOpType::Acos:
-      return "acosf";
+      return "acos";
     case UnaryOpType::Asin:
-      return "asinf";
+      return "asin";
     case UnaryOpType::Atan:
-      return "atanf";
+      return "atan";
     case UnaryOpType::Atanh:
-      return "atanhf";
+      return "atanh";
     case UnaryOpType::Cast:
       return "cast";
     case UnaryOpType::Ceil:
-      return "ceilf";
+      return "ceil";
     case UnaryOpType::Cos:
-      return "cosf";
+      return "cos";
     case UnaryOpType::Cosh:
-      return "coshf";
+      return "cosh";
     case UnaryOpType::Exp:
-      return "expf";
+      return "exp";
     case UnaryOpType::Expm1:
-      return "expm1f";
+      return "expm1";
     case UnaryOpType::Erf:
-      return "erff";
+      return "erf";
     case UnaryOpType::Erfc:
-      return "erfcf";
+      return "erfc";
     case UnaryOpType::Floor:
-      return "floorf";
+      return "floor";
     case UnaryOpType::Frac:
       return "frac";
     case UnaryOpType::Gelu:
       return "gelu";
     case UnaryOpType::Lgamma:
-      return "lgammaf";
+      return "lgamma";
     case UnaryOpType::Log:
-      return "logf";
+      return "log";
     case UnaryOpType::Log10:
-      return "log10f";
+      return "log10";
     case UnaryOpType::Log1p:
-      return "log1pf";
+      return "log1p";
     case UnaryOpType::Log2:
-      return "log2f";
+      return "log2";
     case UnaryOpType::Neg:
       return "neg";
     case UnaryOpType::RandLike:
@@ -142,25 +203,25 @@ static const char* unary_op_type2string(UnaryOpType t) {
     case UnaryOpType::Relu:
       return "relu";
     case UnaryOpType::Rsqrt:
-      return "rsqrtf";
+      return "rsqrt";
     case UnaryOpType::Round:
-      return "nearbyintf";
+      return "nearbyint";
     case UnaryOpType::Set:
       return "set";
     case UnaryOpType::Sigmoid:
       return "sigmoid";
     case UnaryOpType::Sin:
-      return "sinf";
+      return "sin";
     case UnaryOpType::Sinh:
-      return "sinhf";
+      return "sinh";
     case UnaryOpType::Sqrt:
-      return "sqrtf";
+      return "sqrt";
     case UnaryOpType::Tan:
-      return "tanf";
+      return "tan";
     case UnaryOpType::Tanh:
-      return "tanhf";
+      return "tanh";
     case UnaryOpType::Trunc:
-      return "truncf";
+      return "trunc";
     default:
       TORCH_INTERNAL_ASSERT(false, "No string found for unary op type.");
   }
@@ -178,24 +239,43 @@ static const char* unary_op_type_inline_op2string(UnaryOpType t) {
   return nullptr;
 }
 
+bool needFloatSuffix(BinaryOpType t) {
+  switch (t) {
+    case BinaryOpType::Atan2:
+      return true;
+    case BinaryOpType::Div:
+      return true;
+    case BinaryOpType::Fmod:
+      return true;
+    case BinaryOpType::Max:
+      return true;
+    case BinaryOpType::Min:
+      return true;
+    case BinaryOpType::Pow:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static const char* binary_op_type2string(BinaryOpType t) {
   switch (t) {
     case BinaryOpType::Add:
       return "add";
     case BinaryOpType::Atan2:
-      return "atan2f";
+      return "atan2";
     case BinaryOpType::Div:
       return "div";
     case BinaryOpType::Fmod:
-      return "fmodf";
+      return "fmod";
     case BinaryOpType::Max:
-      return "fmaxf";
+      return "fmax";
     case BinaryOpType::Min:
-      return "fminf";
+      return "fmin";
     case BinaryOpType::Mul:
       return "mul";
     case BinaryOpType::Pow:
-      return "powf";
+      return "pow";
     case BinaryOpType::Remainder:
       return "remainder";
     case BinaryOpType::Sub:
@@ -381,6 +461,8 @@ DataType aten_to_data_type(const at::ScalarType& scalar_type) {
   switch (scalar_type) {
     case at::ScalarType::Bool:
       return DataType::Bool;
+    case at::ScalarType::Double:
+      return DataType::Double;
     case at::ScalarType::Float:
       return DataType::Float;
     case at::ScalarType::Half:
@@ -396,6 +478,8 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
   switch (data_type) {
     case DataType::Bool:
       return at::ScalarType::Bool;
+    case DataType::Double:
+      return at::ScalarType::Double;
     case DataType::Float:
       return at::ScalarType::Float;
     case DataType::Half:
@@ -464,6 +548,23 @@ std::string stringifyThread(const ParallelType ptype) {
   return parallel_type2string(ptype);
 }
 
+std::string typePrefix(const DataType data_type) {
+  switch (data_type) {
+    case DataType::Bool:
+      return "b";
+    case DataType::Double:
+      return "d";
+    case DataType::Float:
+      return "f";
+    case DataType::Half:
+      return "f";
+    case DataType::Int:
+      return "i";
+    default:
+      TORCH_INTERNAL_ASSERT(false, "No data type found for scalar type.");
+  }
+}
+
 bool isParallelTypeThreadDim(ParallelType ptype) {
   return ptype == ParallelType::TIDx || ptype == ParallelType::TIDy ||
       ptype == ParallelType::TIDz;
@@ -489,6 +590,8 @@ size_t dataTypeSize(DataType type) {
   switch (type) {
     case DataType::Bool:
       return sizeof(bool);
+    case DataType::Double:
+      return 8;
     case DataType::Float:
       return 4;
     case DataType::Half:

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -31,7 +31,7 @@ enum class ValType {
   NamedScalar,
 };
 
-enum class DataType { Bool, Float, Half, Int, Null };
+enum class DataType { Bool, Double, Float, Half, Int, Null };
 
 enum class ExprType {
   Invalid,
@@ -142,14 +142,19 @@ enum class IterType {
   BroadcastWithoutStride
 };
 
+// Returns if function needs an f suffix on the operator when operating on a
+// float value i.e. sin->sinf
+bool needFloatSuffix(UnaryOpType t);
+bool needFloatSuffix(BinaryOpType t);
+
 ValType promote_type(const ValType& t1, const ValType& t2);
 DataType promote_type(const DataType& t1, const DataType& t2);
 bool is_logical_op(const BinaryOpType& bot);
 
 // If type cannot be found (i.e. codegen does not support provided type) returns
 // DataType::Null
-DataType aten_to_data_type(const at::ScalarType& scalar_type);
-at::ScalarType data_type_to_aten(const DataType& data_type);
+TORCH_CUDA_API DataType aten_to_data_type(const at::ScalarType& scalar_type);
+TORCH_CUDA_API at::ScalarType data_type_to_aten(const DataType& data_type);
 
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const ValType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const DataType);
@@ -163,6 +168,7 @@ TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const IterType);
 
 std::string stringifyThreadSize(const ParallelType);
 std::string stringifyThread(const ParallelType);
+std::string typePrefix(const DataType);
 
 TORCH_CUDA_API bool isParallelTypeThreadDim(ParallelType);
 TORCH_CUDA_API bool isParallelTypeBlockDim(ParallelType);

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -33,11 +33,6 @@ enum class ValType {
 
 enum class DataType { Bool, Double, Float, Half, Int, Null };
 
-// Returns if the datatype is a floating point type
-bool isFloatingPointType(DataType dtype);
-// Returns if the datatype is an integer type
-bool isIntegralType(DataType dtype);
-
 enum class ExprType {
   Invalid,
   UnaryOp,
@@ -84,13 +79,8 @@ enum class UnaryOpType {
   Sqrt,
   Tan,
   Tanh,
-  Trunc,
-
-  // Might be a bitwise operator or boolean operator.
-  Not
+  Trunc
 };
-
-bool maybeBooleanOperator(const UnaryOpType uopt);
 
 // TODO: Order of this list is important as it affects type promotion. it's not
 // in the right order now.
@@ -108,38 +98,18 @@ enum class BinaryOpType {
   Sub,
   // TypeAs,
 
-  // Integer output ops. If changing modify isIntegerOp
+  // Logical Ops
+  // Int operations, leave position of Mod we depend on its location of first
   Mod,
   CeilDiv,
-  Lshift,
-  Rshift,
-  Xor,
-
-  // Logical Ops
-  // Int operations, leave position of Mod as first logical op see
-  // isLogicalOp(BinaryOpType bopt)
+  And,
   Eq,
   GE,
   GT,
   LE,
   LT,
-  NE,
-
-  // Maybe bitwise or boolean op, leave position of and as first bool/int
-  // op. These are ops that have different operators based on output type. See
-  // is boolean op. These ops also don't work on floating point inputs.
-  And,
-  Or
+  NE
 };
-
-// Return if output of operator should be a boolean
-bool isIntegerOp(const BinaryOpType bopt);
-
-// Return if output of operator should be a boolean
-bool isLogicalOp(const BinaryOpType bopt);
-
-// return if operation has a different type based on int or boolean output
-bool maybeBooleanOperator(const BinaryOpType bopt);
 
 enum class TernaryOpType { Clamp, Threshold, Where };
 
@@ -179,6 +149,7 @@ bool needFloatSuffix(BinaryOpType t);
 
 ValType promote_type(const ValType& t1, const ValType& t2);
 DataType promote_type(const DataType& t1, const DataType& t2);
+bool is_logical_op(const BinaryOpType& bot);
 
 // If type cannot be found (i.e. codegen does not support provided type) returns
 // DataType::Null
@@ -194,9 +165,6 @@ TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const TernaryOpType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const ParallelType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const MemoryType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const IterType);
-
-std::string stringifyBooleanOp(const UnaryOpType);
-std::string stringifyBooleanOp(const BinaryOpType);
 
 std::string stringifyThreadSize(const ParallelType);
 std::string stringifyThread(const ParallelType);

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -33,6 +33,11 @@ enum class ValType {
 
 enum class DataType { Bool, Double, Float, Half, Int, Null };
 
+// Returns if the datatype is a floating point type
+bool isFloatingPointType(DataType dtype);
+// Returns if the datatype is an integer type
+bool isIntegralType(DataType dtype);
+
 enum class ExprType {
   Invalid,
   UnaryOp,
@@ -79,8 +84,13 @@ enum class UnaryOpType {
   Sqrt,
   Tan,
   Tanh,
-  Trunc
+  Trunc,
+
+  // Might be a bitwise operator or boolean operator.
+  Not
 };
+
+bool maybeBooleanOperator(const UnaryOpType uopt);
 
 // TODO: Order of this list is important as it affects type promotion. it's not
 // in the right order now.
@@ -98,18 +108,38 @@ enum class BinaryOpType {
   Sub,
   // TypeAs,
 
-  // Logical Ops
-  // Int operations, leave position of Mod we depend on its location of first
+  // Integer output ops. If changing modify isIntegerOp
   Mod,
   CeilDiv,
-  And,
+  Lshift,
+  Rshift,
+  Xor,
+
+  // Logical Ops
+  // Int operations, leave position of Mod as first logical op see
+  // isLogicalOp(BinaryOpType bopt)
   Eq,
   GE,
   GT,
   LE,
   LT,
-  NE
+  NE,
+
+  // Maybe bitwise or boolean op, leave position of and as first bool/int
+  // op. These are ops that have different operators based on output type. See
+  // is boolean op. These ops also don't work on floating point inputs.
+  And,
+  Or
 };
+
+// Return if output of operator should be a boolean
+bool isIntegerOp(const BinaryOpType bopt);
+
+// Return if output of operator should be a boolean
+bool isLogicalOp(const BinaryOpType bopt);
+
+// return if operation has a different type based on int or boolean output
+bool maybeBooleanOperator(const BinaryOpType bopt);
 
 enum class TernaryOpType { Clamp, Threshold, Where };
 
@@ -149,7 +179,6 @@ bool needFloatSuffix(BinaryOpType t);
 
 ValType promote_type(const ValType& t1, const ValType& t2);
 DataType promote_type(const DataType& t1, const DataType& t2);
-bool is_logical_op(const BinaryOpType& bot);
 
 // If type cannot be found (i.e. codegen does not support provided type) returns
 // DataType::Null
@@ -165,6 +194,9 @@ TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const TernaryOpType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const ParallelType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const MemoryType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const IterType);
+
+std::string stringifyBooleanOp(const UnaryOpType);
+std::string stringifyBooleanOp(const BinaryOpType);
 
 std::string stringifyThreadSize(const ParallelType);
 std::string stringifyThread(const ParallelType);


### PR DESCRIPTION
Pipe double support through the fusion system
Includes random number generation
Fixes to code generation (floating point scalar ivalue inputs are always double)
Generic suffix support for operators (e.g. fmaxf / sinf)
Testing in .cpp minor testing in .py (.py testing should be improved cc @shmsong, when this gets merged please improve double testing in the python tests)