### PR TITLE
Manual multi kernel

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9855,6 +9855,83 @@ TEST(NVFuserTest, FusionLoopUnswitch_CUDA) {
       &fusion, outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
+TEST(NVFuserTest, FusionManualMultiKernel_CUDA) {
+  constexpr int bid_x = 80;
+  constexpr int tid_x = 4096;
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = sum(tv0, {0});
+
+  TensorView* tv2 = add(tv1, tv0); // implicit bcast
+
+  TensorView* tv3 = sum(tv2, {1});
+
+  fusion.addOutput(tv3);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  at::Tensor aten_input = at::randn({bid_x, tid_x}, options);
+  auto aten_output =
+      aten_input.to(at::kDouble).sum({0}).add(aten_input).sum({1});
+
+  // Setup and run first fusion
+
+  Fusion fusion0;
+  auto clone0 = Fusion::copy(&fusion, &fusion0);
+
+  fusion0.removeOutput(clone0.clone(tv3));
+  fusion0.addOutput(clone0.clone(tv1));
+
+  // Apply reduction heuristic
+  auto reduction_params0 =
+      getReductionHeuristics(&fusion0, {aten_input}, clone0.clone(tv1));
+  TORCH_CHECK(reduction_params0, "Reduction schedule was not generated!");
+  scheduleReduction(&fusion0, reduction_params0.value(), clone0.clone(tv1), {});
+
+  auto lparams0 = reduction_params0.value().lparams;
+
+  FusionExecutor fe0;
+  fe0.compileFusion(&fusion0);
+  auto cg_tv1 = fe0.runFusion({aten_input}, lparams0)[0];
+
+  // Setup and run second fusion
+
+  Fusion fusion1;
+  auto clone1 = Fusion::copy(&fusion, &fusion1);
+  fusion1.addInput(clone1.clone(tv1));
+
+  // Apply reduction heuristic
+  auto reduction_params1 =
+      getReductionHeuristics(&fusion1, {aten_input, cg_tv1}, clone1.clone(tv3));
+
+  TORCH_CHECK(reduction_params1, "Reduction schedule was not generated!");
+  scheduleReduction(&fusion1, reduction_params1.value(), clone1.clone(tv3), {});
+
+  auto lparams = reduction_params1.value().lparams;
+
+  FusionExecutor fe1;
+  fe1.compileFusion(&fusion1);
+  // no broadcasting needed, omitting the last optional argument;
+  auto cg_outputs = fe1.runFusion({aten_input, cg_tv1}, lparams0);
+
+  testValidate(
+      &fusion,
+      cg_outputs,
+      {aten_input},
+      {aten_output},
+      __LINE__,
+      __FILE__,
+      "",
+      lparams);
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -69,6 +69,7 @@ Fusion::Fusion(const Fusion& other) {
 }
 
 IrCloner Fusion::copy(const Fusion* from, Fusion* to) {
+  to->clear();
   IrCloner ir_cloner(to);
 
   for (auto val : from->val_set_) {
@@ -498,8 +499,6 @@ bool Fusion::hasReduction() {
 
 std::vector<Val*> Fusion::getTerminatingOutputs() {
   FUSER_PERF_SCOPE("getTerminatingOutputs");
-
-  FusionGuard fg(this);
 
   std::unordered_set<Val*> used_vals;
 

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -86,6 +86,12 @@ class TORCH_CUDA_API Fusion final {
 
   void clear() noexcept;
 
+  static IrCloner copy(const Fusion* from, Fusion* to);
+
+  // Extract out copy constructor so we can return the cloner used which
+  // contains the ir maps from other to this.
+  IrCloner clone(const Fusion& other);
+
   //! Break dependency chains associated with Expr, remove references to expr
   //! delete expr
   void removeExpr(Expr* expr);


### PR DESCRIPTION
Modify fusion copy so it will return the ir_cloner used. This provides us with the map between the fusions. We use that map to manually take a single fusion and break it up into more than one kernel.
