### PR TITLE
Fix redundant TensorView in GridReduction

### DIFF
--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -79,7 +79,8 @@ class KernelIrScanner : private kir::IrVisitor {
     if (domain->hasGridReduction()) {
       // tensor_index may be for initialization of a reduction
       // buffer. Avoid counting twice.
-      if (tensor_index->definition()->isA<kir::ReductionOp>()) {
+      if (tensor_index->definition() != nullptr &&
+          tensor_index->definition()->isA<kir::ReductionOp>()) {
         ++summary_.number_of_grid_reductions;
       }
     }


### PR DESCRIPTION
Fixes #{issue number} (issue to be created)

`GridReduction` creates a output tensor without definition, causing error in kernel summary pass. 