### PR TITLE
Remove half scalar type

### DIFF
--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -23,8 +23,6 @@ Val* newScalar(ValType vtype, DataType dtype) {
           return new Float();
         case DataType::Float:
           return new Float();
-        case DataType::Half:
-          return new Half();
         case DataType::Int:
           return new Int();
         default:

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -257,17 +257,6 @@ class CudaKernelGenerator : private kir::IrVisitor {
     }
   }
 
-  void visit(const kir::Half* node) final {
-    const auto def = node->definition();
-    if (print_inline_ && def != nullptr) {
-      code_ << "(" << gen(def) << ")";
-    } else if (node->isConst()) {
-      code_ << "__float2half(" << *node->value() << ")";
-    } else {
-      code_ << varName(node);
-    }
-  }
-
   void visit(const kir::Int* node) final {
     const auto def = node->definition();
     if (print_inline_ && def != nullptr) {

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -54,9 +54,6 @@ void Val::dispatch(T handler, Val* val) {
         case DataType::Float:
           ptr(handler)->handle(val->as<Float>());
           return;
-        case DataType::Half:
-          ptr(handler)->handle(val->as<Half>());
-          return;
         case DataType::Int:
           ptr(handler)->handle(val->as<Int>());
           return;
@@ -134,9 +131,6 @@ void Val::constDispatch(T handler, const Val* val) {
           return;
         case DataType::Float:
           ptr(handler)->handle(val->as<Float>());
-          return;
-        case DataType::Half:
-          ptr(handler)->handle(val->as<Half>());
           return;
         case DataType::Int:
           ptr(handler)->handle(val->as<Int>());
@@ -224,8 +218,6 @@ Statement* Val::mutatorDispatch(T mutator, Val* val) {
           return ptr(mutator)->mutate(val->as<Double>());
         case DataType::Float:
           return ptr(mutator)->mutate(val->as<Float>());
-        case DataType::Half:
-          return ptr(mutator)->mutate(val->as<Half>());
         case DataType::Int:
           return ptr(mutator)->mutate(val->as<Int>());
         default:

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -63,7 +63,6 @@ class TensorView;
 class Bool;
 class Double;
 class Float;
-class Half;
 class Int;
 class NamedScalar;
 
@@ -92,7 +91,6 @@ class TORCH_CUDA_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const Bool*) {}
   virtual void handle(const Double*) {}
   virtual void handle(const Float*) {}
-  virtual void handle(const Half*) {}
   virtual void handle(const Int*) {}
   virtual void handle(const NamedScalar*) {}
 
@@ -120,7 +118,6 @@ class TORCH_CUDA_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(Bool*) {}
   virtual void handle(Double*) {}
   virtual void handle(Float*) {}
-  virtual void handle(Half*) {}
   virtual void handle(Int*) {}
   virtual void handle(NamedScalar*) {}
 
@@ -159,9 +156,6 @@ class TORCH_CUDA_API OptInConstDispatch : public PolymorphicBase {
   }
   virtual void handle(const Float*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
-  }
-  virtual void handle(const Half*) {
-    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Half.");
   }
   virtual void handle(const Int*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
@@ -219,9 +213,6 @@ class TORCH_CUDA_API OptInDispatch : public PolymorphicBase {
   }
   virtual void handle(Float*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
-  }
-  virtual void handle(Half*) {
-    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Half.");
   }
   virtual void handle(Int*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
@@ -291,7 +282,6 @@ class TORCH_CUDA_API OptOutMutator : public PolymorphicBase {
   virtual Statement* mutate(Bool*);
   virtual Statement* mutate(Double*);
   virtual Statement* mutate(Float*);
-  virtual Statement* mutate(Half*);
   virtual Statement* mutate(Int*);
   virtual Statement* mutate(NamedScalar*);
 

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -77,10 +77,6 @@ class ConstCheck : OptOutConstDispatch {
     is_const_ = is_const_ && f->isConst();
   }
 
-  void handle(const Half* h) override {
-    is_const_ = is_const_ && h->isConst();
-  }
-
   void handle(const Int* i) override {
     is_const_ = is_const_ && i->isConst();
   }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
@@ -74,10 +74,6 @@ void IrCloner::handle(const Float* f) {
   clone_ = new Float(f, this);
 }
 
-void IrCloner::handle(const Half* h) {
-  clone_ = new Half(h, this);
-}
-
 void IrCloner::handle(const Int* i) {
   clone_ = new Int(i, this);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -55,7 +55,6 @@ class TORCH_CUDA_API IrCloner : private OptInConstDispatch {
   void handle(const Bool*) override;
   void handle(const Double*) override;
   void handle(const Float*) override;
-  void handle(const Half*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -64,17 +64,6 @@ class IrNodeLabel : private OptInConstDispatch {
     }
   }
 
-  void handle(const Half* h) override {
-    if (h->isSymbolic()) {
-      label_ << "h" << h->name();
-    } else {
-      if (detail_level_ >= DetailLevel::Explicit) {
-        label_ << "h" << h->name() << "=";
-      }
-      label_ << *h->value();
-    }
-  }
-
   void handle(const Int* i) override {
     if (i->isSymbolic()) {
       label_ << "i" << i->name();
@@ -354,10 +343,6 @@ void IrGraphGenerator::handle(const Double* d) {
 
 void IrGraphGenerator::handle(const Float* f) {
   printValue(f, IrNodeLabel::gen(f, detail_level_));
-}
-
-void IrGraphGenerator::handle(const Half* h) {
-  printValue(h, IrNodeLabel::gen(h, detail_level_));
 }
 
 void IrGraphGenerator::handle(const Int* i) {

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -70,7 +70,6 @@ class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
   void handle(const Bool*) override;
   void handle(const Double*) override;
   void handle(const Float*) override;
-  void handle(const Half*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -107,34 +107,6 @@ class TORCH_CUDA_API Float : public Val {
   const c10::optional<ScalarType> maybe_value_;
 };
 
-//! An IEEE 754 Float16 value.
-//! This value can be a symbolic value (defined after the kernel
-//! is compiled) or a constant value (inlined into the kernel definition).
-class TORCH_CUDA_API Half : public Val {
- public:
-  Half() : Val(ValType::Scalar, DataType::Half), maybe_value_{c10::nullopt} {}
-
-  explicit Half(float value)
-      : Val(ValType::Scalar, DataType::Half), maybe_value_{value} {}
-
-  Half(const Half* src, IrCloner* ir_cloner);
-
-  bool isSymbolic() const {
-    return !(maybe_value_.has_value());
-  }
-  bool isConst() const {
-    return maybe_value_.has_value();
-  }
-  c10::optional<float> value() const {
-    return maybe_value_;
-  }
-
-  bool sameAs(const Half* const other) const;
-
- private:
-  const c10::optional<float> maybe_value_;
-};
-
 //! An Int64 value. If used for indexing it's set as size_t. Otherwise it's an
 //! inlined literal in the kernel.
 class TORCH_CUDA_API Int : public Val {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -139,21 +139,6 @@ void IrPrinter::handle(const Float* f) {
   }
 }
 
-void IrPrinter::handle(const Half* h) {
-  if (print_inline_ && FusionGuard::getCurFusion()->origin(h) != nullptr) {
-    os_ << "( ";
-    handle(FusionGuard::getCurFusion()->origin(h));
-    os_ << " )";
-    return;
-  }
-
-  if (h->isSymbolic()) {
-    os_ << "h" << h->name();
-  } else {
-    os_ << "__float2half(" << *(h->value()) << ")";
-  }
-}
-
 void IrPrinter::handle(const Int* i) {
   if (print_inline_) {
     if (auto def = FusionGuard::getCurFusion()->origin(i)) {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -59,7 +59,6 @@ class TORCH_CUDA_API IrPrinter : public OptInConstDispatch {
   void handle(const Bool*) override;
   void handle(const Double*) override;
   void handle(const Float*) override;
-  void handle(const Half*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -47,10 +47,6 @@ class ScalarCheck : OptInConstDispatch {
     same_ = v1_->as<Float>()->sameAs(v2_->as<Float>());
   }
 
-  void handle(const Half* h) override {
-    same_ = v1_->as<Half>()->sameAs(v2_->as<Half>());
-  }
-
   void handle(const Int* i) override {
     same_ = v1_->as<Int>()->sameAs(v2_->as<Int>());
   }
@@ -97,15 +93,6 @@ Float::Float(const Float* src, IrCloner* ir_cloner)
     : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
 
 bool Float::sameAs(const Float* const other) const {
-  if (isConst() && other->isConst())
-    return *value() == *(other->value());
-  return this == other;
-}
-
-Half::Half(const Half* src, IrCloner* ir_cloner)
-    : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
-
-bool Half::sameAs(const Half* const other) const {
   if (isConst() && other->isConst())
     return *value() == *(other->value());
   return this == other;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -36,7 +36,6 @@ class NamedScalar;
 class Bool;
 class Double;
 class Float;
-class Half;
 class Int;
 class IterDomain;
 class TensorDomain;
@@ -95,9 +94,6 @@ class TORCH_CUDA_API IrVisitor : public PolymorphicBase {
     unhandled(value);
   }
   virtual void visit(const Float* value) {
-    unhandled(value);
-  }
-  virtual void visit(const Half* value) {
     unhandled(value);
   }
   virtual void visit(const Int* value) {
@@ -415,36 +411,6 @@ class TORCH_CUDA_API Float final : public Val {
 
  private:
   const c10::optional<ScalarType> maybe_value_;
-};
-
-class TORCH_CUDA_API Half final : public Val {
- public:
-  explicit Half(Passkey passkey, const c10::optional<float>& value)
-      : Val(passkey, DataType::Half), maybe_value_(value) {}
-
-  explicit Half(Passkey passkey, const fuser::cuda::Half* node)
-      : Val(passkey, DataType::Half), maybe_value_(node->value()) {
-    setName(node->name());
-  }
-
-  void accept(IrVisitor* visitor) const override {
-    visitor->visit(this);
-  }
-
-  bool isScalar() const override {
-    return true;
-  }
-
-  bool isConst() const override {
-    return maybe_value_.has_value();
-  }
-
-  c10::optional<float> value() const {
-    return maybe_value_;
-  }
-
- private:
-  const c10::optional<float> maybe_value_;
 };
 
 class TORCH_CUDA_API Int final : public Val {

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
@@ -14,8 +14,6 @@ Val* IrBuilder::newResult(DataType dtype) {
       return create<Double>(c10::nullopt);
     case DataType::Float:
       return create<Float>(c10::nullopt);
-    case DataType::Half:
-      return create<Half>(c10::nullopt);
     case DataType::Int:
       return create<Int>(c10::nullopt);
     default:

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -177,14 +177,6 @@ void IrPrinter::visit(const kir::Float* node) {
   }
 }
 
-void IrPrinter::visit(const kir::Half* node) {
-  if (node->isConst()) {
-    ir_str_ << "half(" << *node->value() << ")";
-  } else {
-    ir_str_ << varName(node, "h");
-  }
-}
-
 void IrPrinter::visit(const kir::Int* node) {
   if (node->isConst()) {
     ir_str_ << *node->value();

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
@@ -55,7 +55,6 @@ class TORCH_CUDA_API IrPrinter : private kir::IrVisitor {
   void visit(const kir::Bool*) final;
   void visit(const kir::Double*) final;
   void visit(const kir::Float*) final;
-  void visit(const kir::Half*) final;
   void visit(const kir::Int*) final;
   void visit(const kir::NamedScalar*) final;
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -229,11 +229,6 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
   }
 
-  void handle(const Half* node) final {
-    const auto lowered_node = ir_builder_.create<kir::Half>(node);
-    TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
-  }
-
   void handle(const Int* node) final {
     const auto lowered_node = ir_builder_.create<kir::Int>(node, false);
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -95,10 +95,6 @@ Statement* OptOutMutator::mutate(Float* f) {
   return f;
 }
 
-Statement* OptOutMutator::mutate(Half* h) {
-  return h;
-}
-
 Statement* OptOutMutator::mutate(Int* i) {
   return i;
 }


### PR DESCRIPTION
We should never directly use half values as a scalar, removing this type completely.
