### PR TITLE
Update test_graph_rng_functional to use native_dropout instead of _fused_dropout

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2936,7 +2936,7 @@ t2.start()
         #
         # (For the raw native_dropout call, p is the probability a value is kept,
         # not the probability it's zeroed.)
-        ops_with_kwargs = ((torch.native_dropout, {"p": 0.9, "scale": 1./0.9, "train": True}),
+        ops_with_kwargs = ((torch.native_dropout, {"p": 0.9, "scale": 1. / 0.9, "train": True}),
                            (torch.nn.functional.rrelu, {"training": True}),)
         size = 10000
 


### PR DESCRIPTION
Update: This PR is obsolete. I was only mucking around with lower-level `_fused_dropout` and `native_dropout` because, before the diffs that made the allocator capturable, I needed to hold a reference to the mask manually. Now that allocator capturability has been pulled in from upstream, I don't need to hold a mask reference, so `test_graph_rng_functional` can use the user-facing `torch.nn.functional.dropout`.

Using [`torch.nn.functional.dropout` in `test_graph_rng_functional` was already pulled into 20_12_3_devel](https://github.com/csarofeen/pytorch/blob/f6d07ddb64a6ddf132d322409f12d8ca38fca023/test/test_cuda.py#L2965-L2966) as part of the upstream allocator-safety diffs, im not sure why it doesn't show for me on the LHS of this PR's "Files changed".


----------------------

`_fused_dropout` was removed.  See https://teams.microsoft.com/l/message/19:7f200e6458394d3481c2b1cba6fe9e61@thread.tacv2/1611776069848?tenantId=43083d15-7273-40c1-b7db-39efd9ccc17a&groupId=74537292-c203-4a6d-aea0-40c527b969f7&parentMessageId=1611775394958&teamName=pyt-staff&channelName=PyT-JIT&createdTime=1611776069848

With these diffs
```
python test_cuda.py -k test_graph_rng_functional
```
passes in a local build.