### PR TITLE
Do not set output-to-output computeAt edges

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1502,7 +1502,9 @@ TEST(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
   TORCH_CHECK(tv3->getComputeAtView() == tv5 && tv3->nDims() == 3);
   TORCH_CHECK(tv4->hasComputeAt() && tv4->nDims() == 3);
   TORCH_CHECK(tv5->getComputeAtView() == tv6 && tv5->nDims() == 3);
-  TORCH_CHECK(tv6->getComputeAtView() == tv7 && tv6->nDims() == 3);
+  TORCH_CHECK(
+      !tv6->hasComputeAt() && tv6->getThisComputeAtAxis() == 1 &&
+      tv6->nDims() == 3);
   TORCH_CHECK(!tv7->hasComputeAt());
 
   for (Val* val : fusion.vals()) {
@@ -1840,7 +1842,7 @@ TEST(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
 
   // Note that tv2 is also computed at tv3.
   TORCH_CHECK(tv1->getComputeAtView() == computeAtTarget);
-  TORCH_CHECK(tv2->getComputeAtView() == tv3);
+  TORCH_CHECK(!tv2->hasComputeAt() && tv2->getThisComputeAtAxis() == 1);
   TORCH_CHECK(!tv3->hasComputeAt());
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
@@ -2089,10 +2091,8 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
   TORCH_CHECK(tv3->getComputeAtView() == tv5);
   TORCH_CHECK(tv4->getComputeAtView() == tv5);
 
-  // tv5 should be computed at tv6 since tv5 is added as an output
-  // before tv6. If we call fusion.addOutput(tv6) first, tv6 should be
-  // computed at tv5.
-  TORCH_CHECK(tv5->getComputeAtView() == tv6);
+  // Output tensors should not have computeAt
+  TORCH_CHECK(!tv5->hasComputeAt() && tv5->getThisComputeAtAxis() == 1);
   TORCH_CHECK(!tv6->hasComputeAt());
 
   for (Val* val : fusion.vals()) {
@@ -2167,7 +2167,7 @@ TEST(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
   TORCH_CHECK(tv2->getComputeAtView() == tv4);
   TORCH_CHECK(tv3->getComputeAtView() == tv4);
   TORCH_CHECK(tv4->getComputeAtView() == tv5);
-  TORCH_CHECK(tv5->getComputeAtView() == tv6);
+  TORCH_CHECK(!tv5->hasComputeAt() && tv5->getThisComputeAtAxis() == 1);
   TORCH_CHECK(!tv6->hasComputeAt());
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
@@ -11110,7 +11110,9 @@ TEST(NVFuserTest, FusionAdvancedComputeAtTransposed1_CUDA) {
   TORCH_CHECK(tv3->getComputeAtView() == tv5 && tv3->nDims() == 3);
   TORCH_CHECK(tv4->hasComputeAt() && tv4->nDims() == 3);
   TORCH_CHECK(tv5->getComputeAtView() == tv6 && tv5->nDims() == 3);
-  TORCH_CHECK(tv6->getComputeAtView() == tv7 && tv6->nDims() == 3);
+  TORCH_CHECK(
+      !tv6->hasComputeAt() && tv6->getThisComputeAtAxis() == 1 &&
+      tv6->nDims() == 3);
   TORCH_CHECK(!tv7->hasComputeAt());
 
   for (Val* val : fusion.vals()) {

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -471,9 +471,7 @@ void ComputeAt::setupOutputs() {
   if (touched_output_order.size() > 0) {
     for (size_t i = 0; i < touched_output_order.size() - 1; i++) {
       touched_output_order[i]->setComputeAt(
-          touched_output_order[i + 1],
-          (int)tv_data.at(touched_output_order[i]).getNewPosition(),
-          (int)tv_data.at(touched_output_order[i + 1]).getNewPosition());
+          (int)tv_data.at(touched_output_order[i]).getNewPosition());
     }
   }
 }

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -341,6 +341,8 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   // computeAt with outputs relative to eachother
   void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
 
+  void setComputeAt(int thisPos);
+
  private:
   int normalizeAxisPos(int pos) const {
     if (pos < 0) {

--- a/torch/csrc/jit/codegen/cuda/lower_compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_compute_at_map.cpp
@@ -520,11 +520,16 @@ std::string ComputeAtMap::toString() {
 
   for (const auto& disjoint_set : disjoint_sets) {
     ss << "  disjoint_set{ ";
+    TORCH_INTERNAL_ASSERT(disjoint_set->size() > 0);
+    auto concrete_id = concrete_id_map_.at(disjoint_set->front());
     for (auto it = disjoint_set->begin(); it != disjoint_set->end(); it++) {
       if (it != disjoint_set->begin()) {
         ss << ", ";
       }
       ss << (*it);
+      if (*it == concrete_id) {
+        ss << "*";
+      }
     }
     ss << " }";
     if (mapping_mode_ == MappingMode::PARALLEL) {


### PR DESCRIPTION
This is a follow-up PR to the lowering refactor PR that's recently merged. No longer terminating outputs needs to be (synthetically) computed at another terminating outputs.

Additionally, refactored the loop-nest gen logic. It was originally needed during this refactoring. Although it should not be necessary now, I believe it's a little cleaner.