### PR TITLE
Check size before front

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_insert_syncs.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_insert_syncs.cpp
@@ -264,7 +264,7 @@ class ReadAfterWriteSyncs : public kir::MutableIrVisitor {
       return;
     }
 
-    if (sync_after_.front() == expr) {
+    if (sync_after_.size() > 0 && sync_after_.front() == expr) {
       sync_after_.pop_front();
       // Found that a sync is needed
       TORCH_INTERNAL_ASSERT(expr->outputs()[0]->isA<kir::TensorView>());


### PR DESCRIPTION
`std::deque::front` is used without checking its size. This seems to cause random failures.
