### PR TITLE
Fix issue #532

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9785,17 +9785,8 @@ TEST(NVFuserTest, FusionIssue532_CUDA) {
   tv1->split(-1, M_BLOCK / M_THREAD);
   // tv1: [M/M_BLOCK, M_THREAD, M_BLOCK / M_THREAD]
 
-  if (true) {
-    tv2->split(-1, M_THREAD);
-    // tv2: [M/M_BLOCK, M_BLOCK / M_THREAD, M_THREAD]
-  } else {
-    // This works fine
-    tv2->split(-1, M_BLOCK / M_THREAD);
-    // tv2: [M/M_BLOCK, M_THREAD, M_BLOCK / M_THREAD]
-  }
-
-  fusion.printMath();
-  fusion.printKernel();
+  tv2->split(-1, M_THREAD);
+  // tv2: [M/M_BLOCK, M_BLOCK / M_THREAD, M_THREAD]
 
   constexpr int M = 1000;
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9763,6 +9763,57 @@ TEST(NVFuserTest, Issue507_CUDA) {
       &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
 }
 
+TEST(NVFuserTest, FusionIssue532_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Algorithm
+  TensorView* tv0 = makeSymbolicTensor(1);
+  TensorView* tv1 = add(tv0, new Float(1));
+  TensorView* tv2 = add(tv1, new Float(1));
+  fusion.addInput(tv0);
+  fusion.addOutput(tv2);
+
+  const int M_BLOCK = 64;
+  const int M_THREAD = 4;
+
+  tv2->split(0, M_BLOCK);
+  // tv2: [M/M_BLOCK, M_BLOCK]
+  tv1->computeAt(tv2, 1);
+  // tv1: [M/M_BLOCK, M_BLOCK]
+
+  tv1->split(-1, M_BLOCK / M_THREAD);
+  // tv1: [M/M_BLOCK, M_THREAD, M_BLOCK / M_THREAD]
+
+  if (true) {
+    tv2->split(-1, M_THREAD);
+    // tv2: [M/M_BLOCK, M_BLOCK / M_THREAD, M_THREAD]
+  } else {
+    // This works fine
+    tv2->split(-1, M_BLOCK / M_THREAD);
+    // tv2: [M/M_BLOCK, M_THREAD, M_BLOCK / M_THREAD]
+  }
+
+  fusion.printMath();
+  fusion.printKernel();
+
+  constexpr int M = 1000;
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::manual_seed(0);
+  at::Tensor t0 = at::randn({M}, options);
+  std::vector<IValue> aten_inputs = {t0};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto outputs = fe.runFusion(aten_inputs);
+
+  at::Tensor aten_output = t0 + 1 + 1;
+
+  testValidate(
+      &fusion, outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/torch/csrc/jit/codegen/cuda/transform_iter.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.cpp
@@ -353,8 +353,21 @@ BestEffortReplay::BestEffortReplay(
 
     // If the expression is a split, make sure it's split by the same ammount.
     if (r_expr->getExprType().value() == ExprType::Split) {
-      if (!r_expr->as<Split>()->factor()->sameAs(
-              r_expr->as<Split>()->factor())) {
+      Val* r_factor = r_expr->as<Split>()->factor();
+      Val* t_factor = t_expr->as<Split>()->factor();
+      bool same_split_factor = false;
+      // TODO: virtual invocation should simplify this conditional logic.
+      if (r_factor->isA<Int>()) {
+        TORCH_INTERNAL_ASSERT(t_factor->isA<Int>());
+        same_split_factor = r_factor->as<Int>()->sameAs(t_factor->as<Int>());
+      } else if (r_factor->isA<NamedScalar>()) {
+        TORCH_INTERNAL_ASSERT(t_factor->isA<NamedScalar>());
+        same_split_factor =
+            r_factor->as<NamedScalar>()->sameAs(t_factor->as<NamedScalar>());
+      } else {
+        same_split_factor = r_factor->sameAs(t_factor);
+      }
+      if (!same_split_factor) {
         TORCH_INTERNAL_ASSERT(!has_rfactor, err_str);
         continue;
       }


### PR DESCRIPTION
Fixes #532 

The logic of checking equivalence of split factors has a simple mistake, which causes the indexing logic to generate wrong expressions.
