### PR TITLE
Scoping kir::Expr

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -11771,6 +11771,142 @@ TEST(NVFuserTest, FusionKirScoping_CUDA) {
   TORCH_CHECK(top_level_scope == nullptr);
 }
 
+TEST(NVFuserTest, FusionOmitPredicate1_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  const int x = 128;
+
+  auto tv0 = makeConcreteTensor({x});
+  fusion.addInput(tv0);
+  auto tv1 = makeSymbolicTensor(3);
+  fusion.addInput(tv1);
+
+  auto tv2 = add(tv0, new Double(1));
+  auto tv3 = add(tv2, new Double(1));
+  auto tv4 = add(tv3, new Double(1));
+  auto tv5 = add(tv4, new Double(1));
+  auto tv6 = add(tv5, new Double(1));
+  auto tv7 = add(tv6, new Double(1));
+  fusion.addOutput(tv7);
+
+  auto tv8 = add(tv1, new Double(1));
+  auto tv9 = add(tv8, new Double(1));
+  fusion.addOutput(tv9);
+
+  tv8->setMemoryType(MemoryType::Global);
+
+  // No predicate needed with evenly divisible split
+  tv3->split(0, 32);
+  // Predicate needed with non-divisible split
+  tv4->split(0, 31);
+  // All split ops are divisible, so no predicate needed
+  tv5->split(0, 32);
+  tv5->split(0, 2);
+  tv5->split(-1, 16);
+  // Merge does not prevent predicate omission
+  tv6->split(0, 32);
+  tv6->merge(0);
+  // If any of split is not divisible, predicate needed
+  tv7->split(0, 32);
+  tv7->split(0, 8);
+
+  // Predicate needed with split of dynamic sizes
+  tv8->split(0, 32);
+
+  // Predicate is not needed with no split of dynamic sizes
+  tv9->merge(0)->merge(0);
+
+  GpuLower gpulw(&fusion);
+
+  auto is_predicated = [&](TensorView* tv) {
+    return gpulw.lowerValue(tv)
+        ->definition()
+        ->parentScope()
+        ->isA<kir::IfThenElse>();
+  };
+
+  TORCH_CHECK(!is_predicated(tv2));
+  TORCH_CHECK(!is_predicated(tv3));
+  TORCH_CHECK(is_predicated(tv4));
+  TORCH_CHECK(!is_predicated(tv5));
+  TORCH_CHECK(!is_predicated(tv6));
+  TORCH_CHECK(is_predicated(tv7));
+  TORCH_CHECK(is_predicated(tv8));
+  TORCH_CHECK(!is_predicated(tv9));
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({x}, options);
+  at::Tensor t1 = at::randn({x, x, x}, options);
+  std::vector<IValue> aten_inputs = {t0, t1};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  auto t7 = t0 + 6;
+  auto t9 = t1 + 2;
+
+  testValidate(&fusion, cg_outputs, aten_inputs, {t7, t9}, __LINE__, __FILE__);
+}
+
+TEST(NVFuserTest, FusionOmitPredicate2_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(1);
+  fusion.addInput(tv0);
+  auto tv1 = makeSymbolicTensor(2);
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv0, {true, false});
+  auto tv3 = add(tv2, tv1);
+  fusion.addOutput(tv3);
+
+  auto tv4 = broadcast(tv0, {true, false});
+  auto tv5 = add(tv4, tv1);
+  fusion.addOutput(tv5);
+
+  // Both tv2 and tv3 should not need predicate
+  tv3->merge(0);
+  tv2->computeAt(tv3, -1);
+
+  // Both tv4 and tv5 should need predicate as we don't know whether
+  // split by 4 is divisible
+  tv5->merge(0);
+  tv5->split(0, 4);
+  tv4->computeAt(tv5, -1);
+
+  GpuLower gpulw(&fusion);
+
+  auto is_predicated = [&](TensorView* tv) {
+    return gpulw.lowerValue(tv)
+        ->definition()
+        ->parentScope()
+        ->isA<kir::IfThenElse>();
+  };
+
+  TORCH_CHECK(!is_predicated(tv2));
+  TORCH_CHECK(!is_predicated(tv3));
+  TORCH_CHECK(is_predicated(tv4));
+  TORCH_CHECK(is_predicated(tv5));
+
+  const int x = 10;
+  const int y = 20;
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({x}, options);
+  at::Tensor t1 = at::randn({y, x}, options);
+  std::vector<IValue> aten_inputs = {t0, t1};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  auto t3 = t0 + t1;
+
+  testValidate(&fusion, cg_outputs, aten_inputs, {t3, t3}, __LINE__, __FILE__);
+}
+
 } // namespace jit
 } // namespace torch
 

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.h
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.h
@@ -32,12 +32,11 @@ class TORCH_CUDA_CU_API ExpressionEvaluator : private OptOutDispatch {
   //! Debugging helper, prints all the currently known values
   void print() const;
 
- protected:
+ private:
   c10::optional<Int::ScalarType> getValue(Val* value);
 
-  using OptOutDispatch::handle;
-  void handle(UnaryOp*) override;
-  void handle(BinaryOp*) override;
+  void handle(UnaryOp*) override final;
+  void handle(BinaryOp*) override final;
 
  private:
   std::unordered_map<const Val*, Int::ScalarType> known_values_;

--- a/torch/csrc/jit/codegen/cuda/expr_evaluator.h
+++ b/torch/csrc/jit/codegen/cuda/expr_evaluator.h
@@ -32,11 +32,12 @@ class TORCH_CUDA_CU_API ExpressionEvaluator : private OptOutDispatch {
   //! Debugging helper, prints all the currently known values
   void print() const;
 
- private:
+ protected:
   c10::optional<Int::ScalarType> getValue(Val* value);
 
-  void handle(UnaryOp*) final;
-  void handle(BinaryOp*) final;
+  using OptOutDispatch::handle;
+  void handle(UnaryOp*) override;
+  void handle(BinaryOp*) override;
 
  private:
   std::unordered_map<const Val*, Int::ScalarType> known_values_;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -347,9 +347,11 @@ void Scope::insert(size_t pos, Expr* expr) {
 void Scope::erase(std::vector<Expr*>::const_iterator pos) {
   // Remove the scope of the expr if this is the scope
   auto expr = *pos;
-  if (expr->scope() == this) {
-    expr->removeScope();
-  }
+  TORCH_INTERNAL_ASSERT(
+      expr->scope() == this,
+      "Inconsistent scoping of expression detected: ",
+      kir::toString(expr));
+  expr->removeScope();
   exprs_.erase(pos);
 }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -26,9 +26,12 @@ Val::Val(Passkey passkey, DataType dtype) : Node(passkey), dtype_(dtype) {
   id_ = passkey.kernel->newValueId(passkey);
 }
 
-void Expr::setParentScope(Expr* scope) {
-  // TODO(kir): checks to make sure the scope lists are consistent
-  parent_scope_ = scope;
+Expr* Expr::parentScope() const {
+  if (scope()) {
+    return scope()->owner();
+  } else {
+    return nullptr;
+  }
 }
 
 NamedScalar* NamedScalar::getParallelDim(ParallelType p_type) {
@@ -307,6 +310,11 @@ TensorIndex::TensorIndex(
 Sync::Sync(Passkey passkey, bool war_sync)
     : Expr(passkey), war_sync_(war_sync) {}
 
+void Scope::insert(std::vector<Expr*>::const_iterator pos, Expr* expr) {
+  exprs_.insert(pos, expr);
+  expr->setScope(this);
+}
+
 void Scope::insert_before(Expr* ref, Expr* expr) {
   const auto it = std::find(exprs_.begin(), exprs_.end(), ref);
   TORCH_INTERNAL_ASSERT(
@@ -316,7 +324,7 @@ void Scope::insert_before(Expr* ref, Expr* expr) {
       " before the reference: ",
       ref,
       " however the reference was not found in this scope.");
-  exprs_.insert(it, expr);
+  insert(it, expr);
 }
 
 void Scope::insert_after(Expr* ref, Expr* expr) {
@@ -328,14 +336,33 @@ void Scope::insert_after(Expr* ref, Expr* expr) {
       " after the reference: ",
       ref,
       " however the reference was not found in this scope.");
-  exprs_.insert(it + 1, expr);
+  insert(it + 1, expr);
+}
+
+void Scope::insert(size_t pos, Expr* expr) {
+  const auto it = exprs_.begin() + pos;
+  insert(it, expr);
+}
+
+void Scope::erase(std::vector<Expr*>::const_iterator pos) {
+  // Remove the scope of the expr if this is the scope
+  auto expr = *pos;
+  if (expr->scope() == this) {
+    expr->removeScope();
+  }
+  exprs_.erase(pos);
 }
 
 void Scope::erase(Expr* ref) {
   const auto it = std::find(exprs_.begin(), exprs_.end(), ref);
   if (it != exprs_.end()) {
-    exprs_.erase(it);
+    erase(it);
   }
+}
+
+void Scope::erase(size_t pos) {
+  TORCH_INTERNAL_ASSERT(pos < size());
+  erase(exprs_.begin() + pos);
 }
 
 bool Scope::contains(Expr* expr) const {
@@ -347,21 +374,15 @@ void Scope::clear() {
   exprs_.clear();
 }
 
-ForLoop::ForLoop(
-    Passkey passkey,
-    Val* index,
-    IterDomain* iter_domain,
-    Expr* parent_scope)
-    : Expr(passkey), index_{index}, iter_domain_{iter_domain} {
+ForLoop::ForLoop(Passkey passkey, Val* index, IterDomain* iter_domain)
+    : Expr(passkey), index_{index}, iter_domain_{iter_domain}, body_(this) {
   TORCH_INTERNAL_ASSERT(index->dtype() == DataType::Int);
-  setParentScope(parent_scope);
   addInput(index);
   addInput(iter_domain);
 }
 
-IfThenElse::IfThenElse(Passkey passkey, Bool* cond, Expr* parent_scope)
-    : Expr(passkey), cond_{cond} {
-  setParentScope(parent_scope);
+IfThenElse::IfThenElse(Passkey passkey, Bool* cond)
+    : Expr(passkey), cond_{cond}, then_body_(this), else_body_(this) {
   addInput(cond);
 }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -351,7 +351,7 @@ void Scope::erase(std::vector<Expr*>::const_iterator pos) {
       expr->scope() == this,
       "Inconsistent scoping of expression detected: ",
       kir::toString(expr));
-  expr->removeScope();
+  expr->setScope(nullptr);
   exprs_.erase(pos);
 }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -1033,7 +1033,7 @@ class TORCH_CUDA_CU_API Sync final : public Expr {
 // TODO(kir): promote to IR node
 class TORCH_CUDA_CU_API Scope {
  public:
-  Scope(Expr* owner) : owner_(owner) {}
+  explicit Scope(Expr* owner) : owner_(owner) {}
 
   const std::vector<Expr*>& exprs() const {
     return exprs_;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -55,6 +55,9 @@ class ForLoop;
 class IfThenElse;
 class GridReduction;
 
+// Expr container
+class Scope;
+
 using ValueId = int32_t;
 
 //! Token used to restrict the access to Kernel IR creation
@@ -308,13 +311,19 @@ class TORCH_CUDA_CU_API Expr : public Node {
     return outputs_;
   }
 
-  
-
-  Expr* parentScope() const {
-    return parent_scope_;
+  Scope* scope() const {
+    return scope_;
   }
 
-  void setParentScope(Expr* scope);
+  void setScope(Scope* scope) {
+    scope_ = scope;
+  }
+
+  void removeScope() {
+    scope_ = nullptr;
+  }
+
+  Expr* parentScope() const;
 
   Bool* predicate() const {
     return predicate_;
@@ -341,7 +350,7 @@ class TORCH_CUDA_CU_API Expr : public Node {
   std::vector<Val*> outputs_;
 
   // TODO(kir): revisit scope/nesting data structures
-  Expr* parent_scope_ = nullptr;
+  Scope* scope_ = nullptr;
 
   Bool* predicate_ = nullptr;
 };
@@ -1027,22 +1036,10 @@ class TORCH_CUDA_CU_API Sync final : public Expr {
 // TODO(kir): promote to IR node
 class TORCH_CUDA_CU_API Scope {
  public:
-  Scope() = default;
+  Scope(Expr* owner) : owner_(owner) {}
 
   const std::vector<Expr*>& exprs() const {
     return exprs_;
-  }
-
-  void push_back(Expr* e) {
-    exprs_.push_back(e);
-  }
-
-  void insert(size_t pos, Expr* expr) {
-    exprs_.insert(exprs_.begin() + pos, expr);
-  }
-
-  void erase(size_t pos) {
-    exprs_.erase(exprs_.begin() + pos);
   }
 
   bool empty() const {
@@ -1061,20 +1058,45 @@ class TORCH_CUDA_CU_API Scope {
     return exprs_[i];
   }
 
+  // Insert expr before expression at pos
+  void insert(size_t pos, Expr* expr);
+
   // Insert expr before ref
   void insert_before(Expr* ref, Expr* expr);
 
   // Insert expr after ref
   void insert_after(Expr* ref, Expr* expr);
 
-  bool contains(Expr* expr) const;
+  void push_back(Expr* e) {
+    exprs_.push_back(e);
+    e->setScope(this);
+  }
 
+  // Erase expr at pos
+  void erase(size_t pos);
+
+  // Erase expr ref
   void erase(Expr* ref);
+
+  bool contains(Expr* expr) const;
 
   void clear();
 
+  Expr* owner() const {
+    return owner_;
+  }
+
+ private:
+  // Insert expr before pos
+  void insert(std::vector<Expr*>::const_iterator pos, Expr* expr);
+
+  // Erase expr at pos
+  void erase(std::vector<Expr*>::const_iterator pos);
+
  private:
   std::vector<Expr*> exprs_;
+  //! Owner exprssion of this scope, e.g., IfThenElse
+  Expr* owner_ = nullptr;
 };
 
 //! ForLoop provides scoping around an int iterator from 0 to range. Exprs
@@ -1086,11 +1108,7 @@ class TORCH_CUDA_CU_API Scope {
 //!
 class TORCH_CUDA_CU_API ForLoop final : public Expr {
  public:
-  ForLoop(
-      Passkey passkey,
-      Val* index,
-      IterDomain* iter_domain,
-      Expr* parent_scope);
+  ForLoop(Passkey passkey, Val* index, IterDomain* iter_domain);
 
   void accept(IrVisitor* visitor) const override {
     visitor->visit(this);
@@ -1131,7 +1149,7 @@ class TORCH_CUDA_CU_API ForLoop final : public Expr {
 //!
 class TORCH_CUDA_CU_API IfThenElse final : public Expr {
  public:
-  explicit IfThenElse(Passkey passkey, Bool* cond, Expr* parent_scope);
+  explicit IfThenElse(Passkey passkey, Bool* cond);
 
   void accept(IrVisitor* visitor) const override {
     visitor->visit(this);

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -308,6 +308,8 @@ class TORCH_CUDA_CU_API Expr : public Node {
     return outputs_;
   }
 
+  
+
   Expr* parentScope() const {
     return parent_scope_;
   }

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -1092,6 +1092,7 @@ class TORCH_CUDA_CU_API Scope {
 
  private:
   std::vector<Expr*> exprs_;
+
   //! Owner exprssion of this scope, e.g., IfThenElse
   Expr* owner_ = nullptr;
 };

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -315,12 +315,9 @@ class TORCH_CUDA_CU_API Expr : public Node {
     return scope_;
   }
 
+  //! Set the current scope
   void setScope(Scope* scope) {
     scope_ = scope;
-  }
-
-  void removeScope() {
-    scope_ = nullptr;
   }
 
   Expr* parentScope() const;

--- a/torch/csrc/jit/codegen/cuda/lower_allocation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_allocation.cpp
@@ -131,14 +131,11 @@ class AllocationInserter : public kir::MutableIrVisitor {
         std::stringstream ss;
         ss << id->parallelType();
         new_loop = ir_builder.create<kir::ForLoop>(
-            ir_builder.create<kir::NamedScalar>(ss.str(), DataType::Int),
-            id,
-            nullptr);
+            ir_builder.create<kir::NamedScalar>(ss.str(), DataType::Int), id);
       } else {
         new_loop = ir_builder.create<kir::ForLoop>(
-            ir_builder.create<kir::Int>(c10::nullopt), id, nullptr);
+            ir_builder.create<kir::Int>(c10::nullopt), id);
       }
-      init_expr->setParentScope(new_loop);
       new_loop->body().push_back(init_expr);
       init_expr = new_loop;
     }
@@ -345,7 +342,6 @@ class AllocationInserter : public kir::MutableIrVisitor {
       } else {
         alloc.for_loop->body().insert_before(
             alloc.place_before, alloc.init_expr);
-        alloc.init_expr->setParentScope(alloc.for_loop);
       }
     }
   }

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -51,8 +51,7 @@ void IndexLowering::visit(const kir::IfThenElse* ite) {
   const auto prev_scope = active_scope_;
 
   // TODO(kir): try to avoid recreating new nodes and leaving old ones around
-  auto new_ite =
-      ir_builder_.create<kir::IfThenElse>(ite->cond(), prev_scope_expr);
+  auto new_ite = ir_builder_.create<kir::IfThenElse>(ite->cond());
   pushBack(new_ite);
 
   active_scope_expr_ = new_ite;
@@ -77,7 +76,7 @@ void IndexLowering::visit(const kir::ForLoop* for_loop) {
   const auto prev_scope = active_scope_;
 
   auto new_for_loop = ir_builder_.create<kir::ForLoop>(
-      for_loop->index(), for_loop->iter_domain(), prev_scope_expr);
+      for_loop->index(), for_loop->iter_domain());
   pushBack(new_for_loop);
 
   active_scope_expr_ = new_for_loop;

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -43,12 +43,10 @@ kir::ForLoop* openForHelper(kir::ForLoop* scope, IterDomain* id) {
     std::stringstream ss;
     ss << id->getParallelType();
     new_scope = ir_builder.create<kir::ForLoop>(
-        ir_builder.create<kir::NamedScalar>(ss.str(), DataType::Int),
-        kir_id,
-        scope);
+        ir_builder.create<kir::NamedScalar>(ss.str(), DataType::Int), kir_id);
   } else {
     new_scope = ir_builder.create<kir::ForLoop>(
-        ir_builder.create<kir::Int>(c10::nullopt), kir_id, scope);
+        ir_builder.create<kir::Int>(c10::nullopt), kir_id);
   }
   if (scope != nullptr) {
     scope->body().insert(0, new_scope);

--- a/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_unroll.cpp
@@ -89,7 +89,6 @@ void UnrollPass::handle(kir::Expr* expr) {
     if (!pred->isConst() || !(pred->isConst() && pred->value().value())) {
       non_trivial_pred_found_ = true;
       kir::IfThenElse* inline_ite = ir_builder.create<kir::IfThenElse>(pred);
-      inline_ite->thenBody().push_back(expr);
       if (for_loops_.empty()) {
         // Special handling for top level output expressions that still
         // need predicates. One motivating example is a reduction op that
@@ -99,6 +98,7 @@ void UnrollPass::handle(kir::Expr* expr) {
         for_loops_.back()->body().insert_before(expr, inline_ite);
         for_loops_.back()->body().erase(expr);
       }
+      inline_ite->thenBody().push_back(expr);
     }
   } else if (auto for_loop = dynamic_cast<kir::ForLoop*>(expr)) {
     handle(for_loop);

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/codegen/cuda/predicate_compute.h>
 
 #include <torch/csrc/jit/codegen/cuda/arith.h>
+#include <torch/csrc/jit/codegen/cuda/expr_evaluator.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/index_compute.h>
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
@@ -106,6 +107,82 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
   return preds;
 }
 
+namespace {
+
+//! Analyze whether IterDomain can be statically determined to be safe
+//! without bounds-checking predicates.
+class IterationDomainAnalysis : private ExpressionEvaluator {
+ public:
+  //! Return true if the expression defining tv can be safely run
+  //! without a predicate
+  static bool canOmitPredicate(const kir::TensorView* tv) {
+    const auto gpu_lower = GpuLower::current();
+    auto fuser_tv = tv->fuserTv();
+    for (size_t i = 0; i < fuser_tv->nDims(); ++i) {
+      IterDomain* id =
+          gpu_lower->caLoopMap().getConcreteMappedID(fuser_tv->axis(i));
+      IterationDomainAnalysis id_analysis(id->fusion());
+      auto extent = id->rawExtent();
+      id_analysis.evaluate(extent);
+      if (!id_analysis.isExact(extent)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  IterationDomainAnalysis(Fusion* fusion) : ExpressionEvaluator(fusion) {}
+
+  using ExpressionEvaluator::handle;
+
+  //! Check if val has nothing that prevents a loop using val as its
+  //! extent to omit a bounds-checking predicate
+  bool isExact(const Val* val) {
+    return val->definition() == nullptr ||
+        exact_vals_.find(val) != exact_vals_.end();
+  }
+
+  //! Record val does not need a predicate.
+  void setExact(const Val* val) {
+    exact_vals_.insert(val);
+  }
+
+  void handle(BinaryOp* bop) override {
+    ExpressionEvaluator::handle(bop);
+
+    const auto lhs = bop->lhs();
+    const auto rhs = bop->rhs();
+
+    if (!(isExact(lhs) && isExact(rhs))) {
+      return;
+    }
+
+    if (bop->getBinaryOpType() == BinaryOpType::CeilDiv) {
+      // CeilDiv is the only expression that can make an extent val
+      // larger than the actual. Need to know the exact values.
+      const auto lhs_value = getValue(lhs);
+      const auto rhs_value = getValue(rhs);
+      if (lhs_value.has_value() && rhs_value.has_value() &&
+          (lhs_value.value() % rhs_value.value()) == 0) {
+        setExact(bop->out());
+      }
+    } else if (bop->getBinaryOpType() == BinaryOpType::Mul) {
+      setExact(bop->out());
+    } else {
+      // Expr on extent should be either CeilDiv or Mul, which are
+      // derived from split and merge, respectively.
+      TORCH_INTERNAL_ASSERT("Unexpected BinaryOpType: ", bop);
+    }
+  }
+
+ private:
+  //! Vals that are known to need no predicate if used as IterDomain extent
+  std::unordered_set<const Val*> exact_vals_;
+};
+
+} // namespace
+
 kir::Bool* PredicateCompute::getInlinePredicate(
     const kir::Expr* expr,
     const std::vector<kir::ForLoop*>& loops,
@@ -163,6 +240,10 @@ kir::Bool* PredicateCompute::getInlinePredicate(
     if (!has_tv_inputs) {
       return ir_builder.create<kir::Bool>(true);
     }
+  }
+
+  if (IterationDomainAnalysis::canOmitPredicate(out_tv)) {
+    return thread_pred;
   }
 
   auto all_preds = PredicateCompute::computePredicates(

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -242,6 +242,8 @@ kir::Bool* PredicateCompute::getInlinePredicate(
     }
   }
 
+  // Don't generate predicates unless needed. This is just for
+  // potential performance benefit.
   if (IterationDomainAnalysis::canOmitPredicate(out_tv)) {
     return thread_pred;
   }


### PR DESCRIPTION
This PR adds `kir::Scope* scope_` field to `kir::Expr`. When an Expr is inserted into a Scope, the Expr gets its `scope_` field set to the scope.

Added also `kir::Expr* owner_` field to `kir::Scope` so as to allow traversing upward from an Expr to its containing IfThenElse/ForLoop exprs.

These would be useful for inspecting/modifying KIR.