### PR TITLE
Detect multiple grid reduction calls

### DIFF
--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -114,7 +114,7 @@ class CudaKernelGenerator : private kir::IrVisitor {
 
     // Do we have any reductions?
     const bool has_reductions = kernel_summary.has_block_reductions ||
-        kernel_summary.has_grid_reductions;
+        kernel_summary.number_of_grid_reductions > 0;
 
     // Shared memory
     if (has_dynamic_smem || has_reductions) {

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -76,8 +76,9 @@ class KernelIrScanner : private kir::IrVisitor {
     summary_.has_block_broadcasts =
         summary_.has_block_broadcasts || domain->hasBlockBroadcast();
 
-    // TODO: Why definition() does not return kir::GridReduction?
     if (domain->hasGridReduction()) {
+      // tensor_index may be for initialization of a reduction
+      // buffer. Avoid counting twice.
       if (tensor_index->definition()->isA<kir::ReductionOp>()) {
         ++summary_.number_of_grid_reductions;
       }

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -98,7 +98,7 @@ class KernelIrScanner : private kir::IrVisitor {
     if (domain->hasGridReduction()) {
       auto fuser_tv = tv->fuserTv();
       for (size_t i = 0; i < fuser_tv->nDims(); ++i) {
-        auto id = fuser_tv->getComputeAtAxis(i).first;
+        const auto id = fuser_tv->getComputeAtAxis(i).first;
         summary_.has_grid_reduction_in_loop =
             summary_.has_grid_reduction_in_loop || !id->isThread();
       }

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -35,10 +35,10 @@ struct KernelSummary {
   //! Do we have any block reductions?
   bool has_block_reductions = false;
 
-  //! TODO -> Number of static grid reduction ops
+  //! Number of static grid reductions
   int number_of_grid_reductions = 0;
 
-  //! TODO
+  //! Do we have any grid reduction in a loop?
   bool has_grid_reduction_in_loop = false;
 
   //! Do we have any block broadcasts?

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -35,8 +35,11 @@ struct KernelSummary {
   //! Do we have any block reductions?
   bool has_block_reductions = false;
 
-  //! Do we have any grid reductions?
-  bool has_grid_reductions = false;
+  //! TODO -> Number of static grid reduction ops
+  int number_of_grid_reductions = 0;
+
+  //! TODO
+  bool has_grid_reduction_in_loop = false;
 
   //! Do we have any block broadcasts?
   bool has_block_broadcasts = false;


### PR DESCRIPTION
In addition to multiple (static) calls to the grid reduction routine, this PR detects grid reduction calls located within a loop.

Fixes #475
