### PR TITLE
Gelu backward parser

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -342,6 +342,7 @@ _(aten, full_like) \
 _(aten, gather) \
 _(aten, gcd) \
 _(aten, gelu) \
+_(aten, gelu_backward) \
 _(aten, geometric) \
 _(aten, geqrf) \
 _(aten, get_device) \

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -120,6 +120,11 @@ class TestCudaFuser(JitTestCase):
         self.assertEqual(o, jit_o)
         self.assertEqual(g, jit_g)
         self.assertGraphContainsExactly(jit_op.graph_for(*args), FUSION_GUARD, 1, consider_subgraphs=True)
+        bwd_graph = list(
+            list(jit_op.get_debug_state().execution_plans.values())[
+                0].code.grad_executor_states()[0].execution_plans.values()
+        )[0].graph
+        self.assertGraphContainsExactly(bwd_graph, FUSION_GUARD, 1, consider_subgraphs=True)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
@@ -1735,7 +1740,7 @@ class TestCudaFuser(JitTestCase):
 
         def t(x: torch.Tensor, p: float, train: bool):
             o = torch.nn.functional.dropout(x, p, training=train)
-            o = o + 1.0
+            o = o * 1.0
             return o
 
         t_jit = torch.jit.script(t)
@@ -1743,6 +1748,24 @@ class TestCudaFuser(JitTestCase):
         # The drop probability needs to be set to zero given that the order of picking random
         # numbers between eager mode and the jit is different
         self._run_training_helper(t_jit, t, grads, x, 0.0, True)
+    
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
+                     "Requires fusion optimization pass to be effective")
+    def test_gelu(self):
+        dtype = torch.float
+        device = "cuda"
+        x = torch.randn([1024, 1024], dtype=dtype, device=device, requires_grad=True)
+        grads = torch.randn([1024, 1024], dtype=dtype, device=device, requires_grad=False)
+
+        def t(x: torch.Tensor):
+            o = torch.nn.functional.gelu(x)
+            o = o * 1.0
+            return o
+
+        t_jit = torch.jit.script(t)
+
+        self._run_training_helper(t_jit, t, grads, x)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -1748,7 +1748,7 @@ class TestCudaFuser(JitTestCase):
         # The drop probability needs to be set to zero given that the order of picking random
         # numbers between eager mode and the jit is different
         self._run_training_helper(t_jit, t, grads, x, 0.0, True)
-    
+
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -96,8 +96,7 @@ bool complyWith(
   // check a. if num_dimension check fails or scalar type check fails
   if (*guard_tensor_type->dim() != static_cast<size_t>(tensor.ndimension()) ||
       (guard_tensor_type->scalarType().has_value() &&
-       (guard_tensor_type->scalarType().value() != tensor.scalar_type())) ||
-      tensor.requires_grad()) {
+       (guard_tensor_type->scalarType().value() != tensor.scalar_type()))) {
     return false;
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -30,7 +30,7 @@ namespace cuda {
 class TORCH_CUDA_CU_API InputsIdLookup : public NonCopyable {
  public:
   //! constructor where maximum cache size is fixed during init
-  explicit InputsIdLookup(size_t max_cache_size = 10)
+  explicit InputsIdLookup(size_t max_cache_size = 100)
       : max_cache_size_(max_cache_size){};
 
   //! struct to hold return value for lookupId.

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -1270,6 +1270,34 @@ class IrParser {
             }
           });
     }
