### PR TITLE
Extends swizzle

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -11357,6 +11357,73 @@ TEST(NVFuserTest, FusionTransposeWithSwizzle_CUDA) {
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
+TEST(NVFuserTest, FusionTransposeWithSwizzle1DThreadBlock_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  auto tv1 = transpose(tv0, {{0, 1}});
+  fusion.addOutput(tv1);
+
+  // tv0: [I0, I1]
+  // tv1: [I1, I0]
+
+  const int BS = 32;
+  const int BDIM = 256;
+
+  // CTA tiling by BS*BS
+  tv1->split(1, BS);
+  tv1->split(0, BS);
+  tv1->reorder({{1, 2}});
+  // tv1: [I1/BS, I0/BS, BS(I1), BS(I0)]
+
+  // Create a smem buffer to cache each tile
+  auto tv0_cache = tv0->cache_after();
+  tv0_cache->setMemoryType(MemoryType::Shared);
+
+  tv0->computeAt(tv1, 2);
+  // tv0: [I0, I1]
+  // tv0_cache: [I1/BS, I0/BS, BS*BS/BDIM, BDIM]
+  // tv1: [I1/BS, I0/BS, BS*BS/BDIM, BDIM]
+
+  // Tranform the tile axes for 1D thread mapping
+  tv1->merge(-2, -1);
+  tv1->split(-1, BDIM);
+  // tv1: [I1/BS, I0/BS, BS*BS/BDIM, BDIM]
+
+  // Transform the cache similarly but apply swizzle to the 2D tile axes.
+  tv0_cache->reorder({{-2, -1}});
+  tv0_cache->swizzle(SwizzleType::Transpose, {2, 3});
+  tv0_cache->merge(-2, -1);
+  tv0_cache->split(-1, BDIM);
+  // tv0: [I1/BS, I0/BS, BS*BS/BDIM, BDIM]
+
+  // Assign each thread block to a tile
+  tv1->axis(0)->parallelize(ParallelType::BIDy);
+  tv1->axis(1)->parallelize(ParallelType::BIDx);
+
+  // Thread mapping for each tile.
+  tv1->axis(-1)->parallelize(ParallelType::TIDx);
+  tv0_cache->axis(-1)->parallelize(ParallelType::TIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  const int bx = 100;
+  const int by = 200;
+  at::Tensor t0 = at::randn({bx, by}, options);
+  std::vector<IValue> aten_inputs = {t0};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  auto aten_output = t0.t();
+
+  testValidate(
+      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -573,7 +573,7 @@ class UpdateLeafIndices : public IterVisitor {
     index_map_[inner_id] = ir_builder.modExpr(index_map_[in_id], factor);
     extent_map_[inner_id] = factor;
     index_map_[outer_id] = ir_builder.divExpr(index_map_[in_id], factor);
-    extent_map_[inner_id] = ir_builder.ceilDivExpr(getExtent(in_id), factor);
+    extent_map_[outer_id] = ir_builder.ceilDivExpr(getExtent(in_id), factor);
   }
 
   void handle(Merge* merge) override {

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -629,9 +629,9 @@ IndexSwizzle::IndexSwizzle(
     std::unordered_set<kir::IterDomain*> zero_merged_in)
     : IndexCompute(
           tv->domain(),
-          initial_index_map,
-          extent_map,
-          zero_merged_in,
+          std::move(initial_index_map),
+          std::move(extent_map),
+          std::move(zero_merged_in),
           std::vector<bool>(tv->getRootDomain().size(), false)),
       tv_(tv),
       swizzle_type_(tv->swizzleType()),

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -399,7 +399,9 @@ IndexCompute::IndexCompute(
       }
     }
   }
+}
 
+void IndexCompute::run() {
   const std::vector<Val*> domain_vals(
       td_->domain().begin(), td_->domain().end());
 
@@ -455,12 +457,14 @@ IndexCompute IndexCompute::updateIndexCompute(
     }
   }
 
-  return IndexCompute(
+  IndexCompute updated_index_compute(
       new_td,
       updated_index_map,
       updated_extent_map,
       updated_zero_merged_in,
       root_contiguity);
+  updated_index_compute.run();
+  return updated_index_compute;
 }
 
 std::vector<bool> IndexCompute::contiguityAnd(
@@ -519,31 +523,6 @@ std::vector<bool> IndexCompute::contiguityPasC(
 }
 
 namespace {
-
-std::deque<const TensorView*> getComputeAtTVStackFrom(
-    const TensorView* from_tv) {
-  // What's the computeAt root tensor view in this operation
-  // This tensor is the terminating tensor in the computeAT dag from consumer
-  auto end_tv = from_tv->getComputeAtAxis(0).second;
-
-  // grab all tensor views from producer_tv -> computeAtRoot
-  std::deque<const TensorView*> tv_stack;
-
-  // Then immediate consumer
-  auto running_tv = from_tv;
-
-  // Follow computeAt path until we hit end_tv
-  while (running_tv != end_tv) {
-    TORCH_INTERNAL_ASSERT(running_tv->hasComputeAt());
-    tv_stack.push_front(running_tv);
-    running_tv = running_tv->getComputeAtView();
-  }
-
-  tv_stack.push_front(end_tv);
-
-  return tv_stack;
-}
-
 // Map indices down to the leaf domains for applying swizzle
 class UpdateLeafIndices : public IterVisitor {
  public:
@@ -641,51 +620,105 @@ class UpdateLeafIndices : public IterVisitor {
   std::unordered_map<kir::IterDomain*, kir::Val*> extent_map_;
 };
 
-void swizzleIndices(const TensorView* tv, IndexCompute& index_compute) {
+} // namespace
+
+IndexSwizzle::IndexSwizzle(
+    const TensorView* tv,
+    std::unordered_map<kir::IterDomain*, kir::Val*> initial_index_map,
+    std::unordered_map<kir::IterDomain*, kir::Val*> extent_map,
+    std::unordered_set<kir::IterDomain*> zero_merged_in)
+    : IndexCompute(
+          tv->domain(),
+          initial_index_map,
+          extent_map,
+          zero_merged_in,
+          std::vector<bool>(tv->getRootDomain().size(), false)),
+      tv_(tv),
+      swizzle_type_(tv->swizzleType()),
+      ids_to_swizzle_(tv->axesToSwizzle()) {}
+
+void IndexSwizzle::run() {
   TORCH_INTERNAL_ASSERT(
-      tv->swizzleType() == SwizzleType::NoSwizzle ||
-          tv->swizzleType() == SwizzleType::Transpose,
+      swizzle_type_ == SwizzleType::NoSwizzle ||
+          swizzle_type_ == SwizzleType::Transpose,
       "Invalid swizzle type");
-  if (tv->swizzleType() == SwizzleType::Transpose) {
+
+  if (swizzle_type_ == SwizzleType::Transpose) {
     // Shifts the second axis by the first axis as ((idx_1 + idx_2) %
     // ext). Alternatively, ((idx_1 - idx_2) & (ext - 1)) would also
     // work if ext is a power of two. Practically, ext should be 32 if
     // the data type of the tensor is float, so the latter approach
     // should also be fine.
-    TORCH_INTERNAL_ASSERT(tv->getMemoryType() == MemoryType::Shared);
-    TORCH_INTERNAL_ASSERT(tv->axesToSwizzle().size() == 2);
-    UpdateLeafIndices update_leaves(
-        tv->domain(), index_compute.indexMap(), index_compute.extentMap());
-    auto id_to_swizzle_i = GpuLower::current()
-                               ->lowerValue(tv->axesToSwizzle().at(0))
-                               ->as<kir::IterDomain>();
-    auto id_to_swizzle_j = GpuLower::current()
-                               ->lowerValue(tv->axesToSwizzle().at(1))
-                               ->as<kir::IterDomain>();
+    TORCH_INTERNAL_ASSERT(tv_->getMemoryType() == MemoryType::Shared);
+    TORCH_INTERNAL_ASSERT(tv_->axesToSwizzle().size() == 2);
 
-    if (update_leaves.indexMap().find(id_to_swizzle_i) !=
-            update_leaves.indexMap().end() &&
-        update_leaves.indexMap().find(id_to_swizzle_j) !=
-            update_leaves.indexMap().end()) {
-      auto updated_idx_map = update_leaves.indexMap();
-      auto idx_to_swizzle_i = updated_idx_map[id_to_swizzle_i];
-      auto idx_to_swizzle_j = updated_idx_map[id_to_swizzle_j];
+    UpdateLeafIndices update_leaves(td_, indexMap(), extentMap());
+    index_map_ = update_leaves.indexMap();
+    extent_map_ = update_leaves.extentMap();
+
+    IterDomain* id_to_swizzle_i = ids_to_swizzle_.at(0);
+    IterDomain* id_to_swizzle_j = ids_to_swizzle_.at(1);
+    kir::IterDomain* id_to_swizzle_i_kir =
+        GpuLower::current()->lowerValue(id_to_swizzle_i)->as<kir::IterDomain>();
+    kir::IterDomain* id_to_swizzle_j_kir =
+        GpuLower::current()->lowerValue(id_to_swizzle_j)->as<kir::IterDomain>();
+
+    if (indexMap().find(id_to_swizzle_i_kir) != indexMap().end() &&
+        indexMap().find(id_to_swizzle_j_kir) != indexMap().end()) {
+      auto idx_to_swizzle_i = indexMap().at(id_to_swizzle_i_kir);
+      auto idx_to_swizzle_j = indexMap().at(id_to_swizzle_j_kir);
 
       kir::IrBuilder ir_builder(GpuLower::current()->kernel());
       auto swizzled_idx = ir_builder.modExpr(
           ir_builder.addExpr(idx_to_swizzle_i, idx_to_swizzle_j),
-          id_to_swizzle_j->rawExtent());
-      updated_idx_map[id_to_swizzle_j] = swizzled_idx;
-
-      // Update the rest of the axes, including the root.
-      index_compute = IndexCompute(
-          tv->domain(),
-          updated_idx_map,
-          update_leaves.extentMap(),
-          index_compute.zeroMergedIn(),
-          std::vector<bool>(tv->getRootDomain().size(), false));
+          id_to_swizzle_j_kir->rawExtent());
+      index_map_[id_to_swizzle_j_kir] = swizzled_idx;
+      swizzled_ids_.insert(id_to_swizzle_j);
+      IndexCompute::run();
     }
   }
+}
+
+void IndexSwizzle::handle(Expr* e) {
+  auto out_ids = ir_utils::filterByType<IterDomain>(e->outputs());
+  bool needs_update =
+      std::any_of(out_ids.begin(), out_ids.end(), [this](IterDomain* id) {
+        return swizzled_ids_.find(id) != swizzled_ids_.end();
+      });
+  if (!needs_update) {
+    return;
+  }
+
+  IndexCompute::handle(e);
+  for (auto input : ir_utils::filterByType<IterDomain>(e->inputs())) {
+    swizzled_ids_.insert(input);
+  }
+}
+
+namespace {
+
+std::deque<const TensorView*> getComputeAtTVStackFrom(
+    const TensorView* from_tv) {
+  // What's the computeAt root tensor view in this operation
+  // This tensor is the terminating tensor in the computeAT dag from consumer
+  auto end_tv = from_tv->getComputeAtAxis(0).second;
+
+  // grab all tensor views from producer_tv -> computeAtRoot
+  std::deque<const TensorView*> tv_stack;
+
+  // Then immediate consumer
+  auto running_tv = from_tv;
+
+  // Follow computeAt path until we hit end_tv
+  while (running_tv != end_tv) {
+    TORCH_INTERNAL_ASSERT(running_tv->hasComputeAt());
+    tv_stack.push_front(running_tv);
+    running_tv = running_tv->getComputeAtView();
+  }
+
+  tv_stack.push_front(end_tv);
+
+  return tv_stack;
 }
 
 //! Generates index and extent expressions of tensors.
@@ -891,6 +924,7 @@ generateIndexAndExtentMap(
       std::unordered_map<kir::IterDomain*, kir::Val*>(),
       std::unordered_set<kir::IterDomain*>(),
       std::vector<bool>(tv->getRootDomain().size(), false));
+  index_compute.run();
 
   p2c_index_maps[tv] = index_compute.indexMap();
 
@@ -970,6 +1004,7 @@ generateIndexAndExtentMap(
       c2p_tv_stack.empty()
           ? last_tv_root_contiguity
           : std::vector<bool>(tv->getRootDomain().size(), false));
+  index_compute.run();
 
   // Go through the tv entire stack
   while (!c2p_tv_stack.empty()) {
@@ -991,9 +1026,17 @@ generateIndexAndExtentMap(
   }
 
   // PROPAGATE CONSUMER -> PRODUCER END
-
+  std::unordered_map<kir::IterDomain*, kir::Val*> index_map;
   if (swizzle_indices) {
-    swizzleIndices(c2p_tv_stack.back(), index_compute);
+    IndexSwizzle index_swizzle(
+        c2p_tv_stack.back(),
+        index_compute.indexMap(),
+        index_compute.extentMap(),
+        index_compute.zeroMergedIn());
+    index_swizzle.run();
+    index_map = index_swizzle.indexMap();
+  } else {
+    index_map = index_compute.indexMap();
   }
 
   // Fill in extent map as some mapped indices may not have their extent filled
@@ -1001,14 +1044,14 @@ generateIndexAndExtentMap(
 
   std::unordered_map<kir::IterDomain*, kir::Val*> extent_map(
       index_compute.extentMap());
-  for (auto ind_entry : index_compute.indexMap()) {
+  for (auto ind_entry : index_map) {
     auto id = ind_entry.first;
     if (extent_map.find(id) == extent_map.end()) {
       extent_map[id] = id->extent();
     }
   }
 
-  return std::make_pair(index_compute.indexMap(), extent_map);
+  return std::make_pair(index_map, extent_map);
 }
 
 } // namespace

--- a/torch/csrc/jit/codegen/cuda/index_compute.h
+++ b/torch/csrc/jit/codegen/cuda/index_compute.h
@@ -141,7 +141,7 @@ class IndexCompute : public BackwardVisitor {
       const std::vector<bool>& contig2);
 };
 
-//! Updates indices that are affected by swizzling
+//! Apply swizzle and update root indices accordingly
 class IndexSwizzle : public IndexCompute {
  public:
   IndexSwizzle(

--- a/torch/csrc/jit/codegen/cuda/index_compute.h
+++ b/torch/csrc/jit/codegen/cuda/index_compute.h
@@ -60,8 +60,9 @@ namespace fuser {
 namespace cuda {
 
 class IndexCompute : public BackwardVisitor {
- private:
+ protected:
   using BackwardVisitor::handle;
+
   void handle(Split*) override;
   void handle(Merge*) override;
   void handle(Expr*) override;
@@ -98,15 +99,15 @@ class IndexCompute : public BackwardVisitor {
   std::unordered_set<kir::IterDomain*> contig_ids;
 
  public:
-  const std::unordered_map<kir::IterDomain*, kir::Val*> indexMap() const {
+  const std::unordered_map<kir::IterDomain*, kir::Val*>& indexMap() const {
     return index_map_;
   }
 
-  const std::unordered_map<kir::IterDomain*, kir::Val*> extentMap() const {
+  const std::unordered_map<kir::IterDomain*, kir::Val*>& extentMap() const {
     return extent_map_;
   }
 
-  std::unordered_set<kir::IterDomain*> zeroMergedIn() const {
+  const std::unordered_set<kir::IterDomain*>& zeroMergedIn() const {
     return zero_merged_in_;
   }
 
@@ -127,6 +128,8 @@ class IndexCompute : public BackwardVisitor {
       std::unordered_map<kir::IterDomain*, kir::Val*> new_index_entries,
       const std::vector<bool>& _root_contiguity);
 
+  virtual void run();
+
   // Map producer contiguity information to consumer, if entries don't match
   // mark as false
   static std::vector<bool> contiguityPasC(
@@ -136,6 +139,29 @@ class IndexCompute : public BackwardVisitor {
   static std::vector<bool> contiguityAnd(
       const std::vector<bool>& contig1,
       const std::vector<bool>& contig2);
+};
+
+//! Updates indices that are affected by swizzling
+class IndexSwizzle : public IndexCompute {
+ public:
+  IndexSwizzle(
+      const TensorView* tv,
+      std::unordered_map<kir::IterDomain*, kir::Val*> initial_index_map,
+      std::unordered_map<kir::IterDomain*, kir::Val*> extent_map,
+      std::unordered_set<kir::IterDomain*> zero_merged_in);
+
+  void run() override;
+
+ protected:
+  using IndexCompute::handle;
+
+  void handle(Expr* e) override;
+
+ private:
+  const TensorView* tv_ = nullptr;
+  SwizzleType swizzle_type_ = SwizzleType::NoSwizzle;
+  std::vector<IterDomain*> ids_to_swizzle_;
+  std::unordered_set<IterDomain*> swizzled_ids_;
 };
 
 // Simple interface for IndexCompute


### PR DESCRIPTION
Previously, swizzle is assumed to be applied to leaf axes. That assumption is too restrictive. For example, when using a 2D tile with a 1D thread block, a common pattern is to merge the two axes of the tile and split the merged axis with the number of threads. Thus, the leaf axes are no longer the axes of the 2D tile. 

This PR removes the assumption. The overall approach is the same. After finishing the C2P and P2C traversal in `generateIndexAndExtentmap`, apply swizzle if specified and update indices by traversing backward. The only difference is that it updates indices only when affected by swizzling to avoid resetting the swizzled index.

See FusionTransposeWithSwizzle1DThreadBlock for a concrete example, where swizzle is used as:
```
  tv0_cache->reorder({{-2, -1}});
  tv0_cache->swizzle(SwizzleType::Transpose, {-2, -1});
  tv0_cache->merge(-2, -1);
  tv0_cache->split(-1, BDIM);
```
