### PR TITLE
Hotfix for implicit reduction 3.

### DIFF
--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -423,7 +423,7 @@ class TORCH_CUDA_API TensorDomain : public Val {
   void resetDomains() {
     no_reduction_domain_ = noReductions(domain_);
     no_bcast_domain_ = noBroadcasts(domain_);
-    has_reduction_ = hasNontrivialReduction(domain_);
+    has_nontrivial_reduction_ = hasNontrivialReduction(domain_);
   }
 
   // i here is int, as we want to accept negative value and ::size_type can be a
@@ -467,7 +467,7 @@ class TORCH_CUDA_API TensorDomain : public Val {
   std::vector<IterDomain*> no_reduction_domain_;
   const std::vector<IterDomain*> rfactor_domain_;
   const std::vector<bool> contiguity_;
-  bool has_reduction_;
+  bool has_nontrivial_reduction_;
 };
 
 //! Representation a split on an IterDomain by "factor"

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -585,7 +585,7 @@ TensorDomain::TensorDomain(
       root_domain_.size());
 
   // Just due to clang-tidy, correct value set in resetDomains
-  has_reduction_ = false;
+  has_nontrivial_reduction_ = false;
   domain_ = root_domain_;
   resetDomains();
 }
@@ -623,7 +623,7 @@ TensorDomain::TensorDomain(
   });
 
   // Just due to clang-tidy, correct value set in resetDomains
-  has_reduction_ = false;
+  has_nontrivial_reduction_ = false;
   resetDomains();
   name_ = fusion_->registerVal(this);
 }
@@ -673,7 +673,7 @@ TensorDomain::TensorDomain(
   });
 
   // Just due to clang-tidy, correct value set in resetDomains
-  has_reduction_ = false;
+  has_nontrivial_reduction_ = false;
   resetDomains();
   name_ = fusion_->registerVal(this);
 }
@@ -686,7 +686,7 @@ TensorDomain::TensorDomain(const TensorDomain* src, IrCloner* ir_cloner)
       no_reduction_domain_(ir_cloner->clone(src->no_reduction_domain_)),
       rfactor_domain_(ir_cloner->clone(src->rfactor_domain_)),
       contiguity_(src->contiguity()),
-      has_reduction_(src->has_reduction_) {}
+      has_nontrivial_reduction_(src->has_nontrivial_reduction_) {}
 
 bool TensorDomain::operator==(const TensorDomain& other) const {
   // Checks equality of each class field. Should not be necessary to
@@ -753,7 +753,7 @@ bool TensorDomain::sameAs(
 }
 
 bool TensorDomain::hasReduction() const {
-  return has_reduction_;
+  return has_nontrivial_reduction_;
 }
 
 bool TensorDomain::hasBlockReduction() const {

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -274,10 +274,10 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
 FusionExecutorCache::FusionExecutorCache(std::unique_ptr<Fusion>&& fusion)
     : fusion_(std::move(fusion)) {
   FUSER_PERF_SCOPE("FusionExecutorCache::FusionExecutorCache");
-  // avoid putting `has_reduction_` in the initializer list
-  has_reduction_ = fusion_->hasReduction();
+  // avoid putting `has_nontrivial_reduction_` in the initializer list
+  has_nontrivial_reduction_ = fusion_->hasReduction();
 
-  if (has_reduction_) {
+  if (has_nontrivial_reduction_) {
     FusionGuard fg(fusion_.get());
 
     // Use dependency check to find the reduction tv as it returns used values
@@ -323,7 +323,7 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
     // entries in cached `FusionExecutor` or compile new one as needed.
 
     // caching strategy is different for pw-fusion and reduction-fusion.
-    if (has_reduction_) {
+    if (has_nontrivial_reduction_) {
       // Generate the reduction parameters
       auto reduction_params = (reduction_tv_.size() > 1)
           ? getMultipleReductionHeuristics(fusion_.get(), inputs, reduction_tv_)

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -158,15 +158,16 @@ class FusionExecutorCache {
   //! original un-scheduled `Fusion`;
   std::unique_ptr<Fusion> fusion_;
 
-  // I'm trading the const model in favor of assigning `has_reduction_` in the
-  // body of constructor, instead of the initializer list;
-  // Because of the move statement used in the constructor, it's tricky to
-  // maintain the code if we have `has_reduction_` as a const member and
-  // initizlize it in the initializer list, where the order of initialization
-  // is controled by the order of declaration instead of their order in the list
+  // I'm trading the const model in favor of assigning
+  // `has_nontrivial_reduction_` in the body of constructor, instead of the
+  // initializer list; Because of the move statement used in the constructor,
+  // it's tricky to maintain the code if we have `has_nontrivial_reduction_` as
+  // a const member and initizlize it in the initializer list, where the order
+  // of initialization is controled by the order of declaration instead of their
+  // order in the list
   //
   //! cache fusion->hasReduction() because it's expensive;
-  bool has_reduction_ = false;
+  bool has_nontrivial_reduction_ = false;
 
   //! cache reduction_tv_ to avoid searching repetitively at runtime
   std::vector<TensorView*> reduction_tv_;

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -432,7 +432,7 @@ void LoopNestGenerator::handle(const Expr* expr) {
   //  If this is a reduction, initialize the output (open for loops to inner
   //  most, predicate, initialize, place next after allocation if exists, close
   //  to computeAt)
-  if (out->hasAnyReduction()) {
+  if (out->hasReduction()) {
     initReduction(out, expr->as<ReductionOp>()->init(), alloc_expr);
   }
 

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -543,8 +543,18 @@ TORCH_CUDA_API c10::optional<ReductionParams> getReductionHeuristics(
   FusionGuard fg(fusion);
 
   auto red_root_dom = red_tv->getRootDomain();
-  const bool fastest_dim_reduction =
-      red_root_dom[red_root_dom.size() - 1]->isReduction();
+  bool fastest_dim_reduction = true;
+  for (size_t i = red_root_dom.size(); i > 0; i--) {
+    if (red_root_dom[i - 1]->isBroadcast()) {
+      continue;
+    } else if (red_root_dom[i - 1]->isReduction()) {
+      fastest_dim_reduction = true;
+      break;
+    } else {
+      fastest_dim_reduction = false;
+      break;
+    }
+  }
 
   TORCH_INTERNAL_ASSERT(
       red_tv != nullptr, "Reduction TensorView wasn't found.");


### PR DESCRIPTION
Single reduction heuristic was considering a reduction being non-inner if there was broadcast dimensions only inside the broadcast dim. This was causing non-deterministic issues in ImplicitBroadcast3 (poorly named) where we were fusing a trivial reduction onto the end of a grid broadcast, which is generally not supported.

Also convert trivial reduction operations to set which would have avoided the issue of having a "reduction" after a grid reduction anyways.