+
+    {
+      auto ptr_op = getOperatorForLiteral(
+          "aten::gelu_backward(Tensor grad, Tensor self) -> Tensor");
+      registerParseRule(
+          ptr_op,
+          [](const Node* node,
+             std::unordered_map<size_t, CgValue>& value_map) -> void {
+            auto grad = value_map[node->inputs()[0]->unique()];
+            auto self = value_map[node->inputs()[1]->unique()];
+
+            constexpr double kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
+
+            auto cdf_1 = mul(self, new Double(M_SQRT1_2)); 
+            auto cdf_2 = unaryOp(UnaryOpType::Erf, cdf_1); 
+            auto cdf_3 = add(cdf_2, new Double(1.)); 
+            auto cdf_4 = mul(cdf_3, new Double(0.5));
+
+            auto pdf_1 = mul(self, self);
+            auto pdf_2 = mul(pdf_1, new Double(-0.5));
+            auto pdf_3 = unaryOp(UnaryOpType::Exp, pdf_2);
+
+            auto out_1 = addcmul(cdf_4, self, pdf_3, new Double(kAlpha)); 
+            auto out_2 = mul(out_1, grad);
+
+            value_map.emplace(node->output()->unique(), out_2);
+          });
+    }
   }
 
   void processJitNode(const JitOp* node) {

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -1282,14 +1282,15 @@ class IrParser {
             auto self = value_map[node->inputs()[1]->unique()];
 
             constexpr double kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
+            const double kHalf = 0.5;
 
             auto cdf_1 = mul(self, new Double(M_SQRT1_2));
             auto cdf_2 = unaryOp(UnaryOpType::Erf, cdf_1);
             auto cdf_3 = add(cdf_2, new Double(1.));
-            auto cdf_4 = mul(cdf_3, new Double(0.5));
+            auto cdf_4 = mul(cdf_3, new Double(kHalf));
 
             auto pdf_1 = mul(self, self);
-            auto pdf_2 = mul(pdf_1, new Double(-0.5));
+            auto pdf_2 = mul(pdf_1, new Double(-kHalf));
             auto pdf_3 = unaryOp(UnaryOpType::Exp, pdf_2);
 
             auto out_1 = addcmul(cdf_4, self, pdf_3, new Double(kAlpha));

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -1283,9 +1283,9 @@ class IrParser {
 
             constexpr double kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
 
-            auto cdf_1 = mul(self, new Double(M_SQRT1_2)); 
-            auto cdf_2 = unaryOp(UnaryOpType::Erf, cdf_1); 
-            auto cdf_3 = add(cdf_2, new Double(1.)); 
+            auto cdf_1 = mul(self, new Double(M_SQRT1_2));
+            auto cdf_2 = unaryOp(UnaryOpType::Erf, cdf_1);
+            auto cdf_3 = add(cdf_2, new Double(1.));
             auto cdf_4 = mul(cdf_3, new Double(0.5));
 
             auto pdf_1 = mul(self, self);

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -1292,7 +1292,7 @@ class IrParser {
             auto pdf_2 = mul(pdf_1, new Double(-0.5));
             auto pdf_3 = unaryOp(UnaryOpType::Exp, pdf_2);
 
-            auto out_1 = addcmul(cdf_4, self, pdf_3, new Double(kAlpha)); 
+            auto out_1 = addcmul(cdf_4, self, pdf_3, new Double(kAlpha));
             auto out_2 = mul(out_1, grad);
 
             value_map.emplace(node->output()->unique(), out_2);

--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -83,6 +83,7 @@ class NaiveTypePropagator {
       case aten::threshold:
       case aten::clamp:
       case aten::gelu:
+      case aten::gelu_backward:
       case aten::tanh: {
         TORCH_CHECK(
             hasTypeAndDim(node->input(0)->type()->cast<TensorType>()),

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -805,6 +805,12 @@ const std::vector<std::string> functions = {
 
             return result, backward
 
+        def gelu(self):
+            result = torch.gelu(self)
+            def backward(grad_output):
+                return torch.gelu_backward(grad_output, self)
+            return result, backward
+
         # Share backward with threshold
         def relu(self):
             result = torch.relu(self)


### PR DESCRIPTION
* Added a parsing function for Gelu Backwards plus a training test.
* Increase kernel cache entries from 10 to 100
* Remove check for `require_grad` from `complyWith` function used in the FusionGuard.  This fixes FusionGuard failures on backward pass.