### PR TITLE
python benchmark infra for jit kernel speed

### DIFF
--- a/test/cuda_fuser_benchmark/benchmark.py
+++ b/test/cuda_fuser_benchmark/benchmark.py
@@ -1,0 +1,140 @@
+import unittest
+import os
+import random
+
+import torch
+
+from torch.testing._internal.common_utils import run_tests, ProfilingMode, GRAPH_EXECUTOR
+from torch.testing._internal.codegen.random_topo_test import runDefaultTestWithSeed
+from torch.testing._internal.jit_utils import JitTestCase, RUN_CUDA
+
+import itertools
+import numpy as np
+import math
+
+os.environ['PYTORCH_NVFUSER_DISABLE_FALLBACK'] = '1'
+os.environ['PYTORCH_NVFUSER_DISABLE_FMA'] = '1'
+os.environ['PYTORCH_NVFUSER_JIT_OPT_LEVEL'] = '0'
+
+if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
+    torch._C._jit_set_texpr_fuser_enabled(False)
+    torch._C._jit_set_profiling_executor(True)
+    torch._C._jit_set_profiling_mode(True)
+
+FUSION_GROUP = 'prim::CudaFusionGroup'
+FUSION_GUARD = 'prim::CudaFusionGuard'
+
+# test suits for generating nvprof log with nvtx marker
+# there is a separate test suit for parsing and comparing result
+class TestBenchmarkNorm(JitTestCase):
+    def setUp(self):
+        super(TestBenchmarkNorm, self).setUp()
+        self.old_cpu_fuse = torch._C._jit_can_fuse_on_cpu()
+        self.old_gpu_fuse = torch._C._jit_can_fuse_on_gpu()
+        torch._C._jit_override_can_fuse_on_cpu(False)
+        torch._C._jit_override_can_fuse_on_gpu(False)
+        self.old_guard = torch._C._jit_set_nvfuser_guard_mode(False)
+
+        if(RUN_CUDA):
+            self.old_nvfuser = torch._C._jit_set_nvfuser_enabled(True)
+
+    def tearDown(self):
+        if(RUN_CUDA):
+            torch._C._jit_set_nvfuser_enabled(self.old_nvfuser)
+        torch._C._jit_override_can_fuse_on_cpu(self.old_cpu_fuse)
+        torch._C._jit_override_can_fuse_on_gpu(self.old_gpu_fuse)
+        torch._C._jit_set_nvfuser_guard_mode(self.old_guard)
+        super(TestBenchmarkNorm, self).tearDown()
+
+    def _benchmark_helper(self, inputs, test_name, layer):
+        # fix to 1000 iteration to get consistent result
+        # parser can make same assumption to generate correct kernel time
+        for i in range(1000):
+            torch.cuda.nvtx.range_push(test_name+'_benchmarknvtx')
+            o = layer(*inputs)
+            torch.cuda.synchronize()
+            torch.cuda.nvtx.range_pop()
+
+    def _softmax_benchmark_helper(self, shape, reduction_axis, dtype, device):
+        class MyLogSoftmax(torch.nn.Module):
+            __constants__ = ['reduction_axis']
+
+            def __init__(self):
+                super(MyLogSoftmax, self).__init__()
+                self.reduction_axis = reduction_axis
+
+            def forward(self, x: torch.Tensor):
+                o = torch.nn.functional.softmax(x, dim=self.reduction_axis)
+                return torch.log(o)
+
+        t = MyLogSoftmax()
+        jit_t = torch.jit.script(t)
+        # for softmax test, we use logsoftmax to get better comparison
+        log_t = torch.nn.LogSoftmax(dim=reduction_axis)
+
+        # create input and run one time to trigger compile
+        x = torch.randn(shape, dtype=dtype, device=device)
+        jit_o = jit_t(x)
+
+        # create name for the test
+        shape_str = ''
+        for s in shape:
+            shape_str += '_' + str(s)
+        test_name = 'softmax' + shape_str + '_' + str(dtype).split(".")[1]
+
+        # run both test with benchmark marker
+        self._benchmark_helper([x], test_name+'_native', log_t)
+        self._benchmark_helper([x], test_name+'_jit', jit_t)
+
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
+                     "Requires fusion optimization pass to be effective")
+    def test_benchmark_softmax(self):
+        for i in [512, 1024, 4096, 50000]:
+            for j in [32, 64, 128, 1024, 2048]:
+                self._softmax_benchmark_helper([i, j], 1, torch.float32, "cuda")
+                self._softmax_benchmark_helper([i, j], 1, torch.float16, "cuda")
+
+    def _batch_norm_benchmark_helper(self, shape, dtype, device):
+        class MyBatchNorm(torch.nn.Module):
+            def __init__(self):
+                super(MyBatchNorm, self).__init__()
+
+            def forward(self, x: torch.Tensor, r_mean: torch.Tensor, r_var: torch.Tensor):
+                o = torch.nn.functional.batch_norm(x, r_mean, r_var, training=True)
+                return torch.log(o)
+
+        t = MyBatchNorm()
+        jit_t = torch.jit.script(t)
+
+        # create input and run one time to trigger compile
+        x = torch.randn(shape, dtype=dtype, device=device)
+        running_mean = torch.randn(shape[1], dtype=torch.float32, device=device)
+        running_var = torch.randn(shape[1], dtype=torch.float32, device=device)
+        jit_o = jit_t(x, running_mean.clone(), running_var.clone())
+
+        eager_running_mean = running_mean.clone()
+        eager_running_var = running_var.clone()
+        jit_running_mean = running_mean.clone()
+        jit_running_var = running_var.clone()
+
+        # create name for the test
+        shape_str = ''
+        for s in shape:
+            shape_str += '_' + str(s)
+        test_name = 'batchnorm' + shape_str + '_' + str(dtype).split(".")[1]
+
+        # run both test with benchmark marker
+        self._benchmark_helper([x, eager_running_mean, eager_running_var], test_name+'_native', t)
+        self._benchmark_helper([x, jit_running_mean, jit_running_var], test_name+'_jit', jit_t)
+
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
+                     "Requires fusion optimization pass to be effective")
+    def test_benchmark_batch_norm(self):
+        self._batch_norm_benchmark_helper([34,128,14,14], torch.float32, "cuda")
+        self._batch_norm_benchmark_helper([34,1024,14,14], torch.float16, "cuda")
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/cuda_fuser_benchmark/nvtx_parser.py
+++ b/test/cuda_fuser_benchmark/nvtx_parser.py
@@ -1,0 +1,30 @@
+def time_to_float(time):
+    m = 1.
+    if 'us' in time:
+        time = float(time[:-2])
+    elif 'ms' in time:
+        time = float(time[:-2])
+        m = 1000.
+    else:
+        time = float(time[:-1])
+        m = 1000000.
+    return m * time
+
+def parse_result(lines, nvtx_mark):
+
+    lines = lines.split('\n')
+
+    result = []
+    # parse result for kernel time
+    for i, line in enumerate(lines):
+        if '==' in line and nvtx_mark in line:
+            # kernel time
+            match = (line.split("\"")[1]).split("_")
+            res = lines[i+3].split()
+            percentage = float(res[2][:-1])/100
+            time = time_to_float(res[3])
+            kernel_time = time / percentage / 1000
+            match[-1] = kernel_time
+            result.append(match)
+
+    return result

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -1299,6 +1299,7 @@ class TestCudaFuser(JitTestCase):
             else:
                 print('Benchmark meeting threshold of {}:'.format(threshold), jit+native[-2:])
 
