### PR TITLE
Remove Float and Half Scalar Types

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -682,22 +682,22 @@ TEST(NVFuserTest, FusionSimpleArith_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Double* f1 = new Double(1.f);
-  Double* f2 = new Double{2.f};
-  Double* f3 = new Double();
+  Double* d1 = new Double(1.f);
+  Double* d2 = new Double{2.f};
+  Double* d3 = new Double();
 
   // Disrupt the fusion to make sure guard works well
   {
     Fusion fusion2;
     FusionGuard fg(&fusion2);
 
-    Double* f1 = new Double(1.f);
-    Double* f2 = new Double(2.f);
-    add(f1, f2);
+    Double* d1 = new Double(1.f);
+    Double* d2 = new Double(2.f);
+    add(d1, d2);
     ss2 << fusion2;
   }
 
-  new BinaryOp(BinaryOpType::Add, f3, f1, f2);
+  new BinaryOp(BinaryOpType::Add, d3, d1, d2);
   ss1 << fusion;
 
   TORCH_CHECK(
@@ -1082,69 +1082,69 @@ TEST(NVFuserTest, FusionDependency_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Double* f0 = new Double(0.f);
-  Double* f1 = new Double(1.f);
-  auto f2 = add(f0, f1);
+  Double* d0 = new Double(0.f);
+  Double* d1 = new Double(1.f);
+  auto d2 = add(d0, d1);
 
-  auto f3 = add(f2, f2);
+  auto d3 = add(d2, d2);
 
-  Double* f4 = new Double(4.f);
-  Double* f5 = new Double(5.f);
-  auto f6 = add(f4, f5);
+  Double* d4 = new Double(4.f);
+  Double* d5 = new Double(5.f);
+  auto d6 = add(d4, d5);
 
-  Double* f7 = new Double(7.f);
-  Double* f8 = new Double(8.f);
-  auto f9 = add(f7, f8);
+  Double* d7 = new Double(7.f);
+  Double* d8 = new Double(8.f);
+  auto d9 = add(d7, d8);
 
-  auto f10 = add(f6, f9);
+  auto d10 = add(d6, d9);
 
-  auto f11 = add(f3, f10);
+  auto d11 = add(d3, d10);
 
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f0, f11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f1, f11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f2, f11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f3, f11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f6, f11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f9, f11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f0, f2));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f2, f3));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f4, f6));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(f8, f10));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d0, d11));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d1, d11));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d2, d11));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d3, d11));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d6, d11));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d9, d11));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d0, d2));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d2, d3));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d4, d6));
+  TORCH_CHECK(DependencyCheck::isDependencyOf(d8, d10));
 
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f11, f0));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f11, f1));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f11, f2));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f11, f3));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f11, f4));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f11, f5));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f2, f0));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f3, f2));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f6, f4));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(f10, f8));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d0));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d1));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d2));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d3));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d4));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d5));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d2, d0));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d3, d2));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d6, d4));
+  TORCH_CHECK(!DependencyCheck::isDependencyOf(d10, d8));
 
-  auto dep_chain = DependencyCheck::getSingleDependencyChain(f0, f11);
-  TORCH_CHECK(dep_chain.back() == f11);
+  auto dep_chain = DependencyCheck::getSingleDependencyChain(d0, d11);
+  TORCH_CHECK(dep_chain.back() == d11);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == f3);
+  TORCH_CHECK(dep_chain.back() == d3);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == f2);
-  dep_chain.pop_back();
-
-  dep_chain = DependencyCheck::getSingleDependencyChain(f6, f11);
-  TORCH_CHECK(dep_chain.back() == f11);
-  dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == f10);
+  TORCH_CHECK(dep_chain.back() == d2);
   dep_chain.pop_back();
 
-  dep_chain = DependencyCheck::getSingleDependencyChain(f4, f11);
-  TORCH_CHECK(dep_chain.back() == f11);
+  dep_chain = DependencyCheck::getSingleDependencyChain(d6, d11);
+  TORCH_CHECK(dep_chain.back() == d11);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == f10);
-  dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == f6);
+  TORCH_CHECK(dep_chain.back() == d10);
   dep_chain.pop_back();
 
-  dep_chain = DependencyCheck::getSingleDependencyChain(f11, f2);
+  dep_chain = DependencyCheck::getSingleDependencyChain(d4, d11);
+  TORCH_CHECK(dep_chain.back() == d11);
+  dep_chain.pop_back();
+  TORCH_CHECK(dep_chain.back() == d10);
+  dep_chain.pop_back();
+  TORCH_CHECK(dep_chain.back() == d6);
+  dep_chain.pop_back();
+
+  dep_chain = DependencyCheck::getSingleDependencyChain(d11, d2);
   TORCH_CHECK(dep_chain.empty());
 }
 
@@ -2727,19 +2727,19 @@ TEST(NVFuserTest, FusionScalarInputs_CUDA) {
   TensorView* tv1 = makeSymbolicTensor(2);
   fusion.addInput(tv1);
 
-  Double* f0 = new Double();
-  fusion.addInput(f0);
-  Double* f1 = new Double();
-  fusion.addInput(f1);
-  Double* f2 = new Double();
-  fusion.addInput(f2);
-  Double* f3 = new Double();
-  fusion.addInput(f3);
-  Val* f4 = mul(f0, f1);
-  Val* f5 = sub(f2, f3);
+  Double* d0 = new Double();
+  fusion.addInput(d0);
+  Double* d1 = new Double();
+  fusion.addInput(d1);
+  Double* d2 = new Double();
+  fusion.addInput(d2);
+  Double* d3 = new Double();
+  fusion.addInput(d3);
+  Val* d4 = mul(d0, d1);
+  Val* d5 = sub(d2, d3);
 
-  TensorView* tv2 = sub(tv1, f4);
-  TensorView* tv3 = add(tv0, f5);
+  TensorView* tv2 = sub(tv1, d4);
+  TensorView* tv3 = add(tv0, d5);
   TensorView* tv4 = mul(tv3, tv2);
 
   fusion.addOutput(tv4);
@@ -2765,10 +2765,10 @@ TEST(NVFuserTest, FusionScalarInputs_CUDA) {
     }
   }
 
