### PR TITLE
Remove getComputeAtAxis and getComputeAtPos

### DIFF
--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -207,17 +207,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   // Return position in compute_at_view that lines up with this->axis(pos)?
   int getComputeAtRelPos(int pos) const;
 
-  // Will check if an axis is inside computeAtAxis and will fetch the reference
-  // to be used in code generation.
-  std::pair<int, const TensorView*> getComputeAtPos(int pos) const {
-    pos = normalizeAxisPos(pos);
-    TORCH_INTERNAL_ASSERT(
-        nDims() > 0, "Tried to access a computeAt axis in a 0-dim TensorView");
-    if (!hasComputeAt() || getThisComputeAtAxis() <= (unsigned int)pos)
-      return std::make_pair(pos, this);
-    return compute_at_view_->getComputeAtPos(getComputeAtRelPos(pos));
-  }
-
   // Compute this TensorView relative to another tensor at axis
   TensorView* computeAt(TensorView* consumer, int axis);
 

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -218,12 +218,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     return compute_at_view_->getComputeAtPos(getComputeAtRelPos(pos));
   }
 
-  std::pair<IterDomain*, const TensorView*> getComputeAtAxis(int pos) const {
-    const auto computeAtPos = getComputeAtPos(pos);
-    return std::make_pair(
-        computeAtPos.second->axis(computeAtPos.first), computeAtPos.second);
-  }
-
   // Compute this TensorView relative to another tensor at axis
   TensorView* computeAt(TensorView* consumer, int axis);
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -106,9 +106,6 @@ void GpuLower::lower() {
   validateIr(fusion_);
   replaceSymbolicSizes();
 
-  // Compute thread predicates
-  ThreadPredicateMap preds(fusion_);
-
   // In the future we may directly use this map, but for now it will propagate
   // and validate (to some extent) the parallelization strategy.
   // This is the first time nodes will be lowered to kir nodes. Since for now we
@@ -124,6 +121,9 @@ void GpuLower::lower() {
   // Generate mappings to generate and map to loop nests
   ca_loop_map_ = ComputeAtMap(ComputeAtMap::MappingMode::LOOP);
   ca_loop_map_.build();
+
+  // Compute thread predicates
+  ThreadPredicateMap preds(fusion_);
 
   // Set the kernel inputs & outputs
   for (auto input : fusion_->inputs()) {

--- a/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
@@ -102,10 +102,11 @@ void maskSouceMap(
 ParallelTypeBitmap avoidRedundantWritesToSmem(
     const TensorView* out_tv,
     const ParallelTypeBitmap& pred) {
+  const auto& ca_map = GpuLower::current()->caParallelMap();
   auto new_pred = pred;
   if (out_tv->getMemoryType() == MemoryType::Shared) {
     for (size_t i = 0; i < out_tv->nDims(); i++) {
-      auto id = out_tv->getComputeAtAxis(i).first;
+      auto id = ca_map.getConcreteMappedID(out_tv->axis(i));
       if (out_tv->axis(i)->isBroadcast() && id->isThreadDim()) {
         new_pred.set(id->getParallelType(), true);
       }

--- a/torch/csrc/jit/codegen/cuda/lower_validation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_validation.cpp
@@ -31,41 +31,30 @@ void validateIr(Fusion* fusion) {
   fusion->validateInputs();
 
   for (auto tv : used_tvs) {
-    for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
-      IterDomain* id = tv->getComputeAtAxis(i).first;
+    if (tv->hasBroadcast() && tv->getMemoryType() != MemoryType::Global) {
+      auto td = tv->domain()->domain();
+      auto ca_inputs = ir_utils::iterDomainInputsOf(
+          {td.begin(), td.begin() + tv->getThisComputeAtAxis()});
+      auto non_ca_inputs = ir_utils::iterDomainInputsOf(
+          {td.begin() + tv->getThisComputeAtAxis(), td.end()});
 
-      if (id->isBlockDim()) {
-        TORCH_CHECK(
-            !id->isBroadcast(),
-            "Parallelization across blocks on broadcast axes is not supported, but found on, ",
-            tv,
-            ".");
-      }
-      if (tv->hasBroadcast() && tv->getMemoryType() != MemoryType::Global) {
-        auto td = tv->domain()->domain();
-        auto ca_inputs = ir_utils::iterDomainInputsOf(
-            {td.begin(), td.begin() + tv->getThisComputeAtAxis()});
-        auto non_ca_inputs = ir_utils::iterDomainInputsOf(
-            {td.begin() + tv->getThisComputeAtAxis(), td.end()});
+      std::unordered_set<IterDomain*> ca_inputs_set(
+          ca_inputs.begin(), ca_inputs.end());
+      std::unordered_set<IterDomain*> non_ca_inputs_set(
+          non_ca_inputs.begin(), non_ca_inputs.end());
 
-        std::unordered_set<IterDomain*> ca_inputs_set(
-            ca_inputs.begin(), ca_inputs.end());
-        std::unordered_set<IterDomain*> non_ca_inputs_set(
-            non_ca_inputs.begin(), non_ca_inputs.end());
-
-        for (auto id : tv->getRootDomain()) {
-          if (id->isBroadcast()) {
-            // If a broadcast dimension is an input to both an axis within the
-            // computeAt point and outside the compute at point we would have to
-            // look at consumers to figure out what that axis will be
-            // broadcasted to, because we would have to generate everything the
-            // consumer could need on that axis. This could be supported but is
-            // not at this point.
-            TORCH_INTERNAL_ASSERT(
-                !(ca_inputs_set.find(id) != ca_inputs_set.end() &&
-                  non_ca_inputs_set.find(id) != non_ca_inputs_set.end()),
-                "Cannot generate a kernel where a root broadcast dimension is input to both IterDomains outside and within the computeAt point.");
-          }
+      for (auto id : tv->getRootDomain()) {
+        if (id->isBroadcast()) {
+          // If a broadcast dimension is an input to both an axis within the
+          // computeAt point and outside the compute at point we would have to
+          // look at consumers to figure out what that axis will be
+          // broadcasted to, because we would have to generate everything the
+          // consumer could need on that axis. This could be supported but is
+          // not at this point.
+          TORCH_INTERNAL_ASSERT(
+              !(ca_inputs_set.find(id) != ca_inputs_set.end() &&
+                non_ca_inputs_set.find(id) != non_ca_inputs_set.end()),
+              "Cannot generate a kernel where a root broadcast dimension is input to both IterDomains outside and within the computeAt point.");
         }
       }
     }


### PR DESCRIPTION
Partially addresses #641 

`TensorView::getComputeAtAxis` and `TensorView::getComputeAtPos` are removed. Other obsolete functions will be removed in a follow-up PR.