### PR TITLE
ProfileIValue PR

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -3,7 +3,6 @@ import os
 import random
 
 import torch
-import torch.autograd.profiler as profiler
 
 from torch.testing._internal.common_utils import run_tests, ProfilingMode, GRAPH_EXECUTOR
 from torch.testing._internal.codegen.random_topo_test import runDefaultTestWithSeed
@@ -1389,7 +1388,7 @@ class TestCudaFuser(JitTestCase):
         self.assertEqual(o, jit_o)
         self.assertGraphContains(t_jit.graph_for(x, y, (4, 1)), FUSION_GUARD)
 
-        #updated shape
+        # updated shape
         x = torch.randn([2, 5, 8], dtype=dtype, device=device)
         y = torch.randn([2, 5, 8], dtype=dtype, device=device)
         # (TODO) check executed kernel, should extend autograd.profiler to fused
@@ -1414,7 +1413,6 @@ class TestCudaFuser(JitTestCase):
 
         def t(x: torch.Tensor, y: torch.Tensor):
             o = torch.add(x, y)
-            #o = torch.add(o, 1.0)
             o = torch.relu(o)
             return o
 

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -1029,7 +1029,7 @@ TensorView* sum_to(TensorView* in, const std::vector<int64_t>& sum_to_size) {
   bool reduction_within_shape = false;
 
   // Reduce rest of the dims with keep_dim
-  for (int i = leading_dims; i < root.size(); i++) {
+  for (int i = leading_dims; i < int(root.size()); i++) {
     if (sum_to_size[i - leading_dims] == 1 &&
         !root[i]->rawExtent()->isOneInt()) {
       inner_red_dims[i - leading_dims] = true;

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -969,6 +969,52 @@ TensorView* sum_to(TensorView* in, const std::vector<Int*>& sum_to_size) {
   return out;
 }
 
+TensorView* sum_to(TensorView* in, const std::vector<int64_t>& sum_to_size) {
+  const auto& root = TensorDomain::noReductions(in->getRootDomain());
+
+  TORCH_CHECK(
+      root.size() >= sum_to_size.size(),
+      "sum_to: Error trying to reduce",
+      in,
+      "into a shape of size",
+      sum_to_size.size());
+
+  // If no reduction is needed sum_to returns the input tv
+  TensorView* out = in;
+
+  const int64_t leading_dims = root.size() - sum_to_size.size();
+
+  // Generate reduction axes for leading dims
+  std::vector<int> reduce_dims(leading_dims);
+  std::iota(reduce_dims.begin(), reduce_dims.end(), 0);
+
+  // Generate reduction axes for dims within sum_to_size
+  std::vector<bool> inner_red_dims(sum_to_size.size(), false);
+  bool reduction_within_shape = false;
+
+  // Reduce rest of the dims with keep_dim
+  for (int i = leading_dims; i < root.size(); i++) {
+    if (sum_to_size[i - leading_dims] == 1 &&
+        !root[i]->rawExtent()->isOneInt()) {
+      inner_red_dims[i - leading_dims] = true;
+      reduce_dims.push_back(i);
+      reduction_within_shape = true;
+    }
+  }
+
+  // Reduction step
+  if (!reduce_dims.empty()) {
+    out = sum(in, reduce_dims);
+  }
+
+  // Broadcast back reduced dims within shape
+  if (reduction_within_shape) {
+    out = broadcast(out, inner_red_dims);
+  }
+
+  return out;
+}
+
 } // namespace cuda
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -224,6 +224,10 @@ TORCH_CUDA_API TensorView* sum_to(
     TensorView* v1,
     const std::vector<Int*>& sum_to_size);
 
+TORCH_CUDA_API TensorView* sum_to(
+    TensorView* v1,
+    const std::vector<int64_t>& sum_to_size);
+
 } // namespace cuda
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -194,9 +194,12 @@ struct CudaGraphFuser {
     // them
     // we insert tensors first because the fuser assumes that to be the case
     // (as a legacy from tensors only)
+    std::cout << "    merge node: " << *n << std::endl;
     WithInsertPoint guard(*subgraph.nodes().begin());
     for (auto input : n->inputs()) {
+      std::cout << "        check input: " << *input->node() << std::endl;
       if (inputs_map.count(input) == 0) {
+        std::cout << " ---add tensor inputs--- ";
         // TODO: we are following the convention for no good reason;
         //       we don't need tensor to come before any other inputs.
         if (input->type()->isSubtypeOf(TensorType::get())) {
@@ -208,14 +211,16 @@ struct CudaGraphFuser {
         } else if (
             // TODO: extend the supporting inputs here.
             (input->type()->isSubtypeOf(FloatType::get()) &&
-             input->node()->kind() != prim::Constant) ||
-            (n->kind() == aten::_grad_sum_to_size &&
-             input->type()->isSubtypeOf(ListType::ofInts()))) {
+             input->node()->kind() != prim::Constant)
+            ) {
+            // || (n->kind() == aten::_grad_sum_to_size &&
+            //  input->type()->isSubtypeOf(ListType::ofInts()))) {
           auto in_group = subgraph.addInput();
           in_group->setType(input->type());
           inputs_map[input] = in_group;
           group->addInput(input);
         } else if (input->node()->kind() == prim::Constant) {
+          std::cout << " ---constant warning--- ";
           // inline the constants directly in the body of the fused group.
 
           // we'll only merge constant into a non-empty graph, which will always
@@ -239,9 +244,9 @@ struct CudaGraphFuser {
                 return in_group;
               });
 
-          subgraph.insertNode(in_const);
-          inputs_map[input] = in_const->output();
+          subgraph.insertNode(in_const); inputs_map[input] = in_const->output();
         } else {
+          std::cout << " ---add scalar input--- ";
           // TODO: we need to figure out what are supported input scalar
           auto in_group = subgraph.addInput();
           in_group->setType(input->type());
@@ -283,6 +288,7 @@ struct CudaGraphFuser {
     // propogate position information for the new node so we can always
     // have a valid mapping
     group->insertBefore(n);
+    std::cout << " create singleton group with node " << *n << std::endl;
     Node* mergedNode = mergeNodeIntoGroup(group, n);
     for (size_t i = 0; i < n->outputs().size(); i++) {
       getSubgraph(group).registerOutput(mergedNode->output(i));
@@ -310,13 +316,17 @@ struct CudaGraphFuser {
         // an output of the fusion group.
         aliasDb_->moveBeforeTopologicallyValid(producer->node(), consumer);
 
+    std::cout << "try to fuse : " << *producer->node() << "   ";
+
     if (!shouldFuse) {
+      std::cout << "shouldn't fuse" << std::endl;
       return at::nullopt;
     }
 
     if ((consumer->inputs().size() + consumer->outputs().size() +
          producer->node()->inputs().size() +
          producer->node()->outputs().size()) > subgraph_arg_limit_) {
+      std::cout << "exceeds limits" << std::endl;
       return at::nullopt;
     }
 
@@ -327,6 +337,7 @@ struct CudaGraphFuser {
 
     if (producer->node()->kind() == kind_) {
       mergeFusionGroups(group, producer->node());
+      std::cout << "fuse groups" << std::endl;
       return group;
     }
     Node* merged = mergeNodeIntoGroup(group, producer->node());
@@ -346,6 +357,7 @@ struct CudaGraphFuser {
       }
     }
     producer->node()->destroy();
+    std::cout << "fuse node" << std::endl;
     return group;
   }
 
@@ -942,6 +954,8 @@ struct CudaGraphFuser {
         any_changed |= changed;
       }
     }
+
+    GRAPH_DUMP("after scan and merge", graph_);
     refreshAliasDb();
 
     // fuseConcats();
@@ -1350,7 +1364,7 @@ void CudaFuseGraph(std::shared_ptr<Graph>& graph) {
   // guard input types as well as conditional constants from
   // aten::profile_ivalue
   guardFusionGroups(graph->block());
-  GRAPH_DUMP("After Fusion: ", graph);
+  GRAPH_DUMP("After Guard Fusion: ", graph);
 
   traverseProfileIValues(graph->block(), RemoveProfileIValue);
 

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -39,6 +39,31 @@ Value* broadcastSizes(at::ArrayRef<Value*> sizes) {
   return broadcast_n->output();
 }
 
+Value* createConditionalConstant(Node* profile_ivalue) {
+  TORCH_INTERNAL_ASSERT(profile_ivalue->kind() == prim::profile_ivalue);
+
+  auto graph = profile_ivalue->owningGraph();
+
+  IValue val; // default to None
+  if (profile_ivalue->hasAttribute(Symbol::attr("profiled_int_list"))) {
+    // int[]
+    val = IValue(profile_ivalue->is(Symbol::attr("profiled_int_list")));
+  } else if (profile_ivalue->hasAttribute(Symbol::attr("profiled_bool"))) {
+    // bool
+    val = IValue(
+        static_cast<bool>(profile_ivalue->i(Symbol::attr("profiled_bool"))));
+  } else {
+    GRAPH_DEBUG("profile_ivalue: ", *profile_ivalue);
+    TORCH_INTERNAL_ASSERT(
+        false,
+        __func__,
+        " gets unidentified type: ",
+        profile_ivalue->ty(attr::profiled_type));
+  }
+
+  return graph->insertConstant(val);
+}
+
 struct CudaGraphFuser {
   using FusionCallback = std::function<bool(Node*)>;
 
@@ -157,7 +182,6 @@ struct CudaGraphFuser {
     std::unordered_map<Value*, Value*> inputs_map;
     size_t i = 0;
     size_t tensor_insert_idx = 0;
-    AT_ASSERT(group->inputs().size() == subgraph.inputs().size());
     for (auto input : group->inputs()) {
       inputs_map[input] = subgraph.inputs()[i++];
       if (input->type()->isSubtypeOf(TensorType::get()))
@@ -190,10 +214,28 @@ struct CudaGraphFuser {
           group->addInput(input);
         } else if (input->node()->kind() == prim::Constant) {
           // inline the constants directly in the body of the fused group.
+
+          // we'll only merge constant into a non-empty graph, which will always
+          // have inputs
+          // Value* dummy_input = subgraph.inputs()[0];
+
           Node* in_const =
-              subgraph.createClone(input->node(), [](Value*) -> Value* {
-                throw std::runtime_error("unexpected input");
+              subgraph.createClone(input->node(), [&](Value* v) -> Value* {
+                if (v->node()->kind() != prim::profile_ivalue) {
+                  throw std::runtime_error(
+                      std::string(
+                          "merging constant with unexpected input from node") +
+                      v->node()->kind().toDisplayString());
+                }
+                group->addInput(v->node()->output());
+
+                // we are doing this just to keep alias_analysis silent with
+                // their checks
+                auto in_group = subgraph.addInput();
+                in_group->setType(v->type());
+                return in_group;
               });
+
           subgraph.insertNode(in_const);
           inputs_map[input] = in_const->output();
         } else {
@@ -205,6 +247,7 @@ struct CudaGraphFuser {
         }
       }
     }
+
     // copy n into the graph, remapping its inputs to internal nodes
     Node* in_graph = subgraph.createClone(
         n, [&](Value* k) -> Value* { return inputs_map[k]; });
@@ -513,6 +556,7 @@ struct CudaGraphFuser {
       bchunk = promoteChunkToBroadcastingChunk(chunk);
     }
     size_t nchunks = bchunk->i(attr::chunks);
+    TORCH_INTERNAL_ASSERT(nchunks > 0, "number of chunks cannot be zero");
     WithInsertPoint guard(bchunk->next());
 
     std::vector<Value*> producer_chunk_outputs;
@@ -757,13 +801,35 @@ struct CudaGraphFuser {
 
         // hmmm, do I need to setInsertPoint...
         Node* in1_const =
-            graph->createClone(n->input(1)->node(), [](Value*) -> Value* {
-              throw std::runtime_error("unexpected input");
+            graph->createClone(n->input(1)->node(), [&](Value* v) -> Value* {
+              // if constant ever has an input, it has to come from
+              // profile_ivalue dependency
+              if (v->node()->kind() == prim::Param &&
+                  fusion_group->input(v->offset())->node()->kind() ==
+                      prim::profile_ivalue) {
+                // we need to map it along profile_ivalue dependency
+                return fusion_group->input(v->offset());
+              } else {
+                throw std::runtime_error(
+                    std::string("unexpected input from node") +
+                    v->node()->kind().toDisplayString());
+              }
             });
         graph->insertNode(in1_const);
         Node* in2_const =
-            graph->createClone(n->input(2)->node(), [](Value*) -> Value* {
-              throw std::runtime_error("unexpected input");
+            graph->createClone(n->input(2)->node(), [&](Value* v) -> Value* {
+              // if constant ever has an input, it has to come from
+              // profile_ivalue dependency
+              if (v->node()->kind() == prim::Param &&
+                  fusion_group->input(v->offset())->node()->kind() ==
+                      prim::profile_ivalue) {
+                // we need to map it along profile_ivalue dependency
+                return fusion_group->input(v->offset());
+              } else {
+                throw std::runtime_error(
+                    std::string("unexpected input from node") +
+                    v->node()->kind().toDisplayString());
+              }
             });
         graph->insertNode(in2_const);
 
@@ -805,7 +871,9 @@ struct CudaGraphFuser {
 
     // TODO: failure in buildShapeExpressions should not break fusion execution,
     // we can add a try/catch here to bailout from removeOutputsUsedOnlyInSize.
+    GRAPH_DUMP("before build shape expression: ", graph_);
     auto shape_of = buildShapeExpressions(fusion_group);
+    GRAPH_DUMP("after build shape expression: ", graph_);
     auto outputs = fusion_group->outputs().vec();
     auto soutputs = subgraph->outputs().vec();
     // XXX: Iterating in this order is not only good for performance reasons!
@@ -825,6 +893,7 @@ struct CudaGraphFuser {
         subgraph->eraseOutput(i);
       }
     }
+    GRAPH_DUMP("after build shape expression and re-wiring: ", graph_);
   }
 
   void refreshAliasDb() {
@@ -1006,41 +1075,35 @@ void PeepholeOptimizeShapeExpressions(Block* block) {
 void guardFusionGroup(Node* fusion) {
   // Fixup types of the subgraph inputs
   std::vector<TypePtr> guard_types;
-  std::vector<Value*> inputs_to_check;
-  for (Value* input : fusion->inputs()) {
-    // We only check inputs of the fusion group and expect NNC to infer
-    // intermediates and outputs shapes
-    if (!input->type()->cast<TensorType>()) {
-      continue;
+  std::vector<Value*> tensor_inputs_to_check;
+  std::set<size_t> profiled_ivalue_indices;
+
+  for (size_t index = 0; index < fusion->inputs().size(); index++) {
+    Value* input = fusion->inputs()[index];
+    if (input->type()->cast<TensorType>()) {
+      // We only check inputs of the fusion group and expect NNC to infer
+      // intermediates and outputs shapes
+
+      // note: modified from original implementation, we are guarding fusion
+      //       outputs
+      if (input->node()->kind() == prim::Constant) {
+        continue;
+      }
+      tensor_inputs_to_check.push_back(input);
+      guard_types.push_back(input->type());
+    } else if (input->node()->kind() == prim::profile_ivalue) {
+      // Conditional constant from profiled_ivalue, should be guarded
+      profiled_ivalue_indices.insert(index);
     }
-
-    // note: modified from original implementation, we are guarding fusion
-    //       outputs
-    if (input->node()->kind() == prim::Constant) {
-      continue;
-    }
-    inputs_to_check.push_back(input);
-    guard_types.push_back(input->type());
   }
-  if (!inputs_to_check.size()) {
-    return;
-  }
+  // we should assert on non-tensor inputs
+  TORCH_INTERNAL_ASSERT(
+      tensor_inputs_to_check.size(),
+      "CudaFusionGuard expects at least one tensor input");
 
-  Node* typecheck_node = fusion->owningGraph()
-                             ->create(prim::CudaFusionGuard, inputs_to_check, 1)
-                             ->insertBefore(fusion);
-  // fix output to BoolType
-  typecheck_node->output()->setType(BoolType::get());
-  Value* typecheck_result = typecheck_node->output();
-  typecheck_node->tys_(attr::types, guard_types);
-
-  std::unordered_map<Value*, Value*> typechecked_inputs;
-
-  // Insert if block
+  // insert the if block first;
   auto versioning_if =
-      fusion->owningGraph()
-          ->create(prim::If, {typecheck_result}, fusion->outputs().size())
-          ->insertAfter(typecheck_node);
+      fusion->owningGraph()->create(prim::If, fusion->outputs().size());
   for (size_t idx = 0; idx < fusion->outputs().size(); ++idx) {
     versioning_if->output(idx)->setType(fusion->output(idx)->type());
     fusion->output(idx)->replaceAllUsesWith(versioning_if->output(idx));
@@ -1048,22 +1111,140 @@ void guardFusionGroup(Node* fusion) {
   auto true_block = versioning_if->addBlock();
   auto false_block = versioning_if->addBlock();
 
+  // insert typecheck_node;
+  Node* typecheck_node =
+      fusion->owningGraph()
+          ->create(prim::CudaFusionGuard, tensor_inputs_to_check, 1)
+          ->insertBefore(fusion);
+  // fix output to BoolType
+  typecheck_node->output()->setType(BoolType::get());
+  Value* typecheck_result = typecheck_node->output();
+  typecheck_node->tys_(attr::types, guard_types);
+
+  versioning_if->insertAfter(typecheck_node);
+
   // Fill in the false block. It should contain the unoptimized
-  // copy of the fused subgraph.
-  auto& subgraph = *fusion->g(attr::Subgraph);
-  WithInsertPoint guard(false_block->return_node());
-  const auto subgraph_outputs =
-      insertGraph(*fusion->owningGraph(), subgraph, fusion->inputs());
-  for (Value* output : subgraph_outputs) {
-    false_block->registerOutput(output);
+  // copy of the fused subgraph, unless we have conditional constants from
+  // profiled_ivalue;
+  auto fusion_graph = fusion->g(attr::Subgraph);
+  std::shared_ptr<Graph> fb_graph; // resource holder;
+  // Restore the dependency for constant introduced by profiled_ivalue within
+  // the graph.
+  if (!profiled_ivalue_indices.empty()) {
+    // This is necessary as it cleans up the fallback graph, which was copied
+    // from subgraph, since the two graph would differ as we cannot use
+    // conditional constant in fallback
+
+    // 1. RESTORE conditional constant dependency in fallback group;
+    fb_graph = fusion_graph->copy();
+    GRAPH_DUMP("re-wiring fallback graph", fb_graph);
+
+    for (const auto& offset : profiled_ivalue_indices) {
+      auto val = fb_graph->inputs()[offset];
+      for (auto use : val->uses()) {
+        // re-wire inputs and remove conditional constant nodes;
+        TORCH_INTERNAL_ASSERT(
+            use.user->kind() == prim::Constant,
+            "profile_ivalue at index: ",
+            offset,
+            " can only be used by conditional constant, instead got: ",
+            use.user->kind().toDisplayString());
+        use.user->output()->replaceAllUsesWith(val);
+        use.user->destroy();
+      }
+    }
+
+    WithInsertPoint guard(false_block->return_node());
+    const auto subgraph_outputs =
+        insertGraph(*fusion->owningGraph(), *fb_graph, fusion->inputs());
+    for (Value* output : subgraph_outputs) {
+      false_block->registerOutput(output);
+    }
+    // types get copied to the fallback graph, so remove specializations before
+    // replacing
+    // TODO: this is not exposed here, I need to remove that before inserting
+    // the graph
+    // removeTensorTypeSpecializations(false_block);
+    replaceBlockWithFallbackGraph(false_block, fusion->inputs());
+
+    // 2. REMOVE conditional constant dependency in fusion group
+    size_t compensation = 0;
+
+    // get a constant false, which is used by `and` pattern later
+    auto const_true = fusion->owningGraph()->insertConstant(IValue(true));
+    const_true->node()->moveBefore(versioning_if);
+
+    for (const auto& original_offset : profiled_ivalue_indices) {
+      size_t offset = original_offset - compensation;
+
+      // step a. handle fusion
+      // remove inputs to fusion, and update check logic for fallback
+      auto profiled_ival = fusion->input(offset)->node()->input();
+      auto const_o = createConditionalConstant(fusion->input(offset)->node());
+      const_o->node()->moveBefore(versioning_if);
+      Value* ivalue_check = nullptr;
+      if (fusion->input(offset)->node()->hasAttribute(
+              Symbol::attr("profiled_bool"))) {
+        // aten::eq doesn't support comparison between two boolean
+        auto xor_n = fusion->owningGraph()
+                         ->create(aten::__xor__, {profiled_ival, const_o}, 1)
+                         ->insertBefore(versioning_if);
+        xor_n->output()->setType(BoolType::get());
+        ivalue_check =
+            fusion->owningGraph()
+                ->create(aten::__xor__, {xor_n->output(), const_true}, 1)
+                ->insertBefore(versioning_if)
+                ->output();
+      } else {
+        ivalue_check = fusion->owningGraph()
+                           ->create(aten::eq, {profiled_ival, const_o}, 1)
+                           ->insertBefore(versioning_if)
+                           ->output();
+      }
+      ivalue_check->setType(BoolType::get());
+
+      typecheck_result =
+          fusion->owningGraph()
+              ->create(aten::__and__, {ivalue_check, typecheck_result}, 1)
+              ->insertBefore(versioning_if)
+              ->output();
+      typecheck_result->setType(BoolType::get());
+
+      // remove inputs to fusion;
+      fusion->removeInput(offset);
+
+      // step b. remove the extra dependency inside fusion;
+      for (auto use : fusion_graph->inputs()[offset]->uses()) {
+        TORCH_INTERNAL_ASSERT(
+            use.user->kind() == prim::Constant,
+            "profile_ivalue at index: ",
+            offset,
+            " can only be used by conditional constant, instead got: ",
+            use.user->kind().toDisplayString());
+        use.user->removeAllInputs();
+      }
+      fusion_graph->eraseInput(offset);
+      compensation++;
+    }
+    // update graph in fusion node
+    fusion->g_(attr::Subgraph, fusion_graph);
+  } else {
+    WithInsertPoint guard(false_block->return_node());
+    const auto subgraph_outputs =
+        insertGraph(*fusion->owningGraph(), *fusion_graph, fusion->inputs());
+    for (Value* output : subgraph_outputs) {
+      false_block->registerOutput(output);
+    }
+    // types get copied to the fallback graph, so remove specializations before
+    // replacing
+    // TODO: this is not exposed here, I need to remove that before inserting
+    // the graph
+    // removeTensorTypeSpecializations(false_block);
+    replaceBlockWithFallbackGraph(false_block, fusion->inputs());
   }
 
-  // types get copied to the fallback graph, so remove specializations before
-  // replacing
-  // TODO: this is not exposed here, I need to remove that before inserting the
-  //       graph
-  // removeTensorTypeSpecializations(false_block);
-  replaceBlockWithFallbackGraph(false_block, fusion->inputs());
+  // wiring up if block
+  versioning_if->addInput(typecheck_result);
 
   // Fill in the true block. It has all inputs type-checked and its
   // body should be the fusion group node.
@@ -1084,7 +1265,50 @@ void guardFusionGroups(Block* block) {
     }
   }
   for (Node* fusion : fusions) {
+    // step 1: a. add prim::CudaFusionGuard and fallback logic
+    //         b. insert guard logic of profile_ivalue with if block
+    //         c. restore conditional constant to non-constant for fallback
     guardFusionGroup(fusion);
+  }
+
+  // step 2: restore conditional constant to non-constant outside of
+}
+
+void ExtractProfileIValue(Node* profile_ivalue) {
+  auto const_o = createConditionalConstant(profile_ivalue);
+  auto const_n = const_o->node();
+  const_n->moveAfter(profile_ivalue);
+  profile_ivalue->output()->replaceAllUsesAfterNodeWith(const_n, const_o);
+  // special wiring, we add this input to constant simply in order to create
+  // dependency, which we can trace and remove later;
+  const_n->addInput(profile_ivalue->output());
+}
+
+void RemoveProfileIValue(Node* profile_ivalue) {
+  for (auto use : profile_ivalue->output()->uses()) {
+    if (use.user->kind() == prim::Constant) {
+      use.user->output()->replaceAllUsesWith(profile_ivalue->input());
+      use.user->destroy();
+    }
+  }
+  profile_ivalue->output()->replaceAllUsesWith(profile_ivalue->input());
+  profile_ivalue->destroy();
+}
+
+void traverseProfileIValues(
+    Block* block,
+    const std::function<void(Node*)>& func) {
+  std::vector<Node*> profile_ivalues;
+  for (Node* n : block->nodes()) {
+    for (Block* b : n->blocks()) {
+      traverseProfileIValues(b, func);
+    }
+    if (n->kind() == prim::profile_ivalue) {
+      profile_ivalues.push_back(n);
+    }
+  }
+  for (Node* profile_ivalue : profile_ivalues) {
+    func(profile_ivalue);
   }
 }
 
@@ -1093,14 +1317,30 @@ void guardFusionGroups(Block* block) {
 void CudaFuseGraph(std::shared_ptr<Graph>& graph) {
   FUSER_PERF_SCOPE("CudaFuseGraph");
   GRAPH_DUMP("Before Fusion: ", graph);
+  // TODO: constant folding on dimensionality;
+
+  // TODO: extract & guard profile_ivalue; but how do we restore it???
+  // I don't know how to store edge/node in attribute. so let's abuse data flow
+  // dependency and add inputs to conditional constant generated by
+  // aten::profile_ivalue
+  traverseProfileIValues(graph->block(), ExtractProfileIValue);
+  GRAPH_DUMP("insert conditional constant from profile_ivalue: ", graph);
+
   // TODO: we need to properly restore shape information after fusion.
   // shamelessly use tool from NNC.
   RemoveProfileNodesAndSpecializeTypes(graph);
 
   GRAPH_DUMP("After Profiling Nodes Removed: ", graph);
   CudaGraphFuser(graph->block(), graph).run();
+
+  GRAPH_DUMP("After Fusion: ", graph);
+
+  // guard input types as well as conditional constants from
+  // aten::profile_ivalue
   guardFusionGroups(graph->block());
   GRAPH_DUMP("After Fusion: ", graph);
+
+  traverseProfileIValues(graph->block(), RemoveProfileIValue);
 
   // After FuseGraph some common subexpressions may come back
   EliminateCommonSubexpression(graph);

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -1123,7 +1123,10 @@ void guardFusionGroup(Node* fusion) {
 
     for (const auto& offset : profiled_ivalue_indices) {
       auto val = fb_graph->inputs()[offset];
-      for (auto use : val->uses()) {
+      auto uses = val->uses();
+      // since we are updating use of val in the loop, we have to copy
+      // val->uses() before hand.
+      for (const auto& use : uses) {
         // re-wire inputs and remove conditional constant nodes;
         TORCH_INTERNAL_ASSERT(
             use.user->kind() == prim::Constant,
@@ -1209,7 +1212,7 @@ void guardFusionGroup(Node* fusion) {
       fusion->removeInput(offset);
 
       // step b. remove the extra dependency inside fusion;
-      for (auto use : fusion_graph->inputs()[offset]->uses()) {
+      for (const auto& use : fusion_graph->inputs()[offset]->uses()) {
         TORCH_INTERNAL_ASSERT(
             use.user->kind() == prim::Constant,
             "profile_ivalue at index: ",
@@ -1280,7 +1283,7 @@ void ExtractProfileIValue(Node* profile_ivalue) {
 }
 
 void RemoveProfileIValue(Node* profile_ivalue) {
-  for (auto use : profile_ivalue->output()->uses()) {
+  for (const auto& use : profile_ivalue->output()->uses()) {
     if (use.user->kind() == prim::Constant) {
       use.user->output()->replaceAllUsesWith(profile_ivalue->input());
       use.user->destroy();

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -208,10 +208,9 @@ struct CudaGraphFuser {
         } else if (
             // TODO: extend the supporting inputs here.
             (input->type()->isSubtypeOf(FloatType::get()) &&
-             input->node()->kind() != prim::Constant)
-            ) {
-            // || (n->kind() == aten::_grad_sum_to_size &&
-            //  input->type()->isSubtypeOf(ListType::ofInts()))) {
+             input->node()->kind() != prim::Constant)) {
+          // || (n->kind() == aten::_grad_sum_to_size &&
+          //  input->type()->isSubtypeOf(ListType::ofInts()))) {
           auto in_group = subgraph.addInput();
           in_group->setType(input->type());
           inputs_map[input] = in_group;
@@ -240,7 +239,8 @@ struct CudaGraphFuser {
                 return in_group;
               });
 
-          subgraph.insertNode(in_const); inputs_map[input] = in_const->output();
+          subgraph.insertNode(in_const);
+          inputs_map[input] = in_const->output();
         } else {
           // TODO: we need to figure out what are supported input scalar
           auto in_group = subgraph.addInput();
@@ -1202,13 +1202,17 @@ void guardFusionGroup(Node* fusion) {
                 ->insertBefore(versioning_if)
                 ->output();
       } else if (fusion->input(offset)->node()->hasAttribute(
-              Symbol::attr("profiled_size"))) {
+                     Symbol::attr("profiled_size"))) {
         // TODO(profile_size): check sizes here with special size comparison op
-        //TORCH_INTERNAL_ASSERT(false, "not implemented yet");
-        ivalue_check = fusion->owningGraph()
-                           ->create(c10::Symbol::fromQualString("prim::CudaFusionSizeEq"), {profiled_ival, const_o}, 1)
-                           ->insertBefore(versioning_if)
-                           ->output();
+        // TORCH_INTERNAL_ASSERT(false, "not implemented yet");
+        ivalue_check =
+            fusion->owningGraph()
+                ->create(
+                    c10::Symbol::fromQualString("prim::CudaFusionSizeEq"),
+                    {profiled_ival, const_o},
+                    1)
+                ->insertBefore(versioning_if)
+                ->output();
       } else {
         ivalue_check = fusion->owningGraph()
                            ->create(aten::eq, {profiled_ival, const_o}, 1)

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -46,6 +46,12 @@ bool canFuseNode(const Node* node) {
       getFuserInterface()->fn_can_fuse_n_(node);
 }
 
+void InsertProfileNodesForCUDAFuser(ProfilingRecord* pr) {
+  if (getFuserInterface()->fn_insert_profile_inodes_) {
+    getFuserInterface()->fn_insert_profile_inodes_(pr);
+  }
+}
+
 //! [ Note -- type guard logic in CudaFusionGuard ]
 //!
 //! CudaFusionGuard is used to Guard input tensor to `CudaFusionGroup` so that

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -22,33 +22,33 @@ CudaFuserInterface* getFuserInterface() {
 
 void compileFusionGroup(Node* fusion_node) {
   TORCH_CHECK(
-      getFuserInterface()->fn_compile_n_ != nullptr,
+      getFuserInterface()->fn_compile_n != nullptr,
       "Running the CUDA fuser requires a CUDA build.");
-  getFuserInterface()->fn_compile_n_(fusion_node);
+  getFuserInterface()->fn_compile_n(fusion_node);
 }
 
 void runFusionGroup(const Node* fusion_node, Stack& stack) {
   TORCH_CHECK(
-      getFuserInterface()->fn_run_n_s_ != nullptr,
+      getFuserInterface()->fn_run_n_s != nullptr,
       "Running the CUDA fuser requires a CUDA build.");
-  getFuserInterface()->fn_run_n_s_(fusion_node, stack);
+  getFuserInterface()->fn_run_n_s(fusion_node, stack);
 }
 
 void fuseGraph(std::shared_ptr<Graph>& graph) {
   TORCH_CHECK(
-      getFuserInterface()->fn_fuse_graph_ != nullptr,
+      getFuserInterface()->fn_fuse_graph != nullptr,
       "Running the CUDA fuser requires a CUDA build.");
-  getFuserInterface()->fn_fuse_graph_(graph);
+  getFuserInterface()->fn_fuse_graph(graph);
 }
 
 bool canFuseNode(const Node* node) {
-  return getFuserInterface()->fn_can_fuse_n_ != nullptr &&
-      getFuserInterface()->fn_can_fuse_n_(node);
+  return getFuserInterface()->fn_can_fuse_n != nullptr &&
+      getFuserInterface()->fn_can_fuse_n(node);
 }
 
 void InsertProfileNodesForCUDAFuser(ProfilingRecord* pr) {
-  if (getFuserInterface()->fn_insert_profile_inodes_) {
-    getFuserInterface()->fn_insert_profile_inodes_(pr);
+  if (getFuserInterface()->fn_insert_profile_inodes) {
+    getFuserInterface()->fn_insert_profile_inodes(pr);
   }
 }
 

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -215,7 +215,6 @@ RegisterOperators size_eq_guard({
                 }
 
                 for (size_t i = 0; i < inp.size(); i++) {
-                  printf("check %d, %d", int(inp[i]), int(ref[i]));
                   if (((inp[i] == 1) != (ref[i] == 1))) {
                     ret = false;
                     break;
@@ -226,11 +225,6 @@ RegisterOperators size_eq_guard({
               }
             }
 
-            if (ret) {
-              printf("  check success\n");
-            } else {
-              printf("  check failed\n");
-            }
             push(stack, IValue(ret));
             return;
           };

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -182,6 +182,7 @@ bool complyWith(
 
 namespace {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterOperators size_eq_guard({
     Operator(
         //"prim::CudaFusionSizeEq(int[] size, int[] ref) -> bool",
@@ -190,7 +191,7 @@ RegisterOperators size_eq_guard({
         // if we would ever return refined tensor, which would change aliasing
         // analysis, we should update aliasdb pass.
         [](const Node* node) -> Operation {
-          return [node](Stack* stack) {
+          return [](Stack* stack) {
             at::ArrayRef<IValue> inputs = last(stack, 2);
             drop(stack, 2);
 
@@ -200,7 +201,8 @@ RegisterOperators size_eq_guard({
             }
 
             // auto inp = inputs[0].toIntList();
-            TORCH_INTERNAL_ASSERT(inputs[1].isIntList(), "reference needs to be of int list");
+            TORCH_INTERNAL_ASSERT(
+                inputs[1].isIntList(), "reference needs to be of int list");
             auto ref = inputs[1].toIntList();
 
             auto ret = true;

--- a/torch/csrc/jit/codegen/cuda/interface.h
+++ b/torch/csrc/jit/codegen/cuda/interface.h
@@ -25,6 +25,7 @@ struct CudaFuserInterface {
   void (*fn_run_n_s_)(const Node*, Stack&) = nullptr;
   void (*fn_fuse_graph_)(std::shared_ptr<Graph>&) = nullptr;
   bool (*fn_can_fuse_n_)(const Node*) = nullptr;
+  void (*fn_insert_profile_inodes_)(ProfilingRecord* pr) = nullptr;
 };
 
 // Get interface, this is used by registration and user facing API internally
@@ -34,6 +35,7 @@ C10_EXPORT void compileFusionGroup(Node* fusion_node);
 C10_EXPORT void runFusionGroup(const Node* fusion_node, Stack& stack);
 C10_EXPORT void fuseGraph(std::shared_ptr<Graph>&);
 C10_EXPORT bool canFuseNode(const Node* node);
+C10_EXPORT void InsertProfileNodesForCUDAFuser(ProfilingRecord* pr);
 
 C10_EXPORT bool complyWith(
     const at::Tensor& tensor,

--- a/torch/csrc/jit/codegen/cuda/interface.h
+++ b/torch/csrc/jit/codegen/cuda/interface.h
@@ -21,11 +21,11 @@ TORCH_API std::atomic<bool>& getCudaFusionGuardMode();
 
 // dummy struct to allow API registration
 struct CudaFuserInterface {
-  void (*fn_compile_n_)(Node*) = nullptr;
-  void (*fn_run_n_s_)(const Node*, Stack&) = nullptr;
-  void (*fn_fuse_graph_)(std::shared_ptr<Graph>&) = nullptr;
-  bool (*fn_can_fuse_n_)(const Node*) = nullptr;
-  void (*fn_insert_profile_inodes_)(ProfilingRecord* pr) = nullptr;
+  void (*fn_compile_n)(Node*) = nullptr;
+  void (*fn_run_n_s)(const Node*, Stack&) = nullptr;
+  void (*fn_fuse_graph)(std::shared_ptr<Graph>&) = nullptr;
+  bool (*fn_can_fuse_n)(const Node*) = nullptr;
+  void (*fn_insert_profile_inodes)(ProfilingRecord* pr) = nullptr;
 };
 
 // Get interface, this is used by registration and user facing API internally

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -28,6 +28,9 @@ constexpr auto kNumLayernormFwd = 2;
 
 namespace {
 
+static const auto intListAttr = Symbol::attr("profiled_int_list");
+static const auto boolAttr = Symbol::attr("profiled_bool");
+
 typedef Val* CgValue;
 typedef Expr* CgOp;
 
@@ -1034,7 +1037,7 @@ class IrParser {
             value_map.emplace(node->output()->unique(), out);
           },
           [](const Node* node) -> bool {
-            // TODO: support cast of output types yet;
+            // TODO: support cast of output types
             if (!node->inputs()[3]->type()->isSubtypeOf(
                     static_cast<c10::TypePtr>(NoneType::get()))) {
               // We can only handle output as half, float, and double;
@@ -1199,6 +1202,79 @@ std::unordered_map<const FunctionSchema*, const IrParser::RegistrationEntry*>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool IrParser::init_registry_ = true;
 
+ProfileIValueOp* insertProfileIValueOp(
+    Node* node,
+    size_t offset,
+    ProfilingRecord* pr) {
+  auto in_val = node->input(offset);
+  auto pn = pr->createProfileIValueNode(in_val);
+  pn->insertBefore(node);
+  node->replaceInput(offset, pn->output());
+  return pn;
+}
+
+void profileIntList(ProfilingRecord* pr, Node* node, size_t offset) {
+  auto pn = insertProfileIValueOp(node, offset, pr);
+
+  std::function<void(Stack&)> ivalue_profiler = [pr, pn](Stack& stack) {
+    std::lock_guard<std::mutex> lock(pr->mutex_);
+
+    // TODO: we don't care about merging multiple profiling runs as we don't
+    // support it at all;
+    int64_t frame_id = 0;
+    pop(stack, frame_id);
+    IValue value;
+    pop(stack, value);
+    TORCH_INTERNAL_ASSERT(
+        value.isIntList(), "profiling seeing the wrong data type");
+    if (!pn->hasAttribute(intListAttr)) {
+      pn->is_(intListAttr, value.toIntVector());
+    } else {
+      auto profiled_ints = pn->is(intListAttr);
+      auto input_ints = value.toIntList();
+      TORCH_INTERNAL_ASSERT(
+          profiled_ints.size() == input_ints.size() &&
+              std::equal(
+                  profiled_ints.begin(),
+                  profiled_ints.end(),
+                  input_ints.begin()),
+          "profiling ivalue doesn't support merge");
+    }
+    push(stack, value);
+  };
+
+  pn->setCallback(ivalue_profiler);
+}
+
+void profileBool(ProfilingRecord* pr, Node* node, size_t offset) {
+  auto pn = insertProfileIValueOp(node, offset, pr);
+
+  std::function<void(Stack&)> ivalue_profiler = [pr, pn](Stack& stack) {
+    std::lock_guard<std::mutex> lock(pr->mutex_);
+
+    // TODO: we don't care about merging multiple profiling runs as we don't
+    // support it at all;
+    int64_t frame_id = 0;
+    pop(stack, frame_id);
+    IValue value;
+    pop(stack, value);
+    TORCH_INTERNAL_ASSERT(
+        value.isBool(), "profiling seeing the wrong data type");
+    if (!pn->hasAttribute(boolAttr)) {
+      pn->i_(boolAttr, value.toBool());
+    } else {
+      auto profiled_bool = pn->i(boolAttr);
+      auto input_bool = value.toBool();
+      TORCH_INTERNAL_ASSERT(
+          input_bool == profiled_bool,
+          "profiling ivalue doesn't support merge");
+    }
+    push(stack, value);
+  };
+
+  pn->setCallback(ivalue_profiler);
+}
+
 bool anyInBlock(
     const Block* block,
     const std::function<bool(const Node*)>& fn) {
@@ -1239,6 +1315,52 @@ bool isElementWiseNode(const Node* node) {
 
 bool isNodeParsible(const Node* node) {
   return IrParser::canParseNode(node);
+}
+
+// TODO: we should incorporate this to our parser as well;
+bool insertProfileIValue(ProfilingRecord* pr, Node* node, size_t offset) {
+  // is skip constant necessary?
+  if (node->input(offset)->node()->kind() == prim::Constant) {
+    return false;
+  }
+
+  static auto reduction_operator_schema =
+      getOperatorForLiteral(
+          "aten::sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, int? dtype=None) -> (Tensor)")
+          ->schema();
+  if (node->matches(reduction_operator_schema)) {
+    switch (offset) {
+      case 1:
+        profileIntList(pr, node, offset);
+        break;
+      case 2:
+        profileBool(pr, node, offset);
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+void insertProfileNodesForCUDAFuser_(Block* block, ProfilingRecord* pr) {
+  for (auto it = block->nodes().begin(); it != block->nodes().end(); ++it) {
+    auto n = *it;
+
+    for (size_t offset = 0; offset < n->inputs().size(); offset++) {
+      insertProfileIValue(pr, n, offset);
+    }
+
+    for (auto ib : n->blocks()) {
+      insertProfileNodesForCUDAFuser_(ib, pr);
+    }
+  }
+}
+
+void InsertProfileNodes(ProfilingRecord* pr) {
+  insertProfileNodesForCUDAFuser_(pr->profiled_graph_->block(), pr);
 }
 
 std::unique_ptr<Fusion> parseJitIR(const std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -1084,7 +1084,7 @@ class IrParser {
               TORCH_INTERNAL_ASSERT(
                   size_to.has_value(),
                   "aten::sum cannot be fused with dynamic axes");
-              if (size_to->empty()) {
+              if (!size_to->empty()) {
                 auto out = sum_to(self->as<TensorView>(), size_to->vec());
                 value_map.emplace(node->output()->unique(), out);
               } else {

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -65,7 +65,8 @@ class IrParser {
     }
 
     bool isType(const Node* node, OperatorType type) const {
-      auto n_type = type_f_ == nullptr ? OperatorType::ElementWise : type_f_(node);
+      auto n_type =
+          type_f_ == nullptr ? OperatorType::ElementWise : type_f_(node);
       return n_type == type;
     }
 
@@ -184,7 +185,8 @@ class IrParser {
     initRegistry();
 
     auto reg_entry = lookupInRegistry(node);
-    return reg_entry != nullptr && reg_entry->isType(node, OperatorType::Reduction);
+    return reg_entry != nullptr &&
+        reg_entry->isType(node, OperatorType::Reduction);
   }
 
   static bool isNormalizationNode(const Node* node) {
@@ -199,7 +201,8 @@ class IrParser {
     initRegistry();
 
     auto reg_entry = lookupInRegistry(node);
-    return reg_entry != nullptr && reg_entry->isType(node, OperatorType::ElementWise);
+    return reg_entry != nullptr &&
+        reg_entry->isType(node, OperatorType::ElementWise);
   }
 
   // TODO: is_reduction is too hacky here. we should categorize operation types
@@ -625,7 +628,9 @@ class IrParser {
             value_map.emplace(node->output()->unique(), output);
           },
           [](const Node* node) -> bool { return true; },
-          [](const Node* node) -> OperatorType { return OperatorType::Normalization; });
+          [](const Node* node) -> OperatorType {
+            return OperatorType::Normalization;
+          });
     }
 
     {
@@ -711,7 +716,9 @@ class IrParser {
           },
           // TODO: #ProfileIValue List should update this
           [](const Node* node) -> bool { return true; },
-          [](const Node* node) -> OperatorType { return OperatorType::Normalization; });
+          [](const Node* node) -> OperatorType {
+            return OperatorType::Normalization;
+          });
     }
 
     {
@@ -810,7 +817,9 @@ class IrParser {
             },
             // TODO: #ProfileIValue List should update this
             [](const Node* node) -> bool { return true; },
-            [](const Node* node) -> OperatorType { return OperatorType::Normalization; });
+            [](const Node* node) -> OperatorType {
+              return OperatorType::Normalization;
+            });
       }
     }
 
@@ -926,7 +935,9 @@ class IrParser {
           },
           // TODO: #ProfileIValue List should update this
           [](const Node* node) -> bool { return true; },
-          [](const Node* node) -> OperatorType { return OperatorType::Normalization; });
+          [](const Node* node) -> OperatorType {
+            return OperatorType::Normalization;
+          });
     }
 
     {
@@ -970,7 +981,9 @@ class IrParser {
             }
             return true;
           },
-          [](const Node* node) -> OperatorType { return OperatorType::Normalization; });
+          [](const Node* node) -> OperatorType {
+            return OperatorType::Normalization;
+          });
     }
 
     {
@@ -1014,7 +1027,9 @@ class IrParser {
             }
             return true;
           },
-          [](const Node* node) -> OperatorType { return OperatorType::Normalization; });
+          [](const Node* node) -> OperatorType {
+            return OperatorType::Normalization;
+          });
     }
 
     {
@@ -1065,7 +1080,9 @@ class IrParser {
             }
             return true;
           },
-          [](const Node* node) -> OperatorType { return OperatorType::Reduction; });
+          [](const Node* node) -> OperatorType {
+            return OperatorType::Reduction;
+          });
     }
 
     {
@@ -1078,7 +1095,6 @@ class IrParser {
             ptr_op,
             [](const Node* node,
                std::unordered_map<size_t, CgValue>& value_map) -> void {
-
               auto self = value_map[node->input(0)->unique()];
               auto size_to = constant_as<c10::List<int64_t>>(node->input(1));
               TORCH_INTERNAL_ASSERT(
@@ -1104,9 +1120,9 @@ class IrParser {
             [](const Node* node) -> OperatorType {
               auto size_to = constant_as<c10::List<int64_t>>(node->input(1));
               if (size_to->empty()) {
-                return OperatorType::ElementWise; 
+                return OperatorType::ElementWise;
               } else {
-                return OperatorType::Reduction; 
+                return OperatorType::Reduction;
               }
             });
       }
@@ -1280,8 +1296,8 @@ void profileSize(ProfilingRecord* pr, Node* node, size_t offset) {
     } else if (value.isNone()) {
       size_vec.clear();
     } else {
-      TORCH_INTERNAL_ASSERT(false,
-          "profileSize does not support data type: ", value.tagKind());
+      TORCH_INTERNAL_ASSERT(
+          false, "profileSize does not support data type: ", value.tagKind());
     }
     if (!pn->hasAttribute(sizeAttr)) {
       pn->is_(sizeAttr, size_vec);
@@ -1290,9 +1306,7 @@ void profileSize(ProfilingRecord* pr, Node* node, size_t offset) {
       TORCH_INTERNAL_ASSERT(
           profiled_ints.size() == size_vec.size() &&
               std::equal(
-                  profiled_ints.begin(),
-                  profiled_ints.end(),
-                  size_vec.begin()),
+                  profiled_ints.begin(), profiled_ints.end(), size_vec.begin()),
           "profiling ivalue doesn't support merge");
     }
     push(stack, value);
@@ -1438,7 +1452,8 @@ bool insertProfileIValue(ProfilingRecord* pr, Node* node, size_t offset) {
       getOperatorForLiteral(
           "aten::_grad_sum_to_size(Tensor(a) self, int[]? size) -> Tensor(a)")
           ->schema();
-  if (node->matches(sum_to_size_schema) || node->matches(grad_sum_to_size_schema)) {
+  if (node->matches(sum_to_size_schema) ||
+      node->matches(grad_sum_to_size_schema)) {
     switch (offset) {
       // argument 1: reduction sizes;
       case 1:

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -29,9 +29,9 @@ constexpr auto kNumSumToSize = 2;
 
 namespace {
 
-static const auto sizeAttr = Symbol::attr("profiled_size");
-static const auto intListAttr = Symbol::attr("profiled_int_list");
-static const auto boolAttr = Symbol::attr("profiled_bool");
+const auto& sizeAttr = Symbol::attr("profiled_size");
+const auto& intListAttr = Symbol::attr("profiled_int_list");
+const auto& boolAttr = Symbol::attr("profiled_bool");
 
 typedef Val* CgValue;
 typedef Expr* CgOp;

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -1119,6 +1119,8 @@ class IrParser {
             },
             [](const Node* node) -> OperatorType {
               auto size_to = constant_as<c10::List<int64_t>>(node->input(1));
+              // technically size_to->empty() should never occur, as specialized
+              // _grad_sum_to_size should have been removed by optimization pass
               if (size_to->empty()) {
                 return OperatorType::ElementWise;
               } else {

--- a/torch/csrc/jit/codegen/cuda/parser.h
+++ b/torch/csrc/jit/codegen/cuda/parser.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/runtime/profiling_record.h>
 
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 
@@ -40,6 +41,8 @@ TORCH_CUDA_API bool isElementWiseNode(const Node* node);
 
 // returns whether or not a parsing function exists for the given node type.
 TORCH_CUDA_API bool isNodeParsible(const Node* node);
+
+void InsertProfileNodes(ProfilingRecord* pr);
 
 // lowers PyTorch jit graph to `Fusion`.
 TORCH_CUDA_API std::unique_ptr<Fusion> parseJitIR(

--- a/torch/csrc/jit/codegen/cuda/register_interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/register_interface.cpp
@@ -19,11 +19,11 @@ class RegisterInterface {
  public:
   RegisterInterface() {
     auto ptr = getFuserInterface();
-    ptr->fn_compile_n_ = &compileCudaFusionGroup;
-    ptr->fn_run_n_s_ = &runCudaFusionGroup;
-    ptr->fn_fuse_graph_ = &CudaFuseGraph;
-    ptr->fn_can_fuse_n_ = &isFusibleCudaFusionGroup;
-    ptr->fn_insert_profile_inodes_ = &InsertProfileNodes;
+    ptr->fn_compile_n = &compileCudaFusionGroup;
+    ptr->fn_run_n_s = &runCudaFusionGroup;
+    ptr->fn_fuse_graph = &CudaFuseGraph;
+    ptr->fn_can_fuse_n = &isFusibleCudaFusionGroup;
+    ptr->fn_insert_profile_inodes = &InsertProfileNodes;
   }
 };
 

--- a/torch/csrc/jit/codegen/cuda/register_interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/register_interface.cpp
@@ -23,8 +23,7 @@ class RegisterInterface {
     ptr->fn_run_n_s_ = &runCudaFusionGroup;
     ptr->fn_fuse_graph_ = &CudaFuseGraph;
     ptr->fn_can_fuse_n_ = &isFusibleCudaFusionGroup;
-
-    RegisterProfilingNode(canFuseNode);
+    ptr->fn_insert_profile_inodes_ = &InsertProfileNodes;
   }
 };
 

--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -267,6 +267,12 @@ class NaiveTypePropagator {
             unary_reduce_type(out_type, dims->vec(), keepdim.value()));
         break;
       }
+      case aten::sum_to_size:
+      case aten::_grad_sum_to_size: {
+        auto out_type = node->input(0)->type()->cast<TensorType>();
+        node->output()->setType(out_type->withDim(c10::nullopt));
+        break;
+      }
       case aten::type_as: {
         const auto type0 = node->input(0)->type()->cast<TensorType>();
         const auto type1 = node->input(1)->type()->cast<TensorType>();

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -342,7 +342,8 @@ struct AutogradZeroSpecializer {
         const Node* node = n->input(1)->node();
         // propagate profiled none through other profile_ivalue nodes;
         while (!profiled_none_flag && node->kind() == prim::profile_ivalue) {
-          profiled_none_flag |= profiled_none_.count(node->input(0));
+          profiled_none_flag =
+              profiled_none_flag || profiled_none_.count(node->input(0));
           node = node->input(0)->node();
         }
         if (n->input(1)->mustBeNone() || profiled_none_flag) {

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -338,7 +338,14 @@ struct AutogradZeroSpecializer {
     for (auto it = b->nodes().begin(); it != b->nodes().end(); ++it) {
       Node* n = *it;
       if (n->kind() == aten::_grad_sum_to_size) {
-        if (n->input(1)->mustBeNone() || profiled_none_.count(n->input(1))) {
+        bool profiled_none_flag = profiled_none_.count(n->input(1));
+        const Node* node = n->input(1)->node();
+        // propagate profiled none through other profile_ivalue nodes;
+        while (!profiled_none_flag && node->kind() == prim::profile_ivalue) {
+          profiled_none_flag |= profiled_none_.count(node->input(0));
+          node = node->input(0)->node();
+        }
+        if (n->input(1)->mustBeNone() || profiled_none_flag) {
           n->output()->replaceAllUsesWith(n->input(0));
           it.destroyCurrent();
         }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -510,6 +510,9 @@ const ExecutionPlan& ProfilingGraphExecutorImpl::getOptimizedPlanFor(
     auto copy = graph->copy();
     runProfilingInsensitiveOptimizations(copy);
     pr_ = ProfilingRecord::instrumentGraph(copy);
+    if (RegisterCudaFuseGraph::isRegistered()) {
+      torch::jit::fuser::cuda::InsertProfileNodesForCUDAFuser(pr_.get());
+    }
     GRAPH_DUMP("Profiled Graph: ", pr_->graph());
     profiling_plan_ = ExecutionPlan(pr_->graph(), function_name_);
     // fall-through

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -7,43 +7,11 @@
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
 
+#include <torch/csrc/jit/codegen/cuda/interface.h>
+#include <torch/csrc/jit/ir/ir.h>
+
 namespace torch {
 namespace jit {
-
-namespace {
-
-class ProfileRegistry {
- public:
-  static ProfileRegistry* getRegistry() {
-    static ProfileRegistry profile_registry_;
-    return &profile_registry_;
-  }
-
-  void registerProfileNode(const std::function<bool(const Node*)>& func) {
-    std::lock_guard<std::mutex> guard(mutex_);
-    registry_funcs_.push_back(func);
-  }
-
-  bool shouldProfileNode(const Node* node) {
-    std::lock_guard<std::mutex> guard(mutex_);
-    for (const auto& func : registry_funcs_) {
-      if (func(node)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
- private:
-  std::vector<std::function<bool(const Node*)>> registry_funcs_;
-  std::mutex mutex_;
-};
-
-} // namespace
-
-void RegisterProfilingNode(const std::function<bool(const Node*)>& func) {
-  ProfileRegistry::getRegistry()->registerProfileNode(func);
-}
 
 bool ShapeSymbolTable::bindSymbolicShapes(
     at::IntArrayRef new_sizes,
@@ -83,6 +51,14 @@ ProfileOp* ProfilingRecord::createProfileNode(
   for (auto in : inputs) {
     pn->addInput(in);
   }
+  return pn;
+}
+
+ProfileIValueOp* ProfilingRecord::createProfileIValueNode(Value* in_val) {
+  auto pn = new ProfileIValueOp(this->profiled_graph_.get(), nullptr);
+  pn->addInput(in_val);
+  auto pno = pn->addOutput();
+  pno->setType(in_val->type());
   return pn;
 }
 
@@ -198,7 +174,7 @@ void ProfilingRecord::insertShapeProfile(Node* n, size_t offset) {
 }
 
 bool needsProfiledInputs(Node* n) {
-  if (tensorexpr::isSupported(n)) {
+  if (tensorexpr::isSupported(n) || fuser::cuda::canFuseNode(n)) {
     return true;
   }
 
@@ -224,12 +200,12 @@ bool needsProfiledInputs(Node* n) {
     case aten::mm:
       return true;
     default:
-      return ProfileRegistry::getRegistry()->shouldProfileNode(n);
+      return false;
   }
 }
 
 bool needsProfiledOutput(Node* n) {
-  if (tensorexpr::isSupported(n)) {
+  if (tensorexpr::isSupported(n) || fuser::cuda::canFuseNode(n)) {
     return true;
   }
 
@@ -238,7 +214,7 @@ bool needsProfiledOutput(Node* n) {
     case prim::AutogradZero:
       return true;
     default:
-      return ProfileRegistry::getRegistry()->shouldProfileNode(n);
+      return false;
   }
 }
 

--- a/torch/csrc/jit/runtime/profiling_record.h
+++ b/torch/csrc/jit/runtime/profiling_record.h
@@ -82,8 +82,6 @@ namespace jit {
 using ::c10::TensorTypePtr;
 using Dimension = int64_t;
 
-TORCH_API void RegisterProfilingNode(const std::function<bool(const Node*)>&);
-
 struct ProfilingRecord;
 
 // `SetPartitioningHelper` is used to maintain the following invariant:
@@ -203,6 +201,8 @@ struct ProfilingRecord {
   std::shared_ptr<Graph> graph() const {
     return profiled_graph_;
   }
+
+ TORCH_API ProfileIValueOp* createProfileIValueNode(Value* in_val);
 
  private:
   ProfileOp* createProfileNode(

--- a/torch/csrc/jit/runtime/profiling_record.h
+++ b/torch/csrc/jit/runtime/profiling_record.h
@@ -202,7 +202,7 @@ struct ProfilingRecord {
     return profiled_graph_;
   }
 
- TORCH_API ProfileIValueOp* createProfileIValueNode(Value* in_val);
+  TORCH_API ProfileIValueOp* createProfileIValueNode(Value* in_val);
 
  private:
   ProfileOp* createProfileNode(


### PR DESCRIPTION
1. `createConditionalConstant` supports profile ivalue including bool, int_list and size
2. New guard to check conditional constant at runtime
3. `size_eq_guard` op to facilitate comparison of dynamic sizes
4. `sum_to_size` & `_grad_sum_to_size` added in integration

- [x] profile size added;
- [x] `sum_to_size` and `_grad_sum_to_size` are working properly;
- [x] Add test for backwards;
- [x] Address upstream review comments