-  // f4 = f0 * f1
-  // f5 = f2 - f3
-  // t2 = t1 - f4
-  // t3 = t0 + f5
+  // d4 = d0 * d1
+  // d5 = d2 - d3
+  // t2 = t1 - d4
+  // t3 = t0 + d5
   // t4 = t3 * t2
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8643,7 +8643,7 @@ TEST(NVFuserTest, FusionReduceImplicitBroadcast2_CUDA) {
   fe.compileFusion(&fusion);
   // no broadcasting needed, omitting the last optional argument;
   auto cg_outputs = fe.runFusion({aten_input}, lparams);
-  auto aten_output = aten_input.to(at::kDouble).sum({red_dim, 2});
+  auto aten_output = aten_input.to(at::kDouble).sum({1, 2});
 
   testValidate(
       &fusion,
@@ -8688,7 +8688,7 @@ TEST(NVFuserTest, FusionReduceImplicitBroadcast3_CUDA) {
   fe.compileFusion(&fusion);
   // no broadcasting needed, omitting the last optional argument;
   auto cg_outputs = fe.runFusion({aten_input}, lparams);
-  auto aten_output = aten_input.to(at::kDouble).sum({red_dim, 2});
+  auto aten_output = aten_input.to(at::kDouble).sum({2, 1});
 
   testValidate(
       &fusion,
@@ -9822,8 +9822,8 @@ TEST(NVFuserTest, FusionIssue532_CUDA) {
 
   // Algorithm
   TensorView* tv0 = makeSymbolicTensor(1);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(1));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(1));
   fusion.addInput(tv0);
   fusion.addOutput(tv2);
 
@@ -9864,8 +9864,8 @@ TEST(NVFuserTest, FusionLoopUnswitch_CUDA) {
 
   // Algorithm
   TensorView* tv0 = makeSymbolicTensor(1);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(1));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(1));
   fusion.addInput(tv0);
   fusion.addOutput(tv2);
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_CUDA)
+// #if defined(USE_CUDA)
 #include <gtest/gtest.h>
 
 #include <torch/csrc/jit/codegen/cuda/arith.h>
@@ -108,10 +108,10 @@ TEST(NVFuserTest, IrGraphGenerator_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv2 = add(tv0, new Float(3.141));
+  TensorView* tv2 = add(tv0, new Double(3.141));
   TensorView* tv3 = broadcast(tv0, {false, true, false, true});
-  TensorView* tv4 = reductionOp(BinaryOpType::Add, {2}, new Float(0), tv3);
-  TensorView* tv5 = clamp(tv4, new Float(0.f), new Float(1.f));
+  TensorView* tv4 = reductionOp(BinaryOpType::Add, {2}, new Double(0), tv3);
+  TensorView* tv5 = clamp(tv4, new Double(0.f), new Double(1.f));
   TensorView* tv6 = add(tv2, tv2);
 
   // Another checkpoint before adding outputs
@@ -151,14 +151,14 @@ TEST(NVFuserTest, FusionDispatch_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Float* f = new Float{2.f};
+  Double* f = new Double{2.f};
   std::stringstream ss1, ss2, ss3;
   ss1 << f;
   ss2 << static_cast<Val*>(f);
   ss3 << static_cast<Statement*>(f);
   TORCH_CHECK(
       ss1.str().compare(ss2.str()) == 0 && ss1.str().compare(ss3.str()) == 0,
-      "Error with dispatch system where results differ by passing Float* vs Val* vs Statement*.");
+      "Error with dispatch system where results differ by passing Double* vs Val* vs Statement*.");
 }
 
 // Evaluate basic scalar operations with constant values
@@ -235,7 +235,7 @@ TEST(NVFuserTest, FusionExprEvalBasic_CUDA) {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Double(2.0));
   TensorView* tv3 = add(tv0, tv2);
 
   fusion.addOutput(tv3);
@@ -287,9 +287,9 @@ TEST(NVFuserTest, FusionExprEvalComplex_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(-1.0));
-  TensorView* tv2 = add(tv0, new Float(3.0));
-  TensorView* tv3 = mul(tv0, new Float(2.0));
+  TensorView* tv1 = mul(tv0, new Double(-1.0));
+  TensorView* tv2 = add(tv0, new Double(3.0));
+  TensorView* tv3 = mul(tv0, new Double(2.0));
   TensorView* tv4 = add(tv2, tv1);
   TensorView* tv5 = add(tv4, tv3);
   TensorView* tv6 = add(tv0, tv3);
@@ -343,7 +343,7 @@ TEST(NVFuserTest, FusionExprEvalPostLower_CUDA) {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Double(2.0));
   TensorView* tv3 = add(tv0, tv2);
 
   fusion.addOutput(tv3);
@@ -467,7 +467,7 @@ TEST(NVFuserTest, FusionClear_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    TensorView* tv2 = add(tv1, new Float(2.0));
+    TensorView* tv2 = add(tv1, new Double(2.0));
     TensorView* tv3 = add(tv0, tv2);
 
     fusion.addOutput(tv3);
@@ -498,7 +498,7 @@ TEST(NVFuserTest, FusionClear_CUDA) {
   {
     TensorView* tv0 = makeSymbolicTensor(3);
     TensorView* tv1 = makeSymbolicTensor(3);
-    TensorView* tv2 = add(tv1, new Float(2.0));
+    TensorView* tv2 = add(tv1, new Double(2.0));
     TensorView* tv3 = add(tv0, tv2);
 
     fusion.addInput(tv0);
@@ -541,7 +541,7 @@ TEST(NVFuserTest, FusionCopy_CUDA) {
 
     auto tv0 = makeSymbolicTensor(3);
     auto tv1 = makeSymbolicTensor(3);
-    auto tv2 = add(tv1, new Float(2.0));
+    auto tv2 = add(tv1, new Double(2.0));
     auto tv3 = sub(add(tv0, mul(tv2, tv2)), tv2);
 
     original_fusion.addInput(tv0);
@@ -615,7 +615,7 @@ TEST(NVFuserTest, FusionMove_CUDA) {
 
     auto tv0 = makeSymbolicTensor(3);
     auto tv1 = makeSymbolicTensor(3);
-    auto tv2 = add(tv1, new Float(2.0));
+    auto tv2 = add(tv1, new Double(2.0));
     auto tv3 = sub(add(tv0, mul(tv2, tv2)), tv2);
 
     fusion.addInput(tv0);
@@ -682,17 +682,17 @@ TEST(NVFuserTest, FusionSimpleArith_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Float* f1 = new Float(1.f);
-  Float* f2 = new Float{2.f};
-  Float* f3 = new Float();
+  Double* f1 = new Double(1.f);
+  Double* f2 = new Double{2.f};
+  Double* f3 = new Double();
 
   // Disrupt the fusion to make sure guard works well
   {
     Fusion fusion2;
     FusionGuard fg(&fusion2);
 
-    Float* f1 = new Float(1.f);
-    Float* f2 = new Float(2.f);
+    Double* f1 = new Double(1.f);
+    Double* f2 = new Double(2.f);
     add(f1, f2);
     ss2 << fusion2;
   }
@@ -709,18 +709,18 @@ TEST(NVFuserTest, FusionSimpleTypePromote_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Float* f4 = new Float{4.f};
+  Double* d4 = new Double{4.f};
   Int* i1 = new Int{3};
-  auto f5 = add(f4, i1);
+  auto d5 = add(d4, i1);
 
-  TORCH_CHECK(f5->getDataType() == DataType::Float);
+  TORCH_CHECK(d5->getDataType() == DataType::Double);
 }
 
 class ZeroMutator : public OptOutMutator {
  public:
-  Statement* mutate(Float* f) {
+  Statement* mutate(Double* f) {
     if (f->isConst() && *(f->value()) == 1.0)
-      return new Float(0.0);
+      return new Double(0.0);
     return f;
   }
   void mutate(Fusion* f) {
@@ -732,25 +732,25 @@ TEST(NVFuserTest, FusionMutator_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Float* f4 = new Float{1.f};
+  Double* d4 = new Double{1.f};
   Int* i1 = new Int{3};
-  Val* f5 = add(f4, i1);
+  Val* d5 = add(d4, i1);
   ZeroMutator mutator;
   mutator.mutate(&fusion);
-  Val* lhs = static_cast<BinaryOp*>(fusion.origin(f5))->lhs();
+  Val* lhs = static_cast<BinaryOp*>(fusion.origin(d5))->lhs();
   TORCH_CHECK(
       lhs->getValType().value() == ValType::Scalar &&
-      lhs->getDataType().value() == DataType::Float);
-  Float* flhs = static_cast<Float*>(lhs);
+      lhs->getDataType().value() == DataType::Double);
+  Double* dlhs = static_cast<Double*>(lhs);
 
-  TORCH_CHECK(flhs->value().value() == 0.f);
+  TORCH_CHECK(dlhs->value().value() == 0.f);
 }
 
 TEST(NVFuserTest, FusionRegister_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
-  Float* v1 = new Float{1.f};
-  Float* v2 = new Float{2.f};
+  Double* v1 = new Double{1.f};
+  Double* v2 = new Double{2.f};
   Val* v3 = binaryOp(BinaryOpType::Add, v1, v2);
   Val* v4 = binaryOp(BinaryOpType::Add, v1, v2);
   TORCH_CHECK(v1->name() + 1 == v2->name());
@@ -785,13 +785,13 @@ TEST(NVFuserTest, FusionTopoSort_CUDA) {
   // e1: v4     =   add(v3, v2)
   // e2: v5     =   add(v2, v4)
   // e3: v6     =   add(v5, v5)
-  Float* v0 = new Float{1.f};
-  Float* v1 = new Float{2.f};
-  Float* v2 = new Float();
-  Float* v3 = new Float();
-  Float* v4 = new Float();
-  Float* v5 = new Float();
-  Float* v6 = new Float();
+  Double* v0 = new Double{1.f};
+  Double* v1 = new Double{2.f};
+  Double* v2 = new Double();
+  Double* v3 = new Double();
+  Double* v4 = new Double();
+  Double* v5 = new Double();
+  Double* v6 = new Double();
 
   Expr* e0 = new DummyExpr(v3, v2, v1, v0);
   Expr* e1 = new BinaryOp(BinaryOpType::Add, v4, v3, v2);
@@ -914,7 +914,7 @@ TEST(NVFuserTest, FusionFilterVals_CUDA) {
 
   auto tv0 = makeSymbolicTensor(1);
   auto tv1 = makeSymbolicTensor(1);
-  auto scalar0 = new Float(0);
+  auto scalar0 = new Double(0);
   auto scalar1 = new Int(0);
   auto scalar2 = new Int(1);
 
@@ -927,9 +927,9 @@ TEST(NVFuserTest, FusionFilterVals_CUDA) {
   TORCH_CHECK(tvs[0] == tv0);
   TORCH_CHECK(tvs[1] == tv1);
 
-  std::vector<Float*> floats(
-      ir_utils::filterByType<Float>(vals).begin(),
-      ir_utils::filterByType<Float>(vals).end());
+  std::vector<Double*> floats(
+      ir_utils::filterByType<Double>(vals).begin(),
+      ir_utils::filterByType<Double>(vals).end());
   TORCH_CHECK(floats.size() == 1);
   TORCH_CHECK(floats[0] == scalar0);
 
@@ -1041,15 +1041,15 @@ TEST(NVFuserTest, FusionEquality_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Float* fval1 = new Float();
-  Float* fval1_copy = fval1;
-  Float* fval2 = new Float();
-  Float* fone = new Float(1.0);
+  Double* fval1 = new Double();
+  Double* fval1_copy = fval1;
+  Double* fval2 = new Double();
+  Double* fone = new Double(1.0);
 
   TORCH_CHECK(fval1->sameAs(fval1_copy));
   TORCH_CHECK(!fval1->sameAs(fval2));
   TORCH_CHECK(!fone->sameAs(fval1));
-  TORCH_CHECK(fone->sameAs(new Float(1.0)));
+  TORCH_CHECK(fone->sameAs(new Double(1.0)));
 
   Int* ival1 = new Int();
   Int* ival1_copy = ival1;
@@ -1061,14 +1061,14 @@ TEST(NVFuserTest, FusionEquality_CUDA) {
   TORCH_CHECK(!ione->sameAs(ival1));
   TORCH_CHECK(ione->sameAs(new Int(1)));
 
-  BinaryOp* add1 = new BinaryOp(BinaryOpType::Add, new Float(), fval1, ival1);
+  BinaryOp* add1 = new BinaryOp(BinaryOpType::Add, new Double(), fval1, ival1);
   BinaryOp* add1_copy =
-      new BinaryOp(BinaryOpType::Add, new Float(), fval1, ival1);
-  BinaryOp* sub1 = new BinaryOp(BinaryOpType::Sub, new Float(), fval1, ival1);
+      new BinaryOp(BinaryOpType::Add, new Double(), fval1, ival1);
+  BinaryOp* sub1 = new BinaryOp(BinaryOpType::Sub, new Double(), fval1, ival1);
 
-  UnaryOp* neg1 = new UnaryOp(UnaryOpType::Neg, new Float(), fval1);
-  UnaryOp* neg2 = new UnaryOp(UnaryOpType::Neg, new Float(), fval2);
-  UnaryOp* neg1_copy = new UnaryOp(UnaryOpType::Neg, new Float(), fval1);
+  UnaryOp* neg1 = new UnaryOp(UnaryOpType::Neg, new Double(), fval1);
+  UnaryOp* neg2 = new UnaryOp(UnaryOpType::Neg, new Double(), fval2);
+  UnaryOp* neg1_copy = new UnaryOp(UnaryOpType::Neg, new Double(), fval1);
 
   TORCH_CHECK(add1->sameAs(add1_copy));
   TORCH_CHECK(!add1->sameAs(sub1));
@@ -1082,18 +1082,18 @@ TEST(NVFuserTest, FusionDependency_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  Float* f0 = new Float(0.f);
-  Float* f1 = new Float(1.f);
+  Double* f0 = new Double(0.f);
+  Double* f1 = new Double(1.f);
   auto f2 = add(f0, f1);
 
   auto f3 = add(f2, f2);
 
-  Float* f4 = new Float(4.f);
-  Float* f5 = new Float(5.f);
+  Double* f4 = new Double(4.f);
+  Double* f5 = new Double(5.f);
   auto f6 = add(f4, f5);
 
-  Float* f7 = new Float(7.f);
-  Float* f8 = new Float(8.f);
+  Double* f7 = new Double(7.f);
+  Double* f8 = new Double(8.f);
   auto f9 = add(f7, f8);
 
   auto f10 = add(f6, f9);
@@ -1275,9 +1275,9 @@ TEST(NVFuserTest, FusionCodeGen_CUDA) {
 
   TensorView* tv0 = makeSymbolicTensor(3);
 
-  new BinaryOp(BinaryOpType::Add, tv0, new Float(0.0), new Float(1.0));
-  TensorView* tv1 = add(tv0, new Float(2.0));
-  TensorView* tv2 = add(tv1, new Float(3.0));
+  new BinaryOp(BinaryOpType::Add, tv0, new Double(0.0), new Double(1.0));
+  TensorView* tv1 = add(tv0, new Double(2.0));
+  TensorView* tv2 = add(tv1, new Double(3.0));
   fusion.addOutput(tv2);
 
   //[I0, I1, I2]
@@ -1312,7 +1312,7 @@ TEST(NVFuserTest, FusionCodeGen2_CUDA) {
 
   TensorView* tv0 = makeSymbolicTensor(3);
   TensorView* tv1 = makeSymbolicTensor(3);
-  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Double(2.0));
   TensorView* tv3 = add(tv0, tv2);
 
   fusion.addInput(tv0);
@@ -1364,7 +1364,7 @@ TEST(NVFuserTest, FusionSimplePWise_CUDA) {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Double(2.0));
   TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
@@ -1419,7 +1419,7 @@ TEST(NVFuserTest, FusionExecKernel_CUDA) {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Double(2.0));
   TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
@@ -1474,10 +1474,10 @@ TEST(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
-  TensorView* tv2 = mul(tv1, new Float(-1.0));
-  TensorView* tv3 = add(tv1, new Float(3.0));
-  TensorView* tv4 = mul(tv1, new Float(2.0));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = add(tv1, new Double(3.0));
+  TensorView* tv4 = mul(tv1, new Double(2.0));
   TensorView* tv5 = add(tv3, tv2);
 
   TensorView* tv6 = add(tv5, tv4);
@@ -1550,9 +1550,9 @@ TEST(NVFuserTest, FusionAdvancedComputeAt2_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(-1.0));
-  TensorView* tv2 = add(tv0, new Float(3.0));
-  TensorView* tv3 = mul(tv0, new Float(2.0));
+  TensorView* tv1 = mul(tv0, new Double(-1.0));
+  TensorView* tv2 = add(tv0, new Double(3.0));
+  TensorView* tv3 = mul(tv0, new Double(2.0));
   TensorView* tv4 = add(tv2, tv1);
 
   TensorView* tv5 = add(tv4, tv3);
@@ -1612,7 +1612,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAt3_CUDA) {
   TensorView* tv1 = makeSymbolicTensor(4);
   fusion.addInput(tv1);
 
-  TensorView* tv2 = mul(tv1, new Float(.979361));
+  TensorView* tv2 = mul(tv1, new Double(.979361));
   TensorView* tv3 = mul(tv2, tv0);
 
   fusion.addOutput(tv3);
@@ -1738,7 +1738,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAt5_CUDA) {
   fusion.addInput(tv0);
   TensorView* tv1 = makeSymbolicTensor(2);
   fusion.addInput(tv1);
-  TensorView* tv2 = add(tv0, new Float(2.0));
+  TensorView* tv2 = add(tv0, new Double(2.0));
   TensorView* tv3 = mul(tv1, tv2);
   fusion.addOutput(tv3);
 
@@ -1774,7 +1774,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
   fusion.addInput(tv0);
   TensorView* tv1 = makeSymbolicTensor(2);
   fusion.addInput(tv1);
-  TensorView* tv2 = add(tv0, new Float(2.0));
+  TensorView* tv2 = add(tv0, new Double(2.0));
   TensorView* tv3 = mul(tv1, tv2);
   fusion.addOutput(tv3);
 
@@ -1815,9 +1815,9 @@ TEST(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
-  TensorView* tv2 = mul(tv1, new Float(-1.0));
-  TensorView* tv3 = mul(tv1, new Float(-2.0));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = mul(tv1, new Double(-2.0));
   fusion.addOutput(tv2);
   fusion.addOutput(tv3);
 
@@ -1880,11 +1880,11 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
-  TensorView* tv2 = mul(tv1, new Float(-1.0));
-  TensorView* tv3 = mul(tv1, new Float(-2.0));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = mul(tv1, new Double(-2.0));
   TensorView* tv4 = add(tv2, tv3);
-  TensorView* tv5 = mul(tv4, new Float(5.0));
+  TensorView* tv5 = mul(tv4, new Double(5.0));
   fusion.addOutput(tv3);
   fusion.addOutput(tv4);
   fusion.addOutput(tv5);
@@ -1951,10 +1951,10 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
-  TensorView* tv2 = mul(tv1, new Float(-1.0));
-  TensorView* tv3 = mul(tv2, new Float(-1.0));
-  TensorView* tv4 = add(tv1, new Float(4.0));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = mul(tv2, new Double(-1.0));
+  TensorView* tv4 = add(tv1, new Double(4.0));
   TensorView* tv5 = add(tv3, tv4);
 
   fusion.addOutput(tv5);
@@ -2040,12 +2040,12 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
-  TensorView* tv2 = mul(tv1, new Float(-1.0));
-  TensorView* tv3 = mul(tv2, new Float(-1.0));
-  TensorView* tv4 = add(tv1, new Float(4.0));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = mul(tv2, new Double(-1.0));
+  TensorView* tv4 = add(tv1, new Double(4.0));
   TensorView* tv5 = add(tv3, tv4);
-  TensorView* tv6 = add(tv1, new Float(6.0));
+  TensorView* tv6 = add(tv1, new Double(6.0));
 
   fusion.addOutput(tv5);
   fusion.addOutput(tv6);
@@ -2139,13 +2139,13 @@ TEST(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
-  TensorView* tv2 = mul(tv1, new Float(-1.0));
-  TensorView* tv3 = mul(tv1, new Float(-2.0));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = mul(tv1, new Double(-2.0));
   TensorView* tv4 = add(tv2, tv3);
-  TensorView* tv5 = mul(tv4, new Float(5.0));
+  TensorView* tv5 = mul(tv4, new Double(5.0));
   // Notice that tv6 is not a consumer of tv4.
-  TensorView* tv6 = mul(tv1, new Float(6.0));
+  TensorView* tv6 = mul(tv1, new Double(6.0));
   fusion.addOutput(tv3);
   fusion.addOutput(tv4);
   fusion.addOutput(tv5);
@@ -2708,7 +2708,7 @@ TEST(NVFuserTest, FusionComputeAtFailDueToRootMapping_CUDA) {
 
   auto tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
-  auto tv1 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
   auto tv2 = broadcast(tv1, {true, false});
   auto tv3 = broadcast(tv1, {false, true});
   auto tv4 = add(tv2, tv3);
@@ -2727,13 +2727,13 @@ TEST(NVFuserTest, FusionScalarInputs_CUDA) {
   TensorView* tv1 = makeSymbolicTensor(2);
   fusion.addInput(tv1);
 
-  Float* f0 = new Float();
+  Double* f0 = new Double();
   fusion.addInput(f0);
-  Float* f1 = new Float();
+  Double* f1 = new Double();
   fusion.addInput(f1);
-  Float* f2 = new Float();
+  Double* f2 = new Double();
   fusion.addInput(f2);
-  Float* f3 = new Float();
+  Double* f3 = new Double();
   fusion.addInput(f3);
   Val* f4 = mul(f0, f1);
   Val* f5 = sub(f2, f3);
@@ -2820,7 +2820,7 @@ TEST(NVFuserTest, FusionLoopUnroll_CUDA) {
 
   // Do math with it, it returns a `Val*` but can be static_casted back to
   // TensorView
-  TensorView* tv2 = add(tv1, new Float(2.0));
+  TensorView* tv2 = add(tv1, new Double(2.0));
   TensorView* tv3 = add(tv0, tv2);
 
   // Register your outputs
@@ -2867,7 +2867,7 @@ Val* gen_jit_operand(std::pair<ValType, DataType> desc) {
     return makeSymbolicTensor(2, desc.second);
   } else if (desc.first == ValType::Scalar) {
     if (desc.second == DataType::Float) {
-      return new Float();
+      return new Double();
     } else if (desc.second == DataType::Double) {
       return new Double();
     } else if (desc.second == DataType::Int) {
@@ -3220,6 +3220,7 @@ TEST(NVFuserTest, FusionBinaryOps_CUDA) {
             std::make_pair(ValType::TensorView, dtype),
             std::make_pair(ValType::TensorView, dtype),
             std::make_pair(ValType::Scalar, dtype)));
+
     test_op(
         /*blocks*/ 640,
         /*threads*/ 64,
@@ -3254,7 +3255,7 @@ TEST(NVFuserTest, FusionTernaryOps_CUDA) {
         /*JIT  Func   */
         [&](Val* in1) -> Val* {
           if (dtype == DataType::Float) {
-            return clamp(in1, new Float(0.f), new Float(1.f));
+            return clamp(in1, new Double(0.f), new Double(1.f));
           } else {
             return clamp(in1, new Double(0.f), new Double(1.f));
           }
@@ -3273,7 +3274,7 @@ TEST(NVFuserTest, FusionTernaryOps_CUDA) {
         /*JIT  Func   */
         [&](Val* in1) -> Val* {
           if (dtype == DataType::Float) {
-            return threshold(in1, new Float(0.f), new Float(1.f));
+            return threshold(in1, new Double(0.f), new Double(1.f));
           } else {
             return threshold(in1, new Double(0.f), new Double(1.f));
           }
@@ -3372,7 +3373,7 @@ TEST(NVFuserTest, FusionCastOps_CUDA) {
   fe.compileFusion(&fusion);
   auto outputs = fe.runFusion(input_ivalues);
 
-  ref_output = at::_cast_Half(at::_cast_Float(input1));
+  ref_output = at::_cast_Half(at::_cast_Double(input1));
 
   TORCH_CHECK(
       outputs[0].equal(ref_output),
@@ -3395,7 +3396,7 @@ TEST(NVFuserTest, FusionReduction1_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -3455,7 +3456,7 @@ TEST(NVFuserTest, FusionReduction2_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
 
   fusion.addOutput(tv1);
 
@@ -3525,7 +3526,7 @@ TEST(NVFuserTest, FusionReduction3_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
 
   fusion.addOutput(tv1);
 
@@ -3581,7 +3582,7 @@ TEST(NVFuserTest, FusionReduction4_CUDA) {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  TensorView* tv3 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv2);
+  TensorView* tv3 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv2);
   // tv3[I0, R1] = tv2[I0, I1]
 
   TensorView* tv4 = makeSymbolicTensor(1);
@@ -3643,7 +3644,7 @@ TEST(NVFuserTest, FusionReduction5_CUDA) {
 
   fusion.addInput(tv0);
 
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
 
   fusion.addOutput(tv1);
 
@@ -3696,7 +3697,7 @@ TEST(NVFuserTest, FusionReduction6_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1, R2] = tv0[I0, I1, I2]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1, 2}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1, 2}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -3754,7 +3755,7 @@ TEST(NVFuserTest, FusionReductionTFT_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
 
   fusion.addOutput(tv1);
 
@@ -3812,7 +3813,7 @@ TEST(NVFuserTest, FusionBranches_CUDA) {
   fusion.addInput(tv1);
   fusion.addInput(tv2);
 
-  auto tv3 = add(tv0, new Float(1.0));
+  auto tv3 = add(tv0, new Double(1.0));
   auto tv4 = add(tv3, tv1);
   auto tv5 = add(tv3, tv2);
   auto tv6 = add(tv4, tv5);
@@ -3867,7 +3868,7 @@ TEST(NVFuserTest, FusionSimpleBCast1_CUDA) {
   // Set up your input tensor views
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
-  TensorView* tv1 = add(tv0, new Float(1.5));
+  TensorView* tv1 = add(tv0, new Double(1.5));
 
   TensorView* tv2 = makeSymbolicTensor(2);
   fusion.addInput(tv2);
@@ -3934,7 +3935,7 @@ TEST(NVFuserTest, FusionSimpleBCast2_CUDA) {
   TensorView* tv4 = makeSymbolicTensor(2);
   fusion.addInput(tv4);
 
-  TensorView* tv5 = sub(tv4, new Float(0.1));
+  TensorView* tv5 = sub(tv4, new Double(0.1));
 
   TensorView* tv6 = broadcast(tv5, {true, false, false});
 
@@ -4144,7 +4145,7 @@ TEST(NVFuserTest, FusionComplexBCast1_CUDA) {
   int x = 2, y = 3, z = 4;
 
   auto tv0 = makeConcreteTensor({y});
-  auto tv1 = div(tv0, new Float(2.0));
+  auto tv1 = div(tv0, new Double(2.0));
   auto tv2 = broadcast(tv1, {false, true});
   auto tv3 = makeConcreteTensor({y, z});
   auto tv4 = mul(tv2, tv3);
@@ -4200,7 +4201,7 @@ TEST(NVFuserTest, FusionComplexBCast2_CUDA) {
   int x = 2, y = 3, z = 4;
 
   auto tv0 = makeConcreteTensor({y, z});
-  auto tv1 = div(tv0, new Float(2.0));
+  auto tv1 = div(tv0, new Double(2.0));
   auto tv2 = sum(tv1, {1});
   auto tv3 = broadcast(tv2, {true, false});
   auto tv4 = makeConcreteTensor({x, y});
@@ -4255,7 +4256,7 @@ TEST(NVFuserTest, FusionAdvancedIndexing1_CUDA) {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  auto tv2 = add(tv0, new Float(1.0));
+  auto tv2 = add(tv0, new Double(1.0));
   auto tv3 = broadcast(tv2, {true, false, false, false});
   auto tv4 = add(tv3, tv1);
 
@@ -4309,7 +4310,7 @@ TEST(NVFuserTest, FusionAdvancedIndexing2_CUDA) {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  auto tv2 = add(tv0, new Float(1.0));
+  auto tv2 = add(tv0, new Double(1.0));
   auto tv3 = broadcast(tv2, {true, false, false, false});
   auto tv4 = add(tv3, tv1);
 
@@ -4362,7 +4363,7 @@ TEST(NVFuserTest, FusionAdvancedIndexing3_CUDA) {
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  auto tv2 = add(tv0, new Float(1.0));
+  auto tv2 = add(tv0, new Double(1.0));
   auto tv3 = add(tv2, tv1);
   fusion.addOutput(tv3);
 
@@ -4395,7 +4396,7 @@ TEST(NVFuserTest, FusionAdvancedIndexing4_CUDA) {
   TensorView* tv1 = makeConcreteTensor({10, 10, 20});
   fusion.addInput(tv1);
 
-  TensorView* tv2 = add(tv0, new Float(1));
+  TensorView* tv2 = add(tv0, new Double(1));
   TensorView* tv3 = broadcast(tv2, {true, false, false});
   TensorView* tv4 = add(tv3, tv1);
   fusion.addOutput(tv4);
@@ -4427,7 +4428,7 @@ TEST(NVFuserTest, FusionAdvancedIndexing5_CUDA) {
   TensorView* tv1 = makeSymbolicTensor(3);
   fusion.addInput(tv1);
 
-  TensorView* tv2 = add(tv0, new Float(1));
+  TensorView* tv2 = add(tv0, new Double(1));
   TensorView* tv3 = broadcast(tv2, {true, false, true});
   TensorView* tv4 = add(tv3, tv1);
   fusion.addOutput(tv4);
@@ -4702,7 +4703,7 @@ TEST(NVFuserTest, FusionSoftmax1DNormalized_CUDA) {
 
   // Normalize with the max value before computing exp.
   TensorView* max_val_tv1 =
-      reductionOp(BinaryOpType::Max, {-1}, new Float(0), input_tv0);
+      reductionOp(BinaryOpType::Max, {-1}, new Double(0), input_tv0);
   TensorView* bcast_max_tv2 = broadcast(max_val_tv1, {true});
   TensorView* sub_tv3 = sub(input_tv0, bcast_max_tv2);
   TensorView* exp_tv4 = unaryOp(UnaryOpType::Exp, sub_tv3);
@@ -4833,7 +4834,7 @@ TEST(NVFuserTest, FusionSoftmax3DNormalized_CUDA) {
 
   // Normalize with the max value before computing exp.
   TensorView* max_val_tv1 =
-      reductionOp(BinaryOpType::Max, {-1}, new Float(0), input_tv0);
+      reductionOp(BinaryOpType::Max, {-1}, new Double(0), input_tv0);
   TensorView* bcast_max_tv2 = broadcast(max_val_tv1, {false, false, true});
   TensorView* sub_tv3 = sub(input_tv0, bcast_max_tv2);
   TensorView* exp_tv4 = unaryOp(UnaryOpType::Exp, sub_tv3);
@@ -4901,7 +4902,7 @@ TEST(NVFuserTest, FusionSoftmaxComputeAt_CUDA) {
   auto tv1 = sum(tv0, {1});
   auto tv2 = broadcast(tv1, {false, true});
 
-  auto tv3 = add(tv0, new Float(1.0));
+  auto tv3 = add(tv0, new Double(1.0));
 
   auto tv4 = mul(tv2, tv3);
 
@@ -4928,7 +4929,7 @@ TEST(NVFuserTest, FusionGridReduction1_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -4988,7 +4989,7 @@ TEST(NVFuserTest, FusionGridReduction2_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -5047,7 +5048,7 @@ TEST(NVFuserTest, FusionGridReduction3dim1_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -5106,7 +5107,7 @@ TEST(NVFuserTest, FusionGridReduction3dim0_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[R0, I1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {0}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {0}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -5159,7 +5160,7 @@ TEST(NVFuserTest, FusionGridReduction4_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -5224,7 +5225,7 @@ TEST(NVFuserTest, FusionGridReduction5_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -5272,7 +5273,7 @@ TEST(NVFuserTest, FusionGridReduction6_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1, R2] = tv0[I0, I1, I2]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1, 2}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1, 2}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(fusion.hasReduction(), "Could not detect reduction in fusion.");
@@ -5339,7 +5340,7 @@ TEST(NVFuserTest, FusionNonRedAxisBind_CUDA) {
   fusion.addInput(tv0);
 
   TensorView* tv1 =
-      reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0);
+      reductionOp(BinaryOpType::Add, {red_dim}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   tv1->split(-1, tid_x);
@@ -5369,7 +5370,7 @@ TEST(NVFuserTest, FusionSplitBCast_CUDA) {
   fusion.addInput(input_tv1);
 
   TensorView* sum_tv2 =
-      reductionOp(BinaryOpType::Add, {2}, new Float(0), input_tv0);
+      reductionOp(BinaryOpType::Add, {2}, new Double(0), input_tv0);
   TensorView* bcast_tv3 = broadcast(sum_tv2, {false, false, true});
   TensorView* output_tv4 = div(input_tv1, bcast_tv3);
 
@@ -5442,8 +5443,8 @@ TEST(NVFuserTest, FusionReductionMultiConsumer_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
   auto tv1 = unaryOp(UnaryOpType::Exp, tv0);
-  auto tv2 = reductionOp(BinaryOpType::Max, {-1}, new Float(0), tv1);
-  auto tv3 = reductionOp(BinaryOpType::Min, {-1}, new Float(0), tv1);
+  auto tv2 = reductionOp(BinaryOpType::Max, {-1}, new Double(0), tv1);
+  auto tv3 = reductionOp(BinaryOpType::Min, {-1}, new Double(0), tv1);
   auto tv4 = add(tv2, tv3);
   fusion.addOutput(tv4);
   tv1->computeAt(tv2, -1);
@@ -5462,8 +5463,8 @@ TEST(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
     TensorView* tv0 = makeSymbolicTensor(1);
     fusion.addInput(tv0);
 
-    auto tv1 = add(tv0, new Float(1));
-    auto tv2 = add(tv0, new Float(1));
+    auto tv1 = add(tv0, new Double(1));
+    auto tv2 = add(tv0, new Double(1));
     TensorView* tv3 = add(tv1, tv2);
     // Set outputs tv2 or tv1 and then tv3
     if (i == 0) {
@@ -5501,8 +5502,8 @@ TEST(NVFuserTest, FusionComputeAtExprOrder2_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  auto tv1 = add(tv0, new Float(1));
-  auto tv2 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
+  auto tv2 = add(tv0, new Double(1));
   TensorView* tv3 = add(tv1, tv2);
   fusion.addOutput(tv3);
 
@@ -5533,7 +5534,7 @@ TEST(NVFuserTest, FusionZeroDimComputeAt_CUDA) {
   fusion.addInput(tv0);
 
   auto tv1 = sum(tv0, {0});
-  auto tv2 = add(tv1, new Float(1));
+  auto tv2 = add(tv1, new Double(1));
   fusion.addOutput(tv2);
   TORCH_CHECK(tv2->nDims() == 0);
   tv1->computeAt(tv2, 0);
@@ -5742,7 +5743,7 @@ TEST(NVFuserTest, FusionReductionKeepDimScheduler_CUDA) {
   fusion.addInput(tv0);
 
   TensorView* tv1 = reductionOp(
-      BinaryOpType::Add, {red_dim}, new Float(0), tv0, /*keep_dim=*/true);
+      BinaryOpType::Add, {red_dim}, new Double(0), tv0, /*keep_dim=*/true);
 
   TensorView* red_tv = fusion.origin(tv1)->inputs()[0]->as<TensorView>();
 
@@ -5843,7 +5844,7 @@ TEST(NVFuserTest, FusionSumToNoop_CUDA) {
   TensorView* tv1 = sum_to(tv0, sum_to_symb);
 
   // Dummy operator to avoid tv0 both input and output
-  TensorView* tv2 = add(tv1, new Float(0));
+  TensorView* tv2 = add(tv1, new Double(0));
   fusion.addOutput(tv2);
 
   const auto options =
@@ -5878,7 +5879,7 @@ TEST(NVFuserTest, FusionReductionScheduler_CUDA) {
   fusion.addInput(tv0);
 
   TensorView* tv1 =
-      reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0);
+      reductionOp(BinaryOpType::Add, {red_dim}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   const auto options =
@@ -5920,7 +5921,7 @@ TEST(NVFuserTest, FusionSymbolicReduction_CUDA) {
   fusion.addInput(tv0);
 
   // tv1[I0, R1] = tv0[I0, I1]
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   // Interface should just be a direct split with a Parallel type. We can
@@ -5983,7 +5984,8 @@ TEST(NVFuserTest, FusionReductionSchedulerMultiDimNonFastest_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(tensor_dims_in.size());
   fusion.addInput(tv0);
 
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, red_dims, new Float(0), tv0);
+  TensorView* tv1 =
+      reductionOp(BinaryOpType::Add, red_dims, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   const auto options =
@@ -6027,7 +6029,8 @@ TEST(NVFuserTest, FusionReductionSchedulerMultiDimFastest_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(tensor_dims_in.size());
   fusion.addInput(tv0);
 
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, red_dims, new Float(0), tv0);
+  TensorView* tv1 =
+      reductionOp(BinaryOpType::Add, red_dims, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   const auto options =
@@ -6210,8 +6213,8 @@ TEST(NVFuserTest, FusionCacheBefore_CUDA) {
   FusionGuard fg(&fusion);
 
   TensorView* tv0 = makeSymbolicTensor(2);
-  TensorView* tv1 = add(tv0, new Float(1.0));
-  TensorView* tv2 = mul(tv1, new Float(3.0));
+  TensorView* tv1 = add(tv0, new Double(1.0));
+  TensorView* tv2 = mul(tv1, new Double(3.0));
   fusion.addInput(tv0);
   fusion.addOutput(tv2);
   // Before: TV2 = TV1 * 3
@@ -6249,8 +6252,8 @@ TEST(NVFuserTest, FusionCacheAfter_CUDA) {
   FusionGuard fg(&fusion);
 
   TensorView* tv0 = makeSymbolicTensor(2);
-  TensorView* tv1 = add(tv0, new Float(1.0));
-  TensorView* tv2 = mul(tv1, new Float(3.0));
+  TensorView* tv1 = add(tv0, new Double(1.0));
+  TensorView* tv2 = mul(tv1, new Double(3.0));
   fusion.addInput(tv0);
   fusion.addOutput(tv2);
   // Before: TV1 = TV0 + 1
@@ -6395,10 +6398,10 @@ TEST(NVFuserTest, FusionCacheMultiConsumer_CUDA) {
   FusionGuard fg(&fusion);
 
   TensorView* tv0 = makeSymbolicTensor(1);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(2));
-  TensorView* tv3 = add(tv0, new Float(1));
-  TensorView* tv4 = add(tv3, new Float(2));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(2));
+  TensorView* tv3 = add(tv0, new Double(1));
+  TensorView* tv4 = add(tv3, new Double(2));
 
   fusion.addInput(tv0);
   fusion.addOutput(tv2);
@@ -6700,7 +6703,7 @@ TEST(NVFuserTest, FusionSmemDynamicPersistentSoftmax2D_CUDA) {
   TensorView* x = makeSymbolicTensor(2);
   fusion.addInput(x);
   TensorView* max_val =
-      reductionOp(BinaryOpType::Max, {-1}, new Float(FLT_MIN), x); // (M)
+      reductionOp(BinaryOpType::Max, {-1}, new Double(FLT_MIN), x); // (M)
   TensorView* bcast_max = broadcast(max_val, {false, true}); // (M, B)
   TensorView* x_max_sub = sub(x, bcast_max); // (M, N)
   TensorView* exp = unaryOp(UnaryOpType::Exp, x_max_sub); // (M, N)
@@ -6858,7 +6861,7 @@ TEST(NVFuserTest, FusionMagicSchedulerLayerNormalization_CUDA) {
   auto var_sum_bcast = broadcast(var_sum, broadcast_mask);
   // Point-wise
   auto var = div(var_sum_bcast, num_features);
-  auto var_eps = add(var, new Float(kEps));
+  auto var_eps = add(var, new Double(kEps));
   auto rvar = unaryOp(UnaryOpType::Rsqrt, var_eps);
   auto output = mul(x_mean_sub, rvar);
   fusion.addOutput(output);
@@ -6941,9 +6944,9 @@ TEST(NVFuserTest, FusionMagicSchedulerBatchNormalization_CUDA) {
   auto x_sum_bcast = broadcast(x_sum, broadcast_mask);
   auto x_mean = div(x_sum_bcast, num_features);
 
-  // auto current_mean_hat = mul(x_mean, new Float(kMomentum));
+  // auto current_mean_hat = mul(x_mean, new Double(kMomentum));
   // auto rmean_bcast = broadcast(running_mean, broadcast_mask);
-  // auto rmean_hat = mul(rmean_bcast, new Float(1.0 - kMomentum));
+  // auto rmean_hat = mul(rmean_bcast, new Double(1.0 - kMomentum));
   // auto new_running_mean = add(rmean_hat, current_mean_hat);
 
   auto x_mean_sub = sub(input, x_mean);
@@ -6952,12 +6955,12 @@ TEST(NVFuserTest, FusionMagicSchedulerBatchNormalization_CUDA) {
   auto var_sum_bcast = broadcast(var_sum, broadcast_mask);
   auto var = div(var_sum_bcast, num_features);
 
-  // auto current_var_hat = mul(var, new Float(kMomentum));
+  // auto current_var_hat = mul(var, new Double(kMomentum));
   // auto rvar_bcast = broadcast(running_var, broadcast_mask);
-  // auto rvar_hat = mul(rvar_bcast, new Float(1.0 - kMomentum));
+  // auto rvar_hat = mul(rvar_bcast, new Double(1.0 - kMomentum));
   // auto new_running_var = add(rvar_hat, current_var_hat);
 
-  auto var_eps = add(var, new Float(kEps));
+  auto var_eps = add(var, new Double(kEps));
   auto rvar = unaryOp(UnaryOpType::Rsqrt, var_eps);
   auto norm = mul(x_mean_sub, rvar);
 
@@ -7050,9 +7053,9 @@ TEST(NVFuserTest, FusionPersistentSoftmaxLocalSmem_CUDA) {
   fusion.addInput(dx);
 
   TensorView* max_sx =
-      reductionOp(BinaryOpType::Max, {-1}, new Float(FLT_MIN), sx); // (M)
+      reductionOp(BinaryOpType::Max, {-1}, new Double(FLT_MIN), sx); // (M)
   TensorView* max_dx =
-      reductionOp(BinaryOpType::Max, {-1}, new Float(FLT_MIN), dx); // (M)
+      reductionOp(BinaryOpType::Max, {-1}, new Double(FLT_MIN), dx); // (M)
 
   // Reduction => merge local and shared memory TensorViews
   TensorView* max_val = binaryOp(BinaryOpType::Max, max_sx, max_dx);
@@ -7179,9 +7182,9 @@ TEST(NVFuserTest, FusionPersistentNormLocalShared_CUDA) {
   fusion.addInput(sx);
   fusion.addInput(dx);
 
-  Float* gamma = new Float();
-  Float* beta = new Float();
-  Float* eps = new Float();
+  Double* gamma = new Double();
+  Double* beta = new Double();
+  Double* eps = new Double();
   Int* N = new Int();
   fusion.addInput(gamma);
   fusion.addInput(beta);
@@ -7352,9 +7355,9 @@ TEST(NVFuserTest, FusionSmemDynamicPersistentNorm_CUDA) {
 
   // Set up your input tensor views
   auto x = makeSymbolicTensor(2);
-  Float* gamma = new Float();
-  Float* beta = new Float();
-  Float* eps = new Float();
+  Double* gamma = new Double();
+  Double* beta = new Double();
+  Double* eps = new Double();
   Int* N = new Int();
   fusion.addInput(x);
   fusion.addInput(gamma);
@@ -7460,7 +7463,7 @@ TEST(NVFuserTest, FusionSmemDynamicReductionSymbolic_CUDA) {
 
   // Set up your input tensor views
   TensorView* tv0 = makeSymbolicTensor(2);
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addInput(tv0);
   fusion.addOutput(tv1);
   // tv1[I0, R1] = tv0[I0, I1]
@@ -7768,7 +7771,7 @@ TEST(NVFuserTest, FusionGlobalIntermediate_CUDA) {
 
   // Set up your input tensor views
   TensorView* tv0 = makeSymbolicTensor(2);
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   fusion.addInput(tv0);
   fusion.addOutput(tv1);
   // tv1[I0, R1] = tv0[I0, I1]
@@ -7881,8 +7884,8 @@ TEST(NVFuserTest, FusionUnrollWithAlloc_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(tensor_dims_in.size());
   fusion.addInput(tv0);
 
-  TensorView* tv1 = add(tv0, new Float(0));
-  TensorView* tv2 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv1);
+  TensorView* tv1 = add(tv0, new Double(0));
+  TensorView* tv2 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv1);
   fusion.addOutput(tv2);
 
   const auto options =
@@ -7951,12 +7954,12 @@ TEST(NVFuserTest, FusionComputeAtNonterminatingOutput_CUDA) {
   fusion.addInput(tv0);
 
   // Common intermediate tensor
-  auto tv1 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
   // tv1 -> tv2
-  auto tv2 = add(tv1, new Float(2));
+  auto tv2 = add(tv1, new Double(2));
   // tv1 -> tv3 -> tv4
-  auto tv3 = add(tv1, new Float(3));
-  auto tv4 = add(tv3, new Float(4));
+  auto tv3 = add(tv1, new Double(3));
+  auto tv4 = add(tv3, new Double(4));
 
   // NOTE: This should no longer occur as of PR #201.
   // The order of adding outputs matters. If tv3 is added before tv4,
@@ -8000,10 +8003,10 @@ TEST(NVFuserTest, FusionTraversalOrder1_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv0, new Float(2));
-  TensorView* tv3 = add(tv1, new Float(3));
-  TensorView* tv4 = add(tv1, new Float(4));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv0, new Double(2));
+  TensorView* tv3 = add(tv1, new Double(3));
+  TensorView* tv4 = add(tv1, new Double(4));
 
   fusion.addOutput(tv2);
   fusion.addOutput(tv3);
@@ -8041,11 +8044,11 @@ TEST(NVFuserTest, FusionTraversalOrder2_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(2));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(2));
 
-  TensorView* tv3 = add(tv0, new Float(3));
-  TensorView* tv4 = add(tv3, new Float(4));
+  TensorView* tv3 = add(tv0, new Double(3));
+  TensorView* tv4 = add(tv3, new Double(4));
 
   TensorView* tv5 = add(tv1, tv3);
 
@@ -8088,11 +8091,11 @@ TEST(NVFuserTest, FusionTraversalOrder3_CUDA) {
     TensorView* tv0 = makeSymbolicTensor(1);
     fusion.addInput(tv0);
 
-    TensorView* tv1 = add(tv0, new Float(1));
-    TensorView* tv2 = add(tv1, new Float(2));
+    TensorView* tv1 = add(tv0, new Double(1));
+    TensorView* tv2 = add(tv1, new Double(2));
 
-    TensorView* tv3 = add(tv0, new Float(3));
-    TensorView* tv4 = add(tv3, new Float(4));
+    TensorView* tv3 = add(tv0, new Double(3));
+    TensorView* tv4 = add(tv3, new Double(4));
 
     TensorView* tv5 = add(tv1, tv3);
 
@@ -8148,18 +8151,18 @@ TEST(NVFuserTest, FusionTraversalOrder4_CUDA) {
   // First tree
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(2));
-  TensorView* tv3 = add(tv1, new Float(3));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(2));
+  TensorView* tv3 = add(tv1, new Double(3));
   fusion.addOutput(tv2);
   fusion.addOutput(tv3);
 
   // Second tree
   TensorView* tv4 = makeSymbolicTensor(1);
   fusion.addInput(tv4);
-  TensorView* tv5 = add(tv4, new Float(5));
-  TensorView* tv6 = add(tv5, new Float(6));
-  TensorView* tv7 = add(tv5, new Float(7));
+  TensorView* tv5 = add(tv4, new Double(5));
+  TensorView* tv6 = add(tv5, new Double(6));
+  TensorView* tv7 = add(tv5, new Double(7));
   fusion.addOutput(tv6);
   fusion.addOutput(tv7);
 
@@ -8198,10 +8201,10 @@ TEST(NVFuserTest, FusionTraversalOrder5_CUDA) {
 
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(2));
-  TensorView* tv3 = add(tv0, new Float(3));
-  TensorView* tv4 = add(tv3, new Float(4));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(2));
+  TensorView* tv3 = add(tv0, new Double(3));
+  TensorView* tv4 = add(tv3, new Double(4));
   TensorView* tv5 = add(tv2, tv4);
 
   fusion.addOutput(tv1);
@@ -8240,10 +8243,10 @@ TEST(NVFuserTest, FusionTraversalOrder6_CUDA) {
 
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv0, new Float(2));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv0, new Double(2));
   TensorView* tv3 = add(tv1, tv2);
-  TensorView* tv4 = add(tv3, new Float(4));
+  TensorView* tv4 = add(tv3, new Double(4));
 
   fusion.addOutput(tv4);
 
@@ -8281,10 +8284,10 @@ TEST(NVFuserTest, FusionTraversalOrder7_CUDA) {
 
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
-  TensorView* tv1 = add(tv0, new Float(1));
-  TensorView* tv2 = add(tv1, new Float(2));
-  TensorView* tv3 = add(tv0, new Float(3));
-  TensorView* tv4 = add(tv3, new Float(4));
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(2));
+  TensorView* tv3 = add(tv0, new Double(3));
+  TensorView* tv4 = add(tv3, new Double(4));
   TensorView* tv5 = add(tv2, tv4);
 
   fusion.addOutput(tv5);
@@ -8333,9 +8336,9 @@ TEST(NVFuserTest, FusionThreadPredicate_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv0);
   TensorView* tv2 = unaryOp(UnaryOpType::Neg, tv1);
-  TensorView* tv3 = add(tv0, new Float(2));
+  TensorView* tv3 = add(tv0, new Double(2));
 
   fusion.addOutput(tv3);
   fusion.addOutput(tv2);
@@ -8471,7 +8474,7 @@ TEST(NVFuserTest, FusionComputeAtMultiBCast_CUDA) {
   TensorView* tv0 = makeSymbolicTensor(1);
   fusion.addInput(tv0);
 
-  TensorView* tv1 = mul(tv0, new Float(0.5));
+  TensorView* tv1 = mul(tv0, new Double(0.5));
   TensorView* tv2 = broadcast(tv1, {true, false});
   TensorView* tv3 = broadcast(tv1, {false, true});
   TensorView* tv4 = add(tv2, tv3);
@@ -8491,7 +8494,7 @@ TEST(NVFuserTest, FusionReductionHalf_CUDA) {
   fusion.addInput(tv0);
 
   auto tv1 = castOp(DataType::Float, tv0);
-  auto tv2 = add(tv1, new Float(1.0));
+  auto tv2 = add(tv1, new Double(1.0));
   auto tv3 = sum(tv2, {2});
   auto tv4 = castOp(DataType::Half, tv3);
 
@@ -8577,7 +8580,7 @@ TEST(NVFuserTest, FusionReduceImplicitBroadcast_CUDA) {
   fusion.addInput(tv0);
 
   TensorView* tv1 =
-      reductionOp(BinaryOpType::Add, {red_dim, 2}, new Float(0), tv0);
+      reductionOp(BinaryOpType::Add, {red_dim, 2}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   const auto options =
@@ -8619,10 +8622,10 @@ TEST(NVFuserTest, FusionReduceImplicitBroadcast2_CUDA) {
   TensorView* tv0 = makeConcreteTensor({bid_x, tid_x, 1});
   fusion.addInput(tv0);
 
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {2}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {2}, new Double(0), tv0);
 
   TensorView* tv2 =
-      reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv1);
+      reductionOp(BinaryOpType::Add, {red_dim}, new Double(0), tv1);
   fusion.addOutput(tv2);
 
   const auto options =
@@ -8666,9 +8669,9 @@ TEST(NVFuserTest, FusionReduceImplicitBroadcast3_CUDA) {
   fusion.addInput(tv0);
 
   TensorView* tv1 =
-      reductionOp(BinaryOpType::Add, {red_dim}, new Float(0), tv0);
+      reductionOp(BinaryOpType::Add, {red_dim}, new Double(0), tv0);
 
-  TensorView* tv2 = reductionOp(BinaryOpType::Add, {1}, new Float(0), tv1);
+  TensorView* tv2 = reductionOp(BinaryOpType::Add, {1}, new Double(0), tv1);
   fusion.addOutput(tv2);
 
   const auto options =
@@ -8705,7 +8708,7 @@ TEST(NVFuserTest, FusionTrivialReduction_CUDA) {
   // Set up your input tensor views
   TensorView* tv0 = makeConcreteTensor({10, 20, 1});
   fusion.addInput(tv0);
-  TensorView* tv1 = reductionOp(BinaryOpType::Add, {2}, new Float(0), tv0);
+  TensorView* tv1 = reductionOp(BinaryOpType::Add, {2}, new Double(0), tv0);
   fusion.addOutput(tv1);
 
   TORCH_CHECK(!fusion.hasReduction(), "Trivial reduction picked up by fusion");
@@ -9069,14 +9072,14 @@ TEST(NVFuserTest, FusionBiasGeluFwd_CUDA) {
   auto t3 = castOp(DataType::Float, t2);
   auto t4 = broadcast(t1, {true, true, false});
   auto t5 = add(t4, t3);
-  auto t6 = mul(t5, new Float(0.5));
-  auto t7 = mul(t5, new Float(k_079));
-  auto t8 = mul(t5, new Float(k_004));
+  auto t6 = mul(t5, new Double(0.5));
+  auto t7 = mul(t5, new Double(k_079));
+  auto t8 = mul(t5, new Double(k_004));
   auto t9 = mul(t8, t5);
   auto t10 = add(t9, new Int(1));
   auto t11 = mul(t7, t10);
   auto t12 = unaryOp(UnaryOpType::Tanh, t11);
-  auto t13 = add(t12, new Float(1));
+  auto t13 = add(t12, new Double(1));
   auto t14 = mul(t6, t13);
   auto t15 = castOp(DataType::Half, t14);
   fusion.addOutput(t15);
@@ -9129,23 +9132,23 @@ TEST(NVFuserTest, FusionBiasGeluBwd_CUDA) {
   auto t5 = castOp(DataType::Float, t4);
   auto t6 = broadcast(t3, {true, true, false});
   auto t7 = add(t6, t5);
-  auto t8 = mul(t7, new Float(k_079));
-  auto t9 = mul(t7, new Float(k_004));
+  auto t8 = mul(t7, new Double(k_079));
+  auto t9 = mul(t7, new Double(k_004));
   auto t10 = mul(t9, t7);
   auto t11 = add(t10, new Int(1));
   auto t12 = mul(t8, t11);
   auto t13 = unaryOp(UnaryOpType::Tanh, t12);
-  auto t14 = mul(t7, new Float(0.5));
+  auto t14 = mul(t7, new Double(0.5));
   auto t15 = mul(t13, t13);
   auto t16 = unaryOp(UnaryOpType::Neg, t15);
   auto t17 = add(t16, new Int(1));
-  auto t18 = mul(t7, new Float(k_010));
+  auto t18 = mul(t7, new Double(k_010));
   auto t19 = mul(t18, t7);
-  auto t20 = add(t19, new Float(k_079));
+  auto t20 = add(t19, new Double(k_079));
   auto t21 = mul(t17, t20);
   auto t22 = mul(t14, t21);
   auto t23 = add(t13, new Int(1));
-  auto t24 = mul(t23, new Float(0.5));
+  auto t24 = mul(t23, new Double(0.5));
   auto t25 = add(t22, t24);
   auto t26 = mul(t25, t1);
   // Save float output for validation
@@ -9194,14 +9197,14 @@ TEST(NVFuserTest, FusionIssue459_CUDA) {
   auto tv1 = makeSymbolicTensor(2);
   fusion.addInput(tv1);
 
-  auto tv2 = add(tv0, new Float(1));
+  auto tv2 = add(tv0, new Double(1));
   auto tv3 = broadcast(tv2, {true, false});
   auto tv4 = add(tv1, tv3);
 
   // Create two outputs from the final arithmetic result
-  auto tv5 = add(tv4, new Float(1));
+  auto tv5 = add(tv4, new Double(1));
   fusion.addOutput(tv5);
-  auto tv6 = add(tv4, new Float(1));
+  auto tv6 = add(tv4, new Double(1));
   fusion.addOutput(tv6);
 
   // Scheduling
@@ -9247,9 +9250,9 @@ TEST(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
 
   auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
-  auto tv1 = add(tv0, new Float(1));
-  auto tv2 = add(tv1, new Float(1));
-  auto tv3 = add(tv2, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
+  auto tv2 = add(tv1, new Double(1));
+  auto tv3 = add(tv2, new Double(1));
   fusion.addOutput(tv3);
 
   tv3->axis(0)->parallelize(ParallelType::BIDx);
@@ -9383,7 +9386,7 @@ TEST(NVFuserTest, FusionCacheBeforeReduction_CUDA) {
 
   auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
-  auto tv1 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
   auto tv2 = sum(tv1, {1});
   fusion.addOutput(tv2);
 
@@ -9417,9 +9420,9 @@ TEST(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
 
   auto tv0 = makeSymbolicTensor(3);
   fusion.addInput(tv0);
-  auto tv1 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
   auto tv2 = sum(tv1, {1});
-  auto tv3 = add(tv2, new Float(1));
+  auto tv3 = add(tv2, new Double(1));
   fusion.addOutput(tv2);
   fusion.addOutput(tv3);
 
@@ -9683,7 +9686,7 @@ TEST(NVFuserTest, FusionIssue484_CUDA) {
   auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
   auto tv1 = sum(tv0, {1});
-  auto tv2 = add(tv1, new Float(0));
+  auto tv2 = add(tv1, new Double(0));
   fusion.addOutput(tv2);
 
   tv1->setMemoryType(MemoryType::Global);
@@ -9710,7 +9713,7 @@ TEST(NVFuserTest, Issue329_CUDA) {
 
   auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
-  auto tv1 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
   auto tv2 = sum(tv1, {1});
   fusion.addOutput(tv2);
   auto tv3 = sum(tv1, {1});
@@ -9742,7 +9745,7 @@ TEST(NVFuserTest, FusionIssue382_CUDA) {
   auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
-  auto tv1 = add(tv0, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
   auto tv2 = broadcast(tv1, {false, false, true});
   auto tv3 = makeSymbolicTensor(3);
   fusion.addInput(tv3);
@@ -9786,8 +9789,8 @@ TEST(NVFuserTest, Issue507_CUDA) {
 
   auto tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
-  auto tv1 = add(tv0, new Float(1));
-  auto tv2 = add(tv1, new Float(1));
+  auto tv1 = add(tv0, new Double(1));
+  auto tv2 = add(tv1, new Double(1));
   fusion.addOutput(tv2);
 
   tv1->setMemoryType(MemoryType::Shared);
@@ -9816,4 +9819,4 @@ TEST(NVFuserTest, Issue507_CUDA) {
 } // namespace jit
 } // namespace torch
 
-#endif // #if defined(USE_CUDA)
+// #endif // #if defined(USE_CUDA)

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 #include <torch/csrc/jit/codegen/cuda/type.h>
 #include <cfloat>
 
@@ -20,9 +21,9 @@ Val* newScalar(ValType vtype, DataType dtype) {
         case DataType::Bool:
           return new Bool();
         case DataType::Double:
-          return new Float();
         case DataType::Float:
-          return new Float();
+        case DataType::Half:
+          return new Double();
         case DataType::Int:
           return new Int();
         default:
@@ -123,27 +124,7 @@ std::vector<Val*> maybeBroadcast(const std::vector<Val*>& vals) {
   return out_vals;
 }
 
-Val* newOutputVal(const std::vector<Val*>& vals) {
-  ValType out_vtype = vals[0]->getValType().value();
-  DataType out_dtype = vals[0]->getDataType().value();
-
-  for (auto val : vals) {
-    TORCH_CHECK(val->isVal(), "Invalid statement found during promotion.");
-    TORCH_CHECK(
-        val->getDataType().value() != DataType::Null,
-        "Invalid datatype found during prmotion.");
-    out_vtype = promote_type(out_vtype, val->getValType().value());
-    out_dtype = promote_type(out_dtype, val->getDataType().value());
-  }
-
-  if (out_vtype == ValType::TensorView)
-    return newOutputTV(vals, out_dtype);
-
-  return newScalar(out_vtype, out_dtype);
-}
-
 Val* newValLike(Val* val, DataType dtype) {
-  TORCH_CHECK(val->isVal(), "Invalid statement provided to create new value.");
   TORCH_CHECK(
       dtype != DataType::Null, "Invalid datatype provided for new value.");
 
@@ -183,7 +164,7 @@ TensorView* castOp(DataType dtype, TensorView* v1) {
 // UNARY OPERATIONS
 
 Val* unaryOp(UnaryOpType type, Val* v1) {
-  Val* out = newOutputVal({v1});
+  Val* out = newValLike(v1, v1->getDataType().value());
   new UnaryOp(type, out, v1);
   return out;
 }
@@ -195,6 +176,7 @@ TensorView* unaryOp(UnaryOpType type, TensorView* v1) {
 Val* neg(Val* v) {
   return unaryOp(UnaryOpType::Neg, v);
 }
+
 TensorView* neg(TensorView* v) {
   return unaryOp(UnaryOpType::Neg, v);
 }
@@ -208,11 +190,13 @@ TensorView* arithOpOverloads(Val* (*func)(Val*, Val*), T1* v1, T2* v2) {
   return func(v1->template as<Val>(), v2->template as<Val>())
       ->template as<TensorView>();
 }
+
 template <typename T1, typename T2>
 TensorView* arithOpOverloads(BinaryOpType type, T1* v1, T2* v2) {
   return binaryOp(type, v1->template as<Val>(), v2->template as<Val>())
       ->template as<TensorView>();
 }
+
 template <typename T1, typename T2, typename T3>
 TensorView* arithOpOverloads(
     Val* (*func)(Val*, Val*, Val*),
@@ -226,6 +210,7 @@ TensorView* arithOpOverloads(
              vals[2]->template as<Val>())
       ->template as<TensorView>();
 }
+
 template <typename T1, typename T2, typename T3, typename T4>
 TensorView* arithOpOverloads(
     Val* (*func)(Val*, Val*, Val*, Val*),
@@ -242,57 +227,67 @@ TensorView* arithOpOverloads(
       ->template as<TensorView>();
 }
 
-DataType getOutputType(BinaryOpType type, DataType v1_type, DataType v2_type) {
-  bool floating_input =
-      isFloatingPointType(v1_type) || isFloatingPointType(v2_type);
-  bool integer_input = isIntegralType(v1_type) || isIntegralType(v2_type);
+// Type promotion logic for binary operators
+DataType getOutputType(BinaryOpType op_type, Val* v1, Val* v2) {
+  DataType v1_dtype = v1->getDataType().value();
+  DataType v2_dtype = v2->getDataType().value();
 
-  if (isIntegerOp(type)) {
-    if (integer_input && !floating_input) {
-      return isIntegralType(v1_type) ? v1_type : v2_type;
+  // If we have a tensor view in one argument but a scalar in the other, don't
+  // type promote, just use the tensorview type
+  if (v1->isA<TensorView>() && !v2->isA<TensorView>()) {
+    v2_dtype = v1_dtype;
+  }
+  if (v2->isA<TensorView>() && !v1->isA<TensorView>()) {
+    v1_dtype = v2_dtype;
+  }
+
+  bool floating_input =
+      isFloatingPointType(v1_dtype) || isFloatingPointType(v2_dtype);
+
+  bool integer_input = isIntegralType(v1_dtype) || isIntegralType(v2_dtype);
+
+  bool all_integer_input = isIntegralType(v1_dtype) && isIntegralType(v2_dtype);
+
+  if (isIntegerOp(op_type) ||
+      (maybeBooleanOperator(op_type) && integer_input)) {
+    // If integer op or maybe bool op with integer inputs meaning binary op
+    if (integer_input && all_integer_input) {
+      return promote_type(v1_dtype, v2_dtype);
+    } else if (integer_input && !all_integer_input) {
+      return isIntegralType(v1_dtype) ? v1_dtype : v2_dtype;
     } else {
-      // When we add more integer types we should return type promoted int
       return DataType::Int;
     }
-  } else if (isLogicalOp(type)) {
+  } else if (isLogicalOp(op_type)) {
+    // If boolean op
     return DataType::Bool;
-  } else if (maybeBooleanOperator(type)) {
+  } else if (maybeBooleanOperator(op_type)) {
+    // If boolean op that can't have floating inputs (& or |)
     TORCH_CHECK(
         !floating_input,
         "Operator ",
-        type,
+        op_type,
         " not supported with floating point inputs.");
-    if (integer_input) {
-      // When we add more integer types we should return type promoted int
-      return DataType::Int;
-    } else {
-      return DataType::Bool;
-    }
+    return DataType::Bool;
   } else {
-    return promote_type(v1_type, v2_type);
+    // Otherwise do normal type promotion
+    return promote_type(v1_dtype, v2_dtype);
   }
 }
 
 } // namespace
 
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
-  auto vals = maybeBroadcast({v1, v2});
-  ValType val_type =
+  auto out_dtype = getOutputType(type, v1, v2);
+  auto out_vtype =
       promote_type(v1->getValType().value(), v2->getValType().value());
-
-  DataType dtype =
-      getOutputType(type, v1->getDataType().value(), v2->getDataType().value());
-
+  auto vals = maybeBroadcast({v1, v2});
   Val* out = nullptr;
-  if (val_type == ValType::TensorView) {
-    out = newOutputTV(vals, dtype);
+  if (out_vtype == ValType::TensorView) {
+    out = newOutputTV(vals, out_dtype);
   } else {
-    out = newScalar(val_type, dtype);
+    out = newScalar(out_vtype, out_dtype);
   }
-
-  TORCH_INTERNAL_ASSERT(
-      out != nullptr,
-      "Something went wrong in type promotion, output is not valid.");
   new BinaryOp(type, out, vals[0], vals[1]);
   return out;
 }
@@ -300,9 +295,11 @@ TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
 TensorView* binaryOp(BinaryOpType type, TensorView* v1, Val* v2) {
   return arithOpOverloads(type, v1, v2);
 }
+
 TensorView* binaryOp(BinaryOpType type, Val* v1, TensorView* v2) {
   return arithOpOverloads(type, v1, v2);
 }
+
 TensorView* binaryOp(BinaryOpType type, TensorView* v1, TensorView* v2) {
   return arithOpOverloads(type, v1, v2);
 }
@@ -320,6 +317,7 @@ TensorView* add(Val* v1, TensorView* v2) {
 TensorView* add(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(add, v1, v2);
 }
+
 // sub
 Val* sub(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Sub, v1, v2);
@@ -333,6 +331,7 @@ TensorView* sub(Val* v1, TensorView* v2) {
 TensorView* sub(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(sub, v1, v2);
 }
+
 // mul
 Val* mul(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Mul, v1, v2);
@@ -346,6 +345,7 @@ TensorView* mul(Val* v1, TensorView* v2) {
 TensorView* mul(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(mul, v1, v2);
 }
+
 // div
 Val* div(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Div, v1, v2);
@@ -359,6 +359,7 @@ TensorView* div(Val* v1, TensorView* v2) {
 TensorView* div(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(div, v1, v2);
 }
+
 // mod
 Val* mod(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Mod, v1, v2);
@@ -372,6 +373,7 @@ TensorView* mod(Val* v1, TensorView* v2) {
 TensorView* mod(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(mod, v1, v2);
 }
+
 // lt
 Val* lt(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::LT, v1, v2);
@@ -385,6 +387,7 @@ TensorView* lt(Val* v1, TensorView* v2) {
 TensorView* lt(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(lt, v1, v2);
 }
+
 // eq
 Val* eq(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::Eq, v1, v2);
@@ -398,6 +401,7 @@ TensorView* eq(Val* v1, TensorView* v2) {
 TensorView* eq(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(eq, v1, v2);
 }
+
 // ceilDiv
 Val* ceilDiv(Val* v1, Val* v2) {
   return binaryOp(BinaryOpType::CeilDiv, v1, v2);
@@ -411,6 +415,7 @@ TensorView* ceilDiv(Val* v1, TensorView* v2) {
 TensorView* ceilDiv(TensorView* v1, TensorView* v2) {
   return arithOpOverloads(ceilDiv, v1, v2);
 }
+
 // andOp
 Val* andOp(Val* v1, Val* v2) {
   TORCH_CHECK(
@@ -516,8 +521,16 @@ TensorView* reductionOp(
   }
 
   TensorView* out = newForReduction(tv, uint_axes);
-  if (init->getDataType().value() != tv->getDataType().value())
-    init = castOp(tv->getDataType().value(), init);
+  auto out_type = out->getDataType().value();
+  auto init_type = init->getDataType().value();
+  TORCH_CHECK(
+      (isFloatingPointType(out_type) && isFloatingPointType(init_type)) ||
+          (isIntegralType(out_type) && isIntegralType(init_type)) ||
+          (out_type == DataType::Bool && init_type == DataType::Bool),
+      "Types should match for reduction ops but received: ",
+      out_type,
+      " and ",
+      init_type);
   new ReductionOp(reduction_op_type, init, out, tv);
 
   if (keep_dim) {
@@ -537,21 +550,16 @@ TensorView* sum(
     const std::vector<int>& axes,
     bool keep_dim /*=false*/) {
   Val* init = nullptr;
-  switch (v1->getDataType().value()) {
-    case (DataType::Double):
-      init = new Double(0.0);
-      break;
-    case (DataType::Float):
-      init = new Float(0.0);
-      break;
-    case (DataType::Int):
-      init = new Int(0);
-      break;
-    default:
-      TORCH_CHECK(
-          false,
-          "Could not generate a sum op for tensor with type: ",
-          v1->getDataType().value());
+  auto dtype = v1->getDataType().value();
+  if (isFloatingPointType(dtype)) {
+    init = new Double(0.0);
+  } else if (isIntegralType(dtype)) {
+    init = new Int(0);
+  } else {
+    TORCH_CHECK(
+        false,
+        "Could not generate a sum op for tensor with type: ",
+        v1->getDataType().value());
   }
 
   return reductionOp(BinaryOpType::Add, axes, init, v1, keep_dim);
@@ -567,7 +575,7 @@ TensorView* max(
       init = new Double(DBL_MIN);
       break;
     case (DataType::Float):
-      init = new Float(FLT_MIN);
+      init = new Double(FLT_MIN);
       break;
     case (DataType::Int):
       init = new Int(INT_MIN);
@@ -592,7 +600,7 @@ TensorView* min(
       init = new Double(DBL_MAX);
       break;
     case (DataType::Float):
-      init = new Float(FLT_MAX);
+      init = new Double(FLT_MAX);
       break;
     case (DataType::Int):
       init = new Int(INT_MAX);
@@ -762,18 +770,28 @@ TensorView* addcmul(TensorView* v1, TensorView* v2, TensorView* v3, Val* v4) {
 }
 
 // TERNARY OPERATIONS
-// where
+// where (c ? v1 : v2)
 Val* where(Val* c, Val* v1, Val* v2) {
   TORCH_CHECK(
       c->getDataType().value() == DataType::Bool,
       "Condition should be of DataType Bool, not ",
       c->getDataType().value());
 
+  // Not actually an add, but need to send a binary op to get output type
+  auto out_dtype = getOutputType(BinaryOpType::Add, v1, v2);
+  auto out_vtype =
+      promote_type(v1->getValType().value(), v2->getValType().value());
   auto vals = maybeBroadcast({c, v1, v2});
-  Val* out = newOutputVal({vals[1], vals[2]});
+  Val* out = nullptr;
+  if (out_vtype == ValType::TensorView) {
+    out = newOutputTV(vals, out_dtype);
+  } else {
+    out = newScalar(out_vtype, out_dtype);
+  }
   new TernaryOp(TernaryOpType::Where, out, vals[0], vals[1], vals[2]);
   return out;
 }
+
 TensorView* where(TensorView* v1, Val* v2, Val* v3) {
   return arithOpOverloads(where, v1, v2, v3);
 }
@@ -799,17 +817,36 @@ TensorView* where(TensorView* v1, TensorView* v2, TensorView* v3) {
 // TERNARY OPERATIONS
 
 Val* threshold(Val* in, Val* thresh, Val* value) {
+  auto in_type = in->getDataType().value();
+  auto thresh_type = thresh->getDataType().value();
+  auto value_type = value->getDataType().value();
+  if (isFloatingPointType(in_type)) {
+    TORCH_CHECK(
+        isFloatingPointType(thresh_type) && isFloatingPointType(value_type),
+        "All input DataType values should match the input type ",
+        in_type,
+        " vs ",
+        thresh_type,
+        " and ",
+        value_type);
+  } else if (isIntegralType(in_type)) {
+    TORCH_CHECK(
+        isIntegralType(thresh_type) && isIntegralType(value_type),
+        "All input DataType values should match the input ",
+        in_type,
+        " vs ",
+        thresh_type,
+        " and ",
+        value_type);
+  }
   TORCH_CHECK(
-      in->getDataType().value() == thresh->getDataType().value() &&
-          in->getDataType().value() == value->getDataType().value(),
-      "All input DataType values should match the input ",
-      in->getDataType().value());
-  TORCH_CHECK(
-      thresh->getValType().value() == ValType::Scalar &&
-          value->getValType().value() == ValType::Scalar,
-      "Thresh and Value values should be Scalars");
+      (thresh->getValType().value() == ValType::Scalar ||
+       thresh->getValType().value() == ValType::NamedScalar) &&
+          (value->getValType().value() == ValType::Scalar ||
+           value->getValType().value() == ValType::NamedScalar),
+      "For Threshold operation: Thresh and Value values should be Scalars.");
 
-  Val* out = newOutputVal({in});
+  Val* out = newValLike(in, in_type);
 
   new TernaryOp(TernaryOpType::Threshold, out, in, thresh, value);
   return out;
@@ -820,17 +857,36 @@ TensorView* threshold(TensorView* in, Val* thresh, Val* value) {
 }
 
 Val* clamp(Val* in, Val* min_val, Val* max_val) {
+  auto in_type = in->getDataType().value();
+  auto min_type = min_val->getDataType().value();
+  auto max_type = max_val->getDataType().value();
+  if (isFloatingPointType(in_type)) {
+    TORCH_CHECK(
+        isFloatingPointType(min_type) && isFloatingPointType(max_type),
+        "All input DataType values should match the input type ",
+        in_type,
+        " vs ",
+        min_type,
+        " and ",
+        max_type);
+  } else if (isIntegralType(in_type)) {
+    TORCH_CHECK(
+        isIntegralType(min_type) && isIntegralType(max_type),
+        "All input DataType values should match the input ",
+        in_type,
+        " vs ",
+        min_type,
+        " and ",
+        max_type);
+  }
   TORCH_CHECK(
-      in->getDataType().value() == min_val->getDataType().value() &&
-          in->getDataType().value() == max_val->getDataType().value(),
-      "All input DataType values should match the input ",
-      in->getDataType().value());
-  TORCH_CHECK(
-      min_val->getValType().value() == ValType::Scalar &&
-          max_val->getValType().value() == ValType::Scalar,
-      "Min and Max values should be Scalars");
+      (min_val->getValType().value() == ValType::Scalar ||
+       min_val->getValType().value() == ValType::NamedScalar) &&
+          (max_val->getValType().value() == ValType::Scalar ||
+           max_val->getValType().value() == ValType::NamedScalar),
+      "For Threshold operation: Thresh and Value values should be Scalars.");
 
-  Val* out = newOutputVal({in});
+  Val* out = newValLike(in, in_type);
 
   new TernaryOp(TernaryOpType::Clamp, out, in, min_val, max_val);
   return out;

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -35,10 +35,11 @@ Val* newScalar(ValType vtype, DataType dtype) {
 
   TORCH_CHECK(
       false,
-      "Was expecting a scalar type, but received ValType: ",
+      "Cannot handle ValType: ",
       vtype,
       " with DataType:",
-      dtype);
+      dtype,
+      " in newScalar.");
 }
 
 TensorView* newOutputTV(const std::vector<Val*>& vals, DataType dtype) {

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -242,12 +242,14 @@ DataType getOutputType(BinaryOpType op_type, Val* v1, Val* v2) {
     v1_dtype = v2_dtype;
   }
 
-  bool floating_input =
+  const bool floating_input =
       isFloatingPointType(v1_dtype) || isFloatingPointType(v2_dtype);
 
-  bool integer_input = isIntegralType(v1_dtype) || isIntegralType(v2_dtype);
+  const bool integer_input =
+      isIntegralType(v1_dtype) || isIntegralType(v2_dtype);
 
-  bool all_integer_input = isIntegralType(v1_dtype) && isIntegralType(v2_dtype);
+  const bool all_integer_input =
+      isIntegralType(v1_dtype) && isIntegralType(v2_dtype);
 
   if (isIntegerOp(op_type) ||
       (maybeBooleanOperator(op_type) && integer_input)) {
@@ -279,8 +281,8 @@ DataType getOutputType(BinaryOpType op_type, Val* v1, Val* v2) {
 } // namespace
 
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2) {
-  auto out_dtype = getOutputType(type, v1, v2);
-  auto out_vtype =
+  const auto out_dtype = getOutputType(type, v1, v2);
+  const auto out_vtype =
       promote_type(v1->getValType().value(), v2->getValType().value());
   auto vals = maybeBroadcast({v1, v2});
   Val* out = nullptr;
@@ -522,8 +524,8 @@ TensorView* reductionOp(
   }
 
   TensorView* out = newForReduction(tv, uint_axes);
-  auto out_type = out->getDataType().value();
-  auto init_type = init->getDataType().value();
+  const auto out_type = out->getDataType().value();
+  const auto init_type = init->getDataType().value();
   TORCH_CHECK(
       (isFloatingPointType(out_type) && isFloatingPointType(init_type)) ||
           (isIntegralType(out_type) && isIntegralType(init_type)) ||
@@ -818,9 +820,9 @@ TensorView* where(TensorView* v1, TensorView* v2, TensorView* v3) {
 // TERNARY OPERATIONS
 
 Val* threshold(Val* in, Val* thresh, Val* value) {
-  auto in_type = in->getDataType().value();
-  auto thresh_type = thresh->getDataType().value();
-  auto value_type = value->getDataType().value();
+  const auto in_type = in->getDataType().value();
+  const auto thresh_type = thresh->getDataType().value();
+  const auto value_type = value->getDataType().value();
   if (isFloatingPointType(in_type)) {
     TORCH_CHECK(
         isFloatingPointType(thresh_type) && isFloatingPointType(value_type),
@@ -858,9 +860,9 @@ TensorView* threshold(TensorView* in, Val* thresh, Val* value) {
 }
 
 Val* clamp(Val* in, Val* min_val, Val* max_val) {
-  auto in_type = in->getDataType().value();
-  auto min_type = min_val->getDataType().value();
-  auto max_type = max_val->getDataType().value();
+  const auto in_type = in->getDataType().value();
+  const auto min_type = min_val->getDataType().value();
+  const auto max_type = max_val->getDataType().value();
   if (isFloatingPointType(in_type)) {
     TORCH_CHECK(
         isFloatingPointType(min_type) && isFloatingPointType(max_type),

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -23,8 +23,6 @@ Val* newScalar(ValType vtype, DataType dtype) {
           return new Float();
         case DataType::Float:
           return new Float();
-        case DataType::Half:
-          return new Half();
         case DataType::Int:
           return new Int();
         default:

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -251,8 +251,7 @@ DataType getOutputType(BinaryOpType op_type, Val* v1, Val* v2) {
   const bool all_integer_input =
       isIntegralType(v1_dtype) && isIntegralType(v2_dtype);
 
-  if (isIntegerOp(op_type) ||
-      (maybeBooleanOperator(op_type) && integer_input)) {
+  if (isIntegerOp(op_type) || (alsoBooleanOperator(op_type) && integer_input)) {
     // If integer op or maybe bool op with integer inputs meaning binary op
     if (integer_input && all_integer_input) {
       return promote_type(v1_dtype, v2_dtype);

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -221,8 +221,6 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else if (node->isConst()) {
       const int digits = std::numeric_limits<Double::ScalarType>::max_digits10;
       code_ << std::setprecision(digits) << *node->value();
-    } else if (def == nullptr) {
-      code_ << varName(node);
     } else {
       code_ << varName(node);
     }

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -235,23 +235,9 @@ class CudaKernelGenerator : private kir::IrVisitor {
       code_ << "(" << gen(def) << ")";
     } else if (node->isConst()) {
       const int digits = std::numeric_limits<Double::ScalarType>::max_digits10;
-      code_ << "double(" << std::setprecision(digits) << *node->value() << ")";
+      code_ << std::setprecision(digits) << *node->value();
     } else if (def == nullptr) {
-      code_ << "(double)" << varName(node);
-    } else {
       code_ << varName(node);
-    }
-  }
-
-  void visit(const kir::Float* node) final {
-    const auto def = node->definition();
-    if (print_inline_ && def != nullptr) {
-      code_ << "(" << gen(def) << ")";
-    } else if (node->isConst()) {
-      const int digits = std::numeric_limits<Float::ScalarType>::max_digits10;
-      code_ << "float(" << std::setprecision(digits) << *node->value() << ")";
-    } else if (def == nullptr) {
-      code_ << "(float) " << varName(node);
     } else {
       code_ << varName(node);
     }
@@ -526,7 +512,8 @@ class CudaKernelGenerator : private kir::IrVisitor {
       } else {
         indent() << kTab << genInline(node->predicate()) << ",\n";
       }
-      indent() << kTab << genInline(node->init()) << ");\n";
+      indent() << kTab << data_type << "(" << genInline(node->init())
+               << "));\n";
     }
   }
 
@@ -608,7 +595,8 @@ class CudaKernelGenerator : private kir::IrVisitor {
     } else {
       indent() << kTab << genInline(node->predicate()) << ",\n";
     }
-    indent() << kTab << genInline(node->reduction_op()->init()) << ");\n";
+    indent() << kTab << data_type << "("
+             << genInline(node->reduction_op()->init()) << "));\n";
   }
 
   void handleScope(const kir::Scope& scope) {

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -257,17 +257,6 @@ class CudaKernelGenerator : private kir::IrVisitor {
     }
   }
 
-  void visit(const kir::Half* node) final {
-    const auto def = node->definition();
-    if (print_inline_ && def != nullptr) {
-      code_ << "(" << gen(def) << ")";
-    } else if (node->isConst()) {
-      code_ << "__float2half(" << *node->value() << ")";
-    } else {
-      code_ << varName(node);
-    }
-  }
-
   void visit(const kir::Int* node) final {
     const auto def = node->definition();
     if (print_inline_ && def != nullptr) {

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -63,23 +63,8 @@ class CudaKernelGenerator : private kir::IrVisitor {
               << "> " << varName(tv);
       } else {
         TORCH_INTERNAL_ASSERT(val->isScalar());
-        // All floating point arguments come in as double, all int arguments
-        // come in as int64
-
-        if (isFloatingPointType(val->dtype())) {
-          // Should always be double
-          code_ << DataType::Double;
-        } else if (val->dtype() == DataType::Bool) {
-          code_ << DataType::Bool;
-        } else {
-          // Should always be int64_t
-          code_ << DataType::Int;
-        }
-        if (val->definition() != nullptr) {
-          code_ << " " << gen(val);
-        } else {
-          code_ << " " << varName(val);
-        }
+        TORCH_INTERNAL_ASSERT(val->definition() == nullptr);
+        code_ << val->dtype() << " " << gen(val);
       }
 
       if (val != params.back()) {

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -54,9 +54,6 @@ void Val::dispatch(T handler, Val* val) {
         case DataType::Float:
           ptr(handler)->handle(val->as<Float>());
           return;
-        case DataType::Half:
-          ptr(handler)->handle(val->as<Half>());
-          return;
         case DataType::Int:
           ptr(handler)->handle(val->as<Int>());
           return;
@@ -134,9 +131,6 @@ void Val::constDispatch(T handler, const Val* val) {
           return;
         case DataType::Float:
           ptr(handler)->handle(val->as<Float>());
-          return;
-        case DataType::Half:
-          ptr(handler)->handle(val->as<Half>());
           return;
         case DataType::Int:
           ptr(handler)->handle(val->as<Int>());
@@ -224,8 +218,6 @@ Statement* Val::mutatorDispatch(T mutator, Val* val) {
           return ptr(mutator)->mutate(val->as<Double>());
         case DataType::Float:
           return ptr(mutator)->mutate(val->as<Float>());
-        case DataType::Half:
-          return ptr(mutator)->mutate(val->as<Half>());
         case DataType::Int:
           return ptr(mutator)->mutate(val->as<Int>());
         default:

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -51,9 +51,6 @@ void Val::dispatch(T handler, Val* val) {
         case DataType::Double:
           ptr(handler)->handle(val->as<Double>());
           return;
-        case DataType::Float:
-          ptr(handler)->handle(val->as<Float>());
-          return;
         case DataType::Int:
           ptr(handler)->handle(val->as<Int>());
           return;
@@ -128,9 +125,6 @@ void Val::constDispatch(T handler, const Val* val) {
           return;
         case DataType::Double:
           ptr(handler)->handle(val->as<Double>());
-          return;
-        case DataType::Float:
-          ptr(handler)->handle(val->as<Float>());
           return;
         case DataType::Int:
           ptr(handler)->handle(val->as<Int>());
@@ -216,8 +210,6 @@ Statement* Val::mutatorDispatch(T mutator, Val* val) {
           return ptr(mutator)->mutate(val->as<Bool>());
         case DataType::Double:
           return ptr(mutator)->mutate(val->as<Double>());
-        case DataType::Float:
-          return ptr(mutator)->mutate(val->as<Float>());
         case DataType::Int:
           return ptr(mutator)->mutate(val->as<Int>());
         default:

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -62,7 +62,6 @@ class TensorDomain;
 class TensorView;
 class Bool;
 class Double;
-class Float;
 class Int;
 class NamedScalar;
 
@@ -90,7 +89,6 @@ class TORCH_CUDA_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const TensorView*) {}
   virtual void handle(const Bool*) {}
   virtual void handle(const Double*) {}
-  virtual void handle(const Float*) {}
   virtual void handle(const Int*) {}
   virtual void handle(const NamedScalar*) {}
 
@@ -117,7 +115,6 @@ class TORCH_CUDA_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(TensorView*) {}
   virtual void handle(Bool*) {}
   virtual void handle(Double*) {}
-  virtual void handle(Float*) {}
   virtual void handle(Int*) {}
   virtual void handle(NamedScalar*) {}
 
@@ -153,9 +150,6 @@ class TORCH_CUDA_API OptInConstDispatch : public PolymorphicBase {
   }
   virtual void handle(const Double*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Double.");
-  }
-  virtual void handle(const Float*) {
-    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
   }
   virtual void handle(const Int*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
@@ -210,9 +204,6 @@ class TORCH_CUDA_API OptInDispatch : public PolymorphicBase {
   }
   virtual void handle(Double*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Double.");
-  }
-  virtual void handle(Float*) {
-    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
   }
   virtual void handle(Int*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
@@ -281,7 +272,6 @@ class TORCH_CUDA_API OptOutMutator : public PolymorphicBase {
   virtual Statement* mutate(TensorView*);
   virtual Statement* mutate(Bool*);
   virtual Statement* mutate(Double*);
-  virtual Statement* mutate(Float*);
   virtual Statement* mutate(Int*);
   virtual Statement* mutate(NamedScalar*);
 
@@ -325,9 +315,6 @@ class TORCH_CUDA_API OptInMutator : public PolymorphicBase {
   }
   virtual Statement* mutate(Bool*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Bool.");
-  }
-  virtual Statement* mutate(Float*) {
-    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Float.");
   }
   virtual Statement* mutate(Int*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for Int.");

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -63,7 +63,6 @@ class TensorView;
 class Bool;
 class Double;
 class Float;
-class Half;
 class Int;
 class NamedScalar;
 
@@ -92,7 +91,6 @@ class TORCH_CUDA_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const Bool*) {}
   virtual void handle(const Double*) {}
   virtual void handle(const Float*) {}
-  virtual void handle(const Half*) {}
   virtual void handle(const Int*) {}
   virtual void handle(const NamedScalar*) {}
 
@@ -120,7 +118,6 @@ class TORCH_CUDA_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(Bool*) {}
   virtual void handle(Double*) {}
   virtual void handle(Float*) {}
-  virtual void handle(Half*) {}
   virtual void handle(Int*) {}
   virtual void handle(NamedScalar*) {}
 
@@ -159,9 +156,6 @@ class TORCH_CUDA_API OptInConstDispatch : public PolymorphicBase {
   }
   virtual void handle(const Float*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
-  }
-  virtual void handle(const Half*) {
-    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Half.");
   }
   virtual void handle(const Int*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
@@ -219,9 +213,6 @@ class TORCH_CUDA_API OptInDispatch : public PolymorphicBase {
   }
   virtual void handle(Float*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Float.");
-  }
-  virtual void handle(Half*) {
-    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Half.");
   }
   virtual void handle(Int*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for Int.");
@@ -291,7 +282,6 @@ class TORCH_CUDA_API OptOutMutator : public PolymorphicBase {
   virtual Statement* mutate(Bool*);
   virtual Statement* mutate(Double*);
   virtual Statement* mutate(Float*);
-  virtual Statement* mutate(Half*);
   virtual Statement* mutate(Int*);
   virtual Statement* mutate(NamedScalar*);
 

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -63,6 +63,9 @@ void KernelArgumentHolder::push(const IValue& val) {
     case c10::ScalarType::Long:
       arguments_.push_back(std::make_unique<LongArg>(scalar_val.toLong()));
       return;
+    case c10::ScalarType::Bool:
+      arguments_.push_back(std::make_unique<BoolArg>(scalar_val.toBool()));
+      return;
     default:
       TORCH_INTERNAL_ASSERT(
           false,

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -61,7 +61,7 @@ void KernelArgumentHolder::push(const IValue& val) {
       arguments_.push_back(std::make_unique<DoubleArg>(scalar_val.toDouble()));
       return;
     case c10::ScalarType::Long:
-      arguments_.push_back(std::make_unique<LongArg>(scalar_val.toInt()));
+      arguments_.push_back(std::make_unique<LongArg>(scalar_val.toLong()));
       return;
     default:
       TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
@@ -56,7 +56,7 @@ struct ArgAbstract {
 // Explicitly for philox seed, not a supported type by any other mechanism
 struct ULongArg : public ArgAbstract {
   uint64_t val_;
-  ULongArg(uint64_t _val) : val_(_val){};
+  explicit ULongArg(uint64_t _val) : val_(_val){};
   void* arg() {
     return &val_;
   }
@@ -64,7 +64,7 @@ struct ULongArg : public ArgAbstract {
 
 struct LongArg : public ArgAbstract {
   int64_t val_;
-  LongArg(int64_t _val) : val_(_val){};
+  explicit LongArg(int64_t _val) : val_(_val){};
   void* arg() {
     return &val_;
   }
@@ -72,7 +72,15 @@ struct LongArg : public ArgAbstract {
 
 struct DoubleArg : public ArgAbstract {
   double val_;
-  DoubleArg(double _val) : val_(_val){};
+  explicit DoubleArg(double _val) : val_(_val){};
+  void* arg() {
+    return &val_;
+  }
+};
+
+struct BoolArg : public ArgAbstract {
+  bool val_;
+  explicit BoolArg(bool _val) : val_(_val){};
   void* arg() {
     return &val_;
   }

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -15,7 +15,7 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-static thread_local Fusion* ACTIVE_FUSION = nullptr;
+static thread_local Fusion* ACTIVE_FUSION = nullptr; // NOLINT
 
 FusionGuard::FusionGuard(Fusion* fusion) {
   prev_fusion = ACTIVE_FUSION;

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -73,10 +73,6 @@ class ConstCheck : OptOutConstDispatch {
     is_const_ = is_const_ && d->isConst();
   }
 
-  void handle(const Float* f) override {
-    is_const_ = is_const_ && f->isConst();
-  }
-
   void handle(const Int* i) override {
     is_const_ = is_const_ && i->isConst();
   }

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.cpp
@@ -77,10 +77,6 @@ class ConstCheck : OptOutConstDispatch {
     is_const_ = is_const_ && f->isConst();
   }
 
-  void handle(const Half* h) override {
-    is_const_ = is_const_ && h->isConst();
-  }
-
   void handle(const Int* i) override {
     is_const_ = is_const_ && i->isConst();
   }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
@@ -70,10 +70,6 @@ void IrCloner::handle(const Double* d) {
   clone_ = new Double(d, this);
 }
 
-void IrCloner::handle(const Float* f) {
-  clone_ = new Float(f, this);
-}
-
 void IrCloner::handle(const Int* i) {
   clone_ = new Int(i, this);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.cpp
@@ -74,10 +74,6 @@ void IrCloner::handle(const Float* f) {
   clone_ = new Float(f, this);
 }
 
-void IrCloner::handle(const Half* h) {
-  clone_ = new Half(h, this);
-}
-
 void IrCloner::handle(const Int* i) {
   clone_ = new Int(i, this);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -55,7 +55,6 @@ class TORCH_CUDA_API IrCloner : private OptInConstDispatch {
   void handle(const Bool*) override;
   void handle(const Double*) override;
   void handle(const Float*) override;
-  void handle(const Half*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -54,7 +54,6 @@ class TORCH_CUDA_API IrCloner : private OptInConstDispatch {
 
   void handle(const Bool*) override;
   void handle(const Double*) override;
-  void handle(const Float*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -53,17 +53,6 @@ class IrNodeLabel : private OptInConstDispatch {
     }
   }
 
-  void handle(const Float* f) override {
-    if (f->isSymbolic()) {
-      label_ << "f" << f->name();
-    } else {
-      if (detail_level_ >= DetailLevel::Explicit) {
-        label_ << "f" << f->name() << "=";
-      }
-      label_ << std::fixed << std::setprecision(2) << *f->value();
-    }
-  }
-
   void handle(const Int* i) override {
     if (i->isSymbolic()) {
       label_ << "i" << i->name();
@@ -339,10 +328,6 @@ void IrGraphGenerator::handle(const Bool* b) {
 
 void IrGraphGenerator::handle(const Double* d) {
   printValue(d, IrNodeLabel::gen(d, detail_level_));
-}
-
-void IrGraphGenerator::handle(const Float* f) {
-  printValue(f, IrNodeLabel::gen(f, detail_level_));
 }
 
 void IrGraphGenerator::handle(const Int* i) {

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -64,17 +64,6 @@ class IrNodeLabel : private OptInConstDispatch {
     }
   }
 
-  void handle(const Half* h) override {
-    if (h->isSymbolic()) {
-      label_ << "h" << h->name();
-    } else {
-      if (detail_level_ >= DetailLevel::Explicit) {
-        label_ << "h" << h->name() << "=";
-      }
-      label_ << *h->value();
-    }
-  }
-
   void handle(const Int* i) override {
     if (i->isSymbolic()) {
       label_ << "i" << i->name();
@@ -354,10 +343,6 @@ void IrGraphGenerator::handle(const Double* d) {
 
 void IrGraphGenerator::handle(const Float* f) {
   printValue(f, IrNodeLabel::gen(f, detail_level_));
-}
-
-void IrGraphGenerator::handle(const Half* h) {
-  printValue(h, IrNodeLabel::gen(h, detail_level_));
 }
 
 void IrGraphGenerator::handle(const Int* i) {

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -69,7 +69,6 @@ class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
 
   void handle(const Bool*) override;
   void handle(const Double*) override;
-  void handle(const Float*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.h
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.h
@@ -70,7 +70,6 @@ class TORCH_CUDA_API IrGraphGenerator : private OptInConstDispatch {
   void handle(const Bool*) override;
   void handle(const Double*) override;
   void handle(const Float*) override;
-  void handle(const Half*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -107,34 +107,6 @@ class TORCH_CUDA_API Float : public Val {
   const c10::optional<ScalarType> maybe_value_;
 };
 
-//! An IEEE 754 Float16 value.
-//! This value can be a symbolic value (defined after the kernel
-//! is compiled) or a constant value (inlined into the kernel definition).
-class TORCH_CUDA_API Half : public Val {
- public:
-  Half() : Val(ValType::Scalar, DataType::Half), maybe_value_{c10::nullopt} {}
-
-  explicit Half(float value)
-      : Val(ValType::Scalar, DataType::Half), maybe_value_{value} {}
-
-  Half(const Half* src, IrCloner* ir_cloner);
-
-  bool isSymbolic() const {
-    return !(maybe_value_.has_value());
-  }
-  bool isConst() const {
-    return maybe_value_.has_value();
-  }
-  c10::optional<float> value() const {
-    return maybe_value_;
-  }
-
-  bool sameAs(const Half* const other) const;
-
- private:
-  const c10::optional<float> maybe_value_;
-};
-
 //! An Int64 value. If used for indexing it's set as size_t. Otherwise it's an
 //! inlined literal in the kernel.
 class TORCH_CUDA_API Int : public Val {

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -77,36 +77,6 @@ class TORCH_CUDA_API Double : public Val {
   const c10::optional<ScalarType> maybe_value_;
 };
 
-//! A Float32 value. For now we don't have any other type besides
-//! Float32. This value can be a symbolic value (defined after the kernel
-//! is compiled) or a constant value (inlined into the kernel definition).
-class TORCH_CUDA_API Float : public Val {
- public:
-  using ScalarType = double;
-
-  Float() : Val(ValType::Scalar, DataType::Float), maybe_value_{c10::nullopt} {}
-
-  explicit Float(ScalarType value)
-      : Val(ValType::Scalar, DataType::Float), maybe_value_{value} {}
-
-  Float(const Float* src, IrCloner* ir_cloner);
-
-  bool isSymbolic() const {
-    return !(maybe_value_.has_value());
-  }
-  bool isConst() const {
-    return maybe_value_.has_value();
-  }
-  c10::optional<ScalarType> value() const {
-    return maybe_value_;
-  }
-
-  bool sameAs(const Float* const other) const;
-
- private:
-  const c10::optional<ScalarType> maybe_value_;
-};
-
 //! An Int64 value. If used for indexing it's set as size_t. Otherwise it's an
 //! inlined literal in the kernel.
 class TORCH_CUDA_API Int : public Val {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -139,21 +139,6 @@ void IrPrinter::handle(const Float* f) {
   }
 }
 
-void IrPrinter::handle(const Half* h) {
-  if (print_inline_ && FusionGuard::getCurFusion()->origin(h) != nullptr) {
-    os_ << "( ";
-    handle(FusionGuard::getCurFusion()->origin(h));
-    os_ << " )";
-    return;
-  }
-
-  if (h->isSymbolic()) {
-    os_ << "h" << h->name();
-  } else {
-    os_ << "__float2half(" << *(h->value()) << ")";
-  }
-}
-
 void IrPrinter::handle(const Int* i) {
   if (print_inline_) {
     if (auto def = FusionGuard::getCurFusion()->origin(i)) {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -121,24 +121,6 @@ void IrPrinter::handle(const Double* d) {
   }
 }
 
-void IrPrinter::handle(const Float* f) {
-  if (print_inline_ && FusionGuard::getCurFusion()->origin(f) != nullptr) {
-    os_ << "( ";
-    handle(FusionGuard::getCurFusion()->origin(f));
-    os_ << " )";
-    return;
-  }
-
-  if (f->isSymbolic()) {
-    os_ << "f" << f->name();
-  } else {
-    os_ << "float("
-        << std::setprecision(
-               std::numeric_limits<Float::ScalarType>::max_digits10)
-        << *(f->value()) << ")";
-  }
-}
-
 void IrPrinter::handle(const Int* i) {
   if (print_inline_) {
     if (auto def = FusionGuard::getCurFusion()->origin(i)) {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -58,7 +58,6 @@ class TORCH_CUDA_API IrPrinter : public OptInConstDispatch {
 
   void handle(const Bool*) override;
   void handle(const Double*) override;
-  void handle(const Float*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -59,7 +59,6 @@ class TORCH_CUDA_API IrPrinter : public OptInConstDispatch {
   void handle(const Bool*) override;
   void handle(const Double*) override;
   void handle(const Float*) override;
-  void handle(const Half*) override;
   void handle(const Int*) override;
   void handle(const NamedScalar*) override;
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -47,10 +47,6 @@ class ScalarCheck : OptInConstDispatch {
     same_ = v1_->as<Float>()->sameAs(v2_->as<Float>());
   }
 
-  void handle(const Half* h) override {
-    same_ = v1_->as<Half>()->sameAs(v2_->as<Half>());
-  }
-
   void handle(const Int* i) override {
     same_ = v1_->as<Int>()->sameAs(v2_->as<Int>());
   }
@@ -97,15 +93,6 @@ Float::Float(const Float* src, IrCloner* ir_cloner)
     : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
 
 bool Float::sameAs(const Float* const other) const {
-  if (isConst() && other->isConst())
-    return *value() == *(other->value());
-  return this == other;
-}
-
-Half::Half(const Half* src, IrCloner* ir_cloner)
-    : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
-
-bool Half::sameAs(const Half* const other) const {
   if (isConst() && other->isConst())
     return *value() == *(other->value());
   return this == other;

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -520,6 +520,8 @@ TensorDomain::TensorDomain(
       " but needed one of size ",
       root_domain_.size());
 
+  // Just due to clang-tidy, correct value set in resetDomains
+  has_reduction_ = false;
   domain_ = root_domain_;
   resetDomains();
 }
@@ -556,8 +558,9 @@ TensorDomain::TensorDomain(
         " is an input of domain, but it is not found in the root domain.");
   });
 
+  // Just due to clang-tidy, correct value set in resetDomains
+  has_reduction_ = false;
   resetDomains();
-
   name_ = fusion_->registerVal(this);
 }
 
@@ -605,6 +608,8 @@ TensorDomain::TensorDomain(
         " is an input of the rfactor domain, but it is not found in the root domain.");
   });
 
+  // Just due to clang-tidy, correct value set in resetDomains
+  has_reduction_ = false;
   resetDomains();
   name_ = fusion_->registerVal(this);
 }

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -43,10 +43,6 @@ class ScalarCheck : OptInConstDispatch {
     same_ = v1_->as<Double>()->sameAs(v2_->as<Double>());
   }
 
-  void handle(const Float* f) override {
-    same_ = v1_->as<Float>()->sameAs(v2_->as<Float>());
-  }
-
   void handle(const Int* i) override {
     same_ = v1_->as<Int>()->sameAs(v2_->as<Int>());
   }
@@ -84,15 +80,6 @@ Double::Double(const Double* src, IrCloner* ir_cloner)
     : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
 
 bool Double::sameAs(const Double* const other) const {
-  if (isConst() && other->isConst())
-    return *value() == *(other->value());
-  return this == other;
-}
-
-Float::Float(const Float* src, IrCloner* ir_cloner)
-    : Val(src, ir_cloner), maybe_value_(src->maybe_value_) {}
-
-bool Float::sameAs(const Float* const other) const {
   if (isConst() && other->isConst())
     return *value() == *(other->value());
   return this == other;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -35,7 +35,6 @@ class Expr;
 class NamedScalar;
 class Bool;
 class Double;
-class Float;
 class Int;
 class IterDomain;
 class TensorDomain;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -36,7 +36,6 @@ class NamedScalar;
 class Bool;
 class Double;
 class Float;
-class Half;
 class Int;
 class IterDomain;
 class TensorDomain;
@@ -95,9 +94,6 @@ class TORCH_CUDA_API IrVisitor : public PolymorphicBase {
     unhandled(value);
   }
   virtual void visit(const Float* value) {
-    unhandled(value);
-  }
-  virtual void visit(const Half* value) {
     unhandled(value);
   }
   virtual void visit(const Int* value) {
@@ -415,36 +411,6 @@ class TORCH_CUDA_API Float final : public Val {
 
  private:
   const c10::optional<ScalarType> maybe_value_;
-};
-
-class TORCH_CUDA_API Half final : public Val {
- public:
-  explicit Half(Passkey passkey, const c10::optional<float>& value)
-      : Val(passkey, DataType::Half), maybe_value_(value) {}
-
-  explicit Half(Passkey passkey, const fuser::cuda::Half* node)
-      : Val(passkey, DataType::Half), maybe_value_(node->value()) {
-    setName(node->name());
-  }
-
-  void accept(IrVisitor* visitor) const override {
-    visitor->visit(this);
-  }
-
-  bool isScalar() const override {
-    return true;
-  }
-
-  bool isConst() const override {
-    return maybe_value_.has_value();
-  }
-
-  c10::optional<float> value() const {
-    return maybe_value_;
-  }
-
- private:
-  const c10::optional<float> maybe_value_;
 };
 
 class TORCH_CUDA_API Int final : public Val {

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -93,9 +93,6 @@ class TORCH_CUDA_API IrVisitor : public PolymorphicBase {
   virtual void visit(const Double* value) {
     unhandled(value);
   }
-  virtual void visit(const Float* value) {
-    unhandled(value);
-  }
   virtual void visit(const Int* value) {
     unhandled(value);
   }
@@ -358,38 +355,6 @@ class TORCH_CUDA_API Double final : public Val {
 
   explicit Double(Passkey passkey, const fuser::cuda::Double* node)
       : Val(passkey, DataType::Double), maybe_value_(node->value()) {
-    setName(node->name());
-  }
-
-  void accept(IrVisitor* visitor) const override {
-    visitor->visit(this);
-  }
-
-  bool isScalar() const override {
-    return true;
-  }
-
-  bool isConst() const override {
-    return maybe_value_.has_value();
-  }
-
-  c10::optional<ScalarType> value() const {
-    return maybe_value_;
-  }
-
- private:
-  const c10::optional<ScalarType> maybe_value_;
-};
-
-class TORCH_CUDA_API Float final : public Val {
- public:
-  using ScalarType = double;
-
-  explicit Float(Passkey passkey, const c10::optional<ScalarType>& value)
-      : Val(passkey, DataType::Float), maybe_value_(value) {}
-
-  explicit Float(Passkey passkey, const fuser::cuda::Float* node)
-      : Val(passkey, DataType::Float), maybe_value_(node->value()) {
     setName(node->name());
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
@@ -14,8 +14,6 @@ Val* IrBuilder::newResult(DataType dtype) {
       return create<Double>(c10::nullopt);
     case DataType::Float:
       return create<Float>(c10::nullopt);
-    case DataType::Half:
-      return create<Half>(c10::nullopt);
     case DataType::Int:
       return create<Int>(c10::nullopt);
     default:

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
@@ -12,8 +12,6 @@ Val* IrBuilder::newResult(DataType dtype) {
       return create<Bool>(c10::nullopt);
     case DataType::Double:
       return create<Double>(c10::nullopt);
-    case DataType::Float:
-      return create<Float>(c10::nullopt);
     case DataType::Int:
       return create<Int>(c10::nullopt);
     default:

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -177,14 +177,6 @@ void IrPrinter::visit(const kir::Float* node) {
   }
 }
 
-void IrPrinter::visit(const kir::Half* node) {
-  if (node->isConst()) {
-    ir_str_ << "half(" << *node->value() << ")";
-  } else {
-    ir_str_ << varName(node, "h");
-  }
-}
-
 void IrPrinter::visit(const kir::Int* node) {
   if (node->isConst()) {
     ir_str_ << *node->value();

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -168,15 +168,6 @@ void IrPrinter::visit(const kir::Double* node) {
   }
 }
 
-void IrPrinter::visit(const kir::Float* node) {
-  if (node->isConst()) {
-    const int digits = std::numeric_limits<Float::ScalarType>::max_digits10;
-    ir_str_ << "float(" << std::setprecision(digits) << *node->value() << ")";
-  } else {
-    ir_str_ << varName(node, "f");
-  }
-}
-
 void IrPrinter::visit(const kir::Int* node) {
   if (node->isConst()) {
     ir_str_ << *node->value();

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
@@ -55,7 +55,6 @@ class TORCH_CUDA_API IrPrinter : private kir::IrVisitor {
   void visit(const kir::Bool*) final;
   void visit(const kir::Double*) final;
   void visit(const kir::Float*) final;
-  void visit(const kir::Half*) final;
   void visit(const kir::Int*) final;
   void visit(const kir::NamedScalar*) final;
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.h
@@ -54,7 +54,6 @@ class TORCH_CUDA_API IrPrinter : private kir::IrVisitor {
 
   void visit(const kir::Bool*) final;
   void visit(const kir::Double*) final;
-  void visit(const kir::Float*) final;
   void visit(const kir::Int*) final;
   void visit(const kir::NamedScalar*) final;
 

--- a/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
@@ -170,7 +170,7 @@ __device__ constexpr int alignBufferSize(const int buffer, const int size) {
 __device__ double clamp(const double x, const double minv, const double maxv) {
   return x < minv ? minv : (x > maxv ? maxv : x);
 }
-__device__ float clamp(const float x, const float minv, const float maxv) {
+__device__ float clamp(const float x, const double minv, const double maxv) {
   return x < minv ? minv : (x > maxv ? maxv : x);
 }
 __device__ double frac(const double x) {
@@ -216,7 +216,7 @@ __device__ float sigmoid(const float x) {
 __device__ double threshold(const double x, const double t, const double v) {
   return x <= t ? v : x;
 }
-__device__ float threshold(const float x, const float t, const float v) {
+__device__ float threshold(const float x, const double t, const double v) {
   return x <= t ? v : x;
 }
 __device__ double where(const bool c, const double a, const double b) {

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -224,11 +224,6 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
   }
 
-  void handle(const Float* node) final {
-    const auto lowered_node = ir_builder_.create<kir::Float>(node);
-    TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
-  }
-
   void handle(const Int* node) final {
     const auto lowered_node = ir_builder_.create<kir::Int>(node, false);
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -229,11 +229,6 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
   }
 
-  void handle(const Half* node) final {
-    const auto lowered_node = ir_builder_.create<kir::Half>(node);
-    TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);
-  }
-
   void handle(const Int* node) final {
     const auto lowered_node = ir_builder_.create<kir::Int>(node, false);
     TORCH_CHECK(gpu_lower_->kir_val_map_.insert({node, lowered_node}).second);

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -17,7 +17,7 @@ namespace fuser {
 namespace cuda {
 
 // TODO(kir): revisit this
-thread_local GpuLower* active_gpu_lower = nullptr;
+thread_local GpuLower* active_gpu_lower = nullptr; // NOLINT
 
 void GpuLower::replaceSymbolicSizes() {
   FUSER_PERF_SCOPE("replaceSymbolicSizes");
@@ -54,14 +54,12 @@ void GpuLower::replaceSymbolicSizes() {
       const Val* orig_size = id->extent();
 
       // Output sizes could have reduction axes, which isn't what gets output.
-      if (id->isReduction()) {
+      if (id->isReduction() ||
+          (id->getIterType() == IterType::BroadcastWithoutStride)) {
         continue;
-      } else if (id->getIterType() == IterType::BroadcastWithoutStride) {
-        continue;
-      } else if (id->getIterType() == IterType::BroadcastWithStride) {
-        dim++;
-        continue;
-      } else if (orig_size->isConstScalar()) {
+      } else if (
+          (id->getIterType() == IterType::BroadcastWithStride) ||
+          orig_size->isConstScalar()) {
         dim++;
         continue;
       }

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -91,10 +91,6 @@ Statement* OptOutMutator::mutate(Double* d) {
   return d;
 }
 
-Statement* OptOutMutator::mutate(Float* f) {
-  return f;
-}
-
 Statement* OptOutMutator::mutate(Int* i) {
   return i;
 }

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -95,10 +95,6 @@ Statement* OptOutMutator::mutate(Float* f) {
   return f;
 }
 
-Statement* OptOutMutator::mutate(Half* h) {
-  return h;
-}
-
 Statement* OptOutMutator::mutate(Int* i) {
   return i;
 }

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -402,10 +402,10 @@ class IrParser {
             // TODO: we need to get a proper lower bound per dtype in operand.
             auto low = value_map.count(node->inputs()[1]->unique()) != 0
                 ? value_map[node->inputs()[1]->unique()]
-                : new Float(std::numeric_limits<float>::min());
+                : new Double(std::numeric_limits<float>::min());
             auto high = value_map.count(node->inputs()[2]->unique()) != 0
                 ? value_map[node->inputs()[2]->unique()]
-                : new Float(std::numeric_limits<float>::max());
+                : new Double(std::numeric_limits<float>::max());
 
             auto out = clamp(operand, low, high);
             value_map.emplace(node->output()->unique(), out);
@@ -543,9 +543,9 @@ class IrParser {
             auto x_sum_bcast = broadcast(x_sum, broadcast_mask);
             auto x_mean = div(x_sum_bcast, num_features);
 
-            // auto current_mean_hat = mul(x_mean, new Float(kMomentum));
+            // auto current_mean_hat = mul(x_mean, new Double(kMomentum));
             // auto rmean_bcast = broadcast(running_mean, broadcast_mask);
-            // auto mean_hat = mul(rmean_bcast, new Float(1.0 - kMomentum));
+            // auto mean_hat = mul(rmean_bcast, new Double(1.0 - kMomentum));
             // auto new_mean_hat = add(mean_hat, current_mean_hat);
 
             auto x_mean_sub = sub(input, x_mean);
@@ -556,12 +556,12 @@ class IrParser {
 
             // auto num_feature_decrement = sub(num_features, new Int(1));
             // auto unbiased_var = div(var_sum_bcast, num_feature_decrement);
-            // auto current_var_hat = mul(unbiased_var, new Float(kMomentum));
+            // auto current_var_hat = mul(unbiased_var, new Double(kMomentum));
             // auto rvar_bcast = broadcast(running_var, broadcast_mask);
-            // auto var_hat = mul(rvar_bcast, new Float(1.0 - kMomentum));
+            // auto var_hat = mul(rvar_bcast, new Double(1.0 - kMomentum));
             // auto new_var_hat = add(var_hat, current_var_hat);
 
-            auto var_eps = add(var, new Float(kEps));
+            auto var_eps = add(var, new Double(kEps));
             auto rvar = unaryOp(UnaryOpType::Rsqrt, var_eps);
             auto output = mul(x_mean_sub, rvar);
 
@@ -635,7 +635,7 @@ class IrParser {
             auto var_sum = sum(x_mean_sub_pow, reduction_axes);
             auto var_sum_bcast = broadcast(var_sum, broadcast_mask);
             auto var = div(var_sum_bcast, num_features);
-            auto var_eps = add(var, new Float(kEps));
+            auto var_eps = add(var, new Double(kEps));
             auto rvar = unaryOp(UnaryOpType::Rsqrt, var_eps);
             auto output = mul(x_mean_sub, rvar);
 
@@ -800,17 +800,17 @@ class IrParser {
   bool registerScalar(const JitValue* val) {
     if (val->type()->isSubtypeOf(static_cast<c10::TypePtr>(FloatType::get()))) {
       CgValue cg_val;
-      if (auto ival = constant_as<float>(val)) {
-        cg_val = new Float(ival.value());
+      if (auto ival = constant_as<double>(val)) {
+        cg_val = new Double(ival.value());
       } else {
-        cg_val = new Float();
+        cg_val = new Double();
       }
       value_map_.emplace(val->unique(), cg_val);
       return true;
     } else if (val->type()->isSubtypeOf(
                    static_cast<c10::TypePtr>(IntType::get()))) {
       CgValue cg_val;
-      if (auto ival = constant_as<int>(val)) {
+      if (auto ival = constant_as<int64_t>(val)) {
         cg_val = new Int(ival.value());
       } else {
         cg_val = new Int();

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -13,9 +13,7 @@ bool isFloatingPointType(DataType dtype) {
     case DataType::Bool:
       return false;
     case DataType::Double:
-      return true;
     case DataType::Float:
-      return true;
     case DataType::Half:
       return true;
     case DataType::Int:


### PR DESCRIPTION
Right now we have multiple floating point scalar types. However, this doesn't really match with the JIT IValue's which can only hold 3 types of scalar values, bool, float64 and int64. Therefore this PR removes Half and Float scalar types in favor of Double.

In the future if we find it helpful we could specialize Scalar on all types that we support, however, since we are focused on fusing operations on Tensors, we don't need to duplicate a scalar promotion logic as Tensors dominate type promotion.