+    @unittest.skipUnless(int(os.getenv('CUDA_FUSER_BENCHMARK', 0)) == 1, "only run this when explicitly want for now")
     def test_benchmark_all(self):
         self._benchmark_helper('', 1.2)
 
@@ -1348,6 +1349,7 @@ class TestPassManagerCudaFuser(JitTestCase):
         self.assertTrue(torch._C._jit_nvfuser_enabled())
         self.assertTrue(torch._C._jit_set_nvfuser_enabled(False))
         self.assertFalse(torch._C._jit_nvfuser_enabled())
+
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
This PR added a nvprof based kernel benchmark method in python unit test.
With this, user can now easily write python test to compare jit and native kernel speed on various config and sizes.
I'm using it for testing kernel speed without effect of fusion considered, but it is also suitable to test fused kernel speed against multiple native kernel since the parser aggregates kernel time.

```
root@6e328e4ca2b3:/jit_code# CUDA_FUSER_BENCHMARK=1 python pytorch/test/test_jit_cuda_fuser.py TestCudaFuser.test_benchmark_all
Benchmark not meeting threshold of 1.2: ['batchnorm', '34', '1024', '14', '14', 'float16', 'jit', 18777.7, 'native', 112.50377358490564]
Benchmark not meeting threshold of 1.2: ['batchnorm', '34', '128', '14', '14', 'float32', 'jit', 13589.9, 'native', 24.455150665732308]
Benchmark not meeting threshold of 1.2: ['layernorm', '32', '36', '30', '40', 'normshape', '30', '40', 'float16', 'jit', 35.477, 'native', 16.15524034672971]
Benchmark not meeting threshold of 1.2: ['layernorm', '32', '36', '30', '40', 'normshape', '30', '40', 'float32', 'jit', 36.462, 'native', 27.177255047230968]
Benchmark not meeting threshold of 1.2: ['softmax', '256', '128', 'float16', 'jit', 3.7571, 'native', 1.8329]
Benchmark not meeting threshold of 1.2: ['softmax', '256', '128', 'float32', 'jit', 3.2647, 'native', 1.6879]
Benchmark not meeting threshold of 1.2: ['softmax', '256', '2048', 'float16', 'jit', 12.385, 'native', 5.4366]
Benchmark not meeting threshold of 1.2: ['softmax', '256', '2048', 'float32', 'jit', 14.238, 'native', 6.2442]
Benchmark not meeting threshold of 1.2: ['softmax', '256', '32', 'float16', 'jit', 2.5125, 'native', 1.5068]
Benchmark not meeting threshold of 1.2: ['softmax', '256', '32', 'float32', 'jit', 2.4673, 'native', 1.4991]
Benchmark not meeting threshold of 1.2: ['softmax', '50000', '128', 'float16', 'jit', 74.608, 'native', 34.249]
Benchmark not meeting threshold of 1.2: ['softmax', '50000', '128', 'float32', 'jit', 88.535, 'native', 63.643]
Benchmark not meeting threshold of 1.2: ['softmax', '50000', '2048', 'float16', 'jit', 1274.28, 'native', 682.77]
Benchmark meeting threshold of 1.2: ['softmax', '50000', '2048', 'float32', 'jit', 1385.83, 'native', 1294.63]
Benchmark not meeting threshold of 1.2: ['softmax', '50000', '32', 'float16', 'jit', 73.414, 'native', 13.153]
Benchmark not meeting threshold of 1.2: ['softmax', '50000', '32', 'float32', 'jit', 73.492, 'native', 18.238]
Benchmark not meeting threshold of 1.2: ['softmax', '8192', '128', 'float16', 'jit', 17.464, 'native', 5.1998]
Benchmark not meeting threshold of 1.2: ['softmax', '8192', '128', 'float32', 'jit', 19.806, 'native', 11.307]
Benchmark not meeting threshold of 1.2: ['softmax', '8192', '2048', 'float16', 'jit', 207.93, 'native', 109.93]
Benchmark meeting threshold of 1.2: ['softmax', '8192', '2048', 'float32', 'jit', 227.82, 'native', 215.29]
Benchmark not meeting threshold of 1.2: ['softmax', '8192', '32', 'float16', 'jit', 16.066, 'native', 3.7499]
Benchmark not meeting threshold of 1.2: ['softmax', '8192', '32', 'float32', 'jit', 16.015, 'native', 3.7437]
.
----------------------------------------------------------------------
Ran 1 test in 93.368s

OK
```
