### PR TITLE
TensorView cleanup

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -5737,7 +5737,7 @@ TEST(NVFuserTest, FusionReductionMultiConsumer_CUDA) {
 
   TORCH_CHECK(
       (tv1->getComputeAtView() == tv2 || tv1->getComputeAtView() == tv3) &&
-      tv1->getThisComputeAtAxis() == 2 && tv1->getRelativeComputeAtAxis() == 2);
+      tv1->getThisComputeAtAxis() == 2);
 }
 
 TEST(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
@@ -10166,7 +10166,6 @@ TEST(NVFuserTest, FusionIssue477_CUDA) {
   tv0->computeAt(tv4, -3);
 
   TORCH_CHECK(tv1->getThisComputeAtAxis() == 1);
-  TORCH_CHECK(tv1->getRelativeComputeAtAxis() == 2);
 }
 
 TEST(NVFuserTest, FusionIssue484_CUDA) {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1499,15 +1499,12 @@ TEST(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
 
   tv0->computeAt(tv7, 1);
 
-  TORCH_CHECK(tv1->hasComputeAt() && tv1->nDims() == 3);
-  TORCH_CHECK(tv2->getComputeAtView() == tv5 && tv2->nDims() == 3);
-  TORCH_CHECK(tv3->getComputeAtView() == tv5 && tv3->nDims() == 3);
-  TORCH_CHECK(tv4->hasComputeAt() && tv4->nDims() == 3);
-  TORCH_CHECK(tv5->getComputeAtView() == tv6 && tv5->nDims() == 3);
-  TORCH_CHECK(
-      !tv6->hasComputeAt() && tv6->getThisComputeAtAxis() == 1 &&
-      tv6->nDims() == 3);
-  TORCH_CHECK(!tv7->hasComputeAt());
+  // The this-position of the last tensor should be zero.
+  TORCH_CHECK(tv7->nDims() == 3 && tv7->getThisComputeAtAxis() == 0);
+  // The position of every other tensor should be 1.
+  for (auto tv : {tv1, tv2, tv3, tv4, tv5, tv6}) {
+    TORCH_CHECK(tv->nDims() == 3 && tv->getThisComputeAtAxis() == 1);
+  }
 
   for (Val* val : fusion.vals()) {
     if (!fusion.hasInput(val) &&
@@ -1843,9 +1840,9 @@ TEST(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
   }
 
   // Note that tv2 is also computed at tv3.
-  TORCH_CHECK(tv1->getComputeAtView() == computeAtTarget);
-  TORCH_CHECK(!tv2->hasComputeAt() && tv2->getThisComputeAtAxis() == 1);
-  TORCH_CHECK(!tv3->hasComputeAt());
+  TORCH_CHECK(tv1->getThisComputeAtAxis() == 1);
+  TORCH_CHECK(tv2->getThisComputeAtAxis() == 1);
+  TORCH_CHECK(tv3->getThisComputeAtAxis() == 0);
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
   for (auto tv : affected_tensors) {
@@ -1900,7 +1897,7 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
   // the common consumer of tv2 and tv3, so they are computed at
   // tv4. The indirect propagation of the computeAt should stop at the
   // common consumer, and no further change should occur. More
-  // specifically, tv4 and tv5 should not have a computeAt tensor.
+  // specifically, the computeAT position of tv4 and tv5 should be zero.
   TensorView* computeAtTarget = tv3;
   computeAtTarget->split(0, 128);
   tv1->computeAt(computeAtTarget, 1);
@@ -1910,11 +1907,11 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
     TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
   }
 
-  TORCH_CHECK(tv1->getComputeAtView() == computeAtTarget);
-  TORCH_CHECK(tv2->getComputeAtView() == tv4);
-  TORCH_CHECK(tv3->getComputeAtView() == tv4);
-  TORCH_CHECK(!tv4->hasComputeAt());
-  TORCH_CHECK(!tv5->hasComputeAt());
+  TORCH_CHECK(tv1->getThisComputeAtAxis() == 1);
+  TORCH_CHECK(tv2->getThisComputeAtAxis() == 1);
+  TORCH_CHECK(tv3->getThisComputeAtAxis() == 1);
+  TORCH_CHECK(tv4->getThisComputeAtAxis() == 0);
+  TORCH_CHECK(tv5->getThisComputeAtAxis() == 0);
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
 
@@ -1994,19 +1991,15 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
     }
     TensorView* tv = val->as<TensorView>();
     TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    if (tv == tv5) {
+      TORCH_CHECK(tv->getThisComputeAtAxis() == 0);
+    } else {
+      TORCH_CHECK(tv->getThisComputeAtAxis() == 1);
+    }
   }
 
-  TORCH_CHECK(tv1->getComputeAtView() == tv2);
-  TORCH_CHECK(tv2->getComputeAtView() == tv3);
-  // tv3 and tv4 are computed at tv5
-  TORCH_CHECK(tv3->getComputeAtView() == tv5);
-  TORCH_CHECK(tv4->getComputeAtView() == tv5);
-  TORCH_CHECK(!tv5->hasComputeAt());
-
-  for (Val* val : fusion.vals()) {
-    if (!fusion.hasInput(val) &&
-        val->getValType().value() == ValType::TensorView) {
-      TensorView* tv = val->as<TensorView>();
+  for (auto tv : ir_utils::filterByType<TensorView>(fusion.vals())) {
+    if (!fusion.hasInput(tv)) {
       tv->axis(1)->parallelize(ParallelType::Unroll);
       tv->axis(-1)->parallelize(ParallelType::TIDx);
     }
@@ -2077,25 +2070,17 @@ TEST(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
   tv1->computeAt(computeAtTarget, 1);
 
   // All tensors should have the same dimenionality as the target
-  for (Val* val : fusion.vals()) {
-    if (fusion.hasInput(val) ||
-        val->getValType().value() != ValType::TensorView) {
+  for (auto tv : ir_utils::filterByType<TensorView>(fusion.vals())) {
+    if (fusion.hasInput(tv)) {
       continue;
     }
-    TensorView* tv = val->as<TensorView>();
     TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    if (tv == tv6) {
+      TORCH_CHECK(tv->getThisComputeAtAxis() == 0);
+    } else {
+      TORCH_CHECK(tv->getThisComputeAtAxis() == 1);
+    }
   }
-
-  TORCH_CHECK(tv1->getComputeAtView() == tv2);
-  TORCH_CHECK(tv2->getComputeAtView() == tv3);
-
-  // tv3 and tv4 are computed at tv5
-  TORCH_CHECK(tv3->getComputeAtView() == tv5);
-  TORCH_CHECK(tv4->getComputeAtView() == tv5);
-
-  // Output tensors should not have computeAt
-  TORCH_CHECK(!tv5->hasComputeAt() && tv5->getThisComputeAtAxis() == 1);
-  TORCH_CHECK(!tv6->hasComputeAt());
 
   for (Val* val : fusion.vals()) {
     if (!fusion.hasInput(val) &&
@@ -2163,14 +2148,12 @@ TEST(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
   TensorView* affected_tensors[] = {tv1, tv2, tv3, tv4, tv6};
   for (auto tv : affected_tensors) {
     TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    if (tv == tv6) {
+      TORCH_CHECK(tv->getThisComputeAtAxis() == 0);
+    } else {
+      TORCH_CHECK(tv->getThisComputeAtAxis() == 1);
+    }
   }
-
-  TORCH_CHECK(tv1->getComputeAtView() == computeAtTarget);
-  TORCH_CHECK(tv2->getComputeAtView() == tv4);
-  TORCH_CHECK(tv3->getComputeAtView() == tv4);
-  TORCH_CHECK(tv4->getComputeAtView() == tv5);
-  TORCH_CHECK(!tv5->hasComputeAt() && tv5->getThisComputeAtAxis() == 1);
-  TORCH_CHECK(!tv6->hasComputeAt());
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
 
@@ -5735,9 +5718,7 @@ TEST(NVFuserTest, FusionReductionMultiConsumer_CUDA) {
   fusion.addOutput(tv4);
   tv1->computeAt(tv2, -1);
 
-  TORCH_CHECK(
-      (tv1->getComputeAtView() == tv2 || tv1->getComputeAtView() == tv3) &&
-      tv1->getThisComputeAtAxis() == 2);
+  TORCH_CHECK(tv1->getThisComputeAtAxis() == 2);
 }
 
 TEST(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
@@ -8458,9 +8439,8 @@ TEST(NVFuserTest, FusionComputeAtNonterminatingOutput_CUDA) {
 
   tv0->computeAt(tv2, -1);
 
-  TORCH_CHECK(
-      !(tv3->getComputeAtView() == tv4 && tv4->getComputeAtView() == tv3),
-      "ComputeAt cycle detected between tv3 and tv4");
+  TORCH_CHECK(tv3->hasComputeAt());
+  TORCH_CHECK(!tv4->hasComputeAt());
 
   const auto options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -10796,69 +10776,6 @@ __global__ void kernel1(
   TORCH_CHECK(in0.mean(dims).allclose(out_avg, /*rtol*/ 1e-5, /*atol*/ 1e-6));
 }
 
-TEST(NVFuserTest, FusionGetComputeAtRelPos_CUDA) {
-  {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
-
-    auto tv0 = makeSymbolicTensor(1);
-    auto tv1 = broadcast(tv0, {false, true});
-    auto tv2 = broadcast(tv1, {false, true, false});
-    fusion.addInput(tv0);
-    fusion.addOutput(tv2);
-
-    tv1->computeAt(tv2, -1);
-
-    TORCH_CHECK(tv1->getComputeAtRelPos(1) == 2);
-  }
-  {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
-
-    auto tv0 = makeSymbolicTensor(1);
-    auto tv1 = broadcast(tv0, {false, true});
-    auto tv2 = broadcast(tv1, {false, true, false});
-    fusion.addInput(tv0);
-    fusion.addOutput(tv2);
-
-    tv2->merge(1, 2);
-    tv1->computeAt(tv2, -1);
-
-    TORCH_CHECK(tv1->getComputeAtRelPos(1) == 1);
-  }
-  {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
-
-    auto tv0 = makeSymbolicTensor(1);
-    auto tv1 = broadcast(tv0, {false, true});
-    auto tv2 = broadcast(tv1, {false, true, false});
-    fusion.addInput(tv0);
-    fusion.addOutput(tv2);
-
-    tv2->merge(1, 2);
-    tv1->computeAt(tv2, -1);
-
-    TORCH_CHECK(tv1->getComputeAtRelPos(1) == 1);
-  }
-  {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
-
-    auto tv0 = makeSymbolicTensor(1);
-    auto tv1 = add(tv0, new Double(1));
-    auto tv2 = broadcast(tv1, {false, true});
-    auto tv3 = broadcast(tv1, {false, true});
-    fusion.addInput(tv0);
-    fusion.addOutput(tv2);
-    fusion.addOutput(tv3);
-
-    tv0->computeAt(tv3, -1);
-
-    TORCH_CHECK(tv1->getComputeAtRelPos(0) == 0);
-  }
-}
-
 TEST(NVFuserTest, FusionTranspose1_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
@@ -11107,15 +11024,12 @@ TEST(NVFuserTest, FusionAdvancedComputeAtTransposed1_CUDA) {
 
   tv0->computeAt(tv7, 1);
 
-  TORCH_CHECK(tv1->hasComputeAt() && tv1->nDims() == 3);
-  TORCH_CHECK(tv2->getComputeAtView() == tv5 && tv2->nDims() == 3);
-  TORCH_CHECK(tv3->getComputeAtView() == tv5 && tv3->nDims() == 3);
-  TORCH_CHECK(tv4->hasComputeAt() && tv4->nDims() == 3);
-  TORCH_CHECK(tv5->getComputeAtView() == tv6 && tv5->nDims() == 3);
-  TORCH_CHECK(
-      !tv6->hasComputeAt() && tv6->getThisComputeAtAxis() == 1 &&
-      tv6->nDims() == 3);
-  TORCH_CHECK(!tv7->hasComputeAt());
+  // The this-position of the last tensor should be zero.
+  TORCH_CHECK(tv7->nDims() == 3 && tv7->getThisComputeAtAxis() == 0);
+  // The position of every other tensor should be 1.
+  for (auto tv : {tv1, tv2, tv3, tv4, tv5, tv6}) {
+    TORCH_CHECK(tv->nDims() == 3 && tv->getThisComputeAtAxis() == 1);
+  }
 
   for (Val* val : fusion.vals()) {
     if (!fusion.hasInput(val) &&

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -235,8 +235,7 @@ unsigned int ComputeAt::backwardComputeAt_impl(
     TensorDomain* new_domain = replay.first;
     producer->setDomain(new_domain);
     root_map_.setAlias(current_domain, new_domain);
-    producer->setComputeAt(
-        consumer, (int)replay.second);
+    producer->setComputeAt(consumer, (int)replay.second);
     producer_entry.setComputeAtDomain(producer->domain());
   }
 

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -235,7 +235,7 @@ unsigned int ComputeAt::backwardComputeAt_impl(
     TensorDomain* new_domain = replay.first;
     producer->setDomain(new_domain);
     root_map_.setAlias(current_domain, new_domain);
-    producer->setComputeAt(consumer, (int)replay.second);
+    producer->setComputeAt(replay.second);
     producer_entry.setComputeAtDomain(producer->domain());
   }
 
@@ -266,7 +266,7 @@ unsigned int ComputeAt::forwardComputeAt_impl(
     if (producer_this_pos > producer_rel_pos) {
       producer_this_pos = producer_rel_pos;
     }
-    producer->setComputeAt(consumer, producer_this_pos);
+    producer->setComputeAt(producer_this_pos);
   }
 
   consumer_entry.setPassPosition(replay.second);

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -236,7 +236,7 @@ unsigned int ComputeAt::backwardComputeAt_impl(
     producer->setDomain(new_domain);
     root_map_.setAlias(current_domain, new_domain);
     producer->setComputeAt(
-        consumer, (int)replay.second, (int)consumer_compute_at_axis);
+        consumer, (int)replay.second);
     producer_entry.setComputeAtDomain(producer->domain());
   }
 
@@ -267,7 +267,7 @@ unsigned int ComputeAt::forwardComputeAt_impl(
     if (producer_this_pos > producer_rel_pos) {
       producer_this_pos = producer_rel_pos;
     }
-    producer->setComputeAt(consumer, producer_this_pos, producer_rel_pos);
+    producer->setComputeAt(consumer, producer_this_pos);
   }
 
   consumer_entry.setPassPosition(replay.second);

--- a/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_graphviz.cpp
@@ -365,13 +365,6 @@ void IrGraphGenerator::handle(const TensorView* tv) {
   graph_def_ << "    " << getid(tv) << " [label=\"" << label.str()
              << "\", shape=Mrecord, color=brown, " << style << "];\n";
 
-  if (const auto* compute_at_view = tv->getComputeAtView()) {
-    std::stringstream arc_style;
-    arc_style << "[color=red, style=dashed, label=\""
-              << "ComputeAt(" << tv->getRelativeComputeAtAxis() << ")\"]";
-    addArc(tv, compute_at_view, arc_style.str());
-  }
-
   tensor_views_.push_back(tv);
 }
 

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -199,9 +199,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     return this_compute_at_axis_;
   }
 
-  // Return position in compute_at_view that lines up with this->axis(pos)?
-  int getComputeAtRelPos(int pos) const;
-
   // Compute this TensorView relative to another tensor at axis
   TensorView* computeAt(TensorView* consumer, int axis);
 

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -199,11 +199,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     return this_compute_at_axis_;
   }
 
-  // Return compute at axis relative to compute at view
-  unsigned int getRelativeComputeAtAxis() const {
-    return relative_compute_at_axis_;
-  }
-
   // Return position in compute_at_view that lines up with this->axis(pos)?
   int getComputeAtRelPos(int pos) const;
 
@@ -212,7 +207,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   void clearComputeAt() {
     this_compute_at_axis_ = 0;
-    relative_compute_at_axis_ = 0;
     compute_at_view_ = nullptr;
   }
 
@@ -322,7 +316,9 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   // Set all computeAt members without checking any correctness. Useful for
   // computeAt with outputs relative to eachother
-  void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
+  //void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
+
+  void setComputeAt(TensorView* computeAtView, int thisPos);
 
   void setComputeAt(int thisPos);
 
@@ -352,8 +348,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
  private:
   TensorDomain* domain_ = nullptr;
   TensorView* compute_at_view_ = nullptr;
-  // compute at axis in compute at view
-  unsigned int relative_compute_at_axis_ = 0;
   unsigned int this_compute_at_axis_ = 0;
   MemoryType memory_type_ = MemoryType::Local;
   SwizzleType swizzle_type_ = SwizzleType::NoSwizzle;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -305,7 +305,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     domain_ = td;
   }
 
-  void setComputeAt(int thisPos);
+  void setComputeAt(unsigned int thisPos);
 
  private:
   int normalizeAxisPos(int pos) const {

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -182,14 +182,9 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   IterDomain* axis(int pos) const;
 
-  // Is there an active computeAt TensorView/Axis
+  // Does it share outer axes with other tensors?
   bool hasComputeAt() const {
-    return compute_at_view_ != nullptr;
-  }
-
-  // Return the TensorView we're computing at
-  TensorView* getComputeAtView() const {
-    return compute_at_view_;
+    return this_compute_at_axis_ > 0;
   }
 
   size_t nDims() const;
@@ -204,7 +199,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   void clearComputeAt() {
     this_compute_at_axis_ = 0;
-    compute_at_view_ = nullptr;
   }
 
   // Split "axis" into 2 axes
@@ -311,12 +305,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     domain_ = td;
   }
 
-  // Set all computeAt members without checking any correctness. Useful for
-  // computeAt with outputs relative to eachother
-  // void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
-
-  void setComputeAt(TensorView* computeAtView, int thisPos);
-
   void setComputeAt(int thisPos);
 
  private:
@@ -344,7 +332,6 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
  private:
   TensorDomain* domain_ = nullptr;
-  TensorView* compute_at_view_ = nullptr;
   unsigned int this_compute_at_axis_ = 0;
   MemoryType memory_type_ = MemoryType::Local;
   SwizzleType swizzle_type_ = SwizzleType::NoSwizzle;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -305,7 +305,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     domain_ = td;
   }
 
-  void setComputeAt(unsigned int thisPos);
+  void setComputeAt(unsigned int this_pos);
 
  private:
   int normalizeAxisPos(int pos) const {

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -316,7 +316,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   // Set all computeAt members without checking any correctness. Useful for
   // computeAt with outputs relative to eachother
-  //void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
+  // void setComputeAt(TensorView* computeAtView, int thisPos, int relPos);
 
   void setComputeAt(TensorView* computeAtView, int thisPos);
 

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -66,9 +66,9 @@ void IrPrinter::handle(const TensorView* tv) {
     os_ << "T" << tv->name();
     handle(tv->domain());
 
-    if (tv->getComputeAtView() != nullptr) {
+    if (tv->hasComputeAt()) {
       os_ << " compute_at( ";
-      os_ << "T" << tv->getComputeAtView()->name();
+      os_ << tv->getThisComputeAtAxis();
       os_ << " )";
     }
   }

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -69,7 +69,7 @@ void IrPrinter::handle(const TensorView* tv) {
     if (tv->getComputeAtView() != nullptr) {
       os_ << " compute_at( ";
       os_ << "T" << tv->getComputeAtView()->name();
-      os_ << ", " << tv->getRelativeComputeAtAxis() << " )";
+      os_ << " )";
     }
   }
 }

--- a/torch/csrc/jit/codegen/cuda/lower_compute_at_map.h
+++ b/torch/csrc/jit/codegen/cuda/lower_compute_at_map.h
@@ -11,7 +11,7 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-class ComputeAtMap {
+class TORCH_CUDA_CU_API ComputeAtMap {
  public:
   // There's three modes of these iter domain mappings. For indexing, for loop
   // nest mapping/generation, and to figure out the parallelization strategy.

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -55,9 +55,7 @@ Statement* OptOutMutator::mutate(TensorView* tv) {
       (tv->hasComputeAt() && !tv->getComputeAtView()->sameAs(computeAtView))) {
     TensorView* mutated_tv = new TensorView(td, tv->getDataType().value());
     if (tv->hasComputeAt()) {
-      mutated_tv->setComputeAt(
-          computeAtView,
-          (int)tv->getThisComputeAtAxis());
+      mutated_tv->setComputeAt(computeAtView, (int)tv->getThisComputeAtAxis());
     }
     registerMutation(tv, mutated_tv);
     return mutated_tv;

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -57,8 +57,7 @@ Statement* OptOutMutator::mutate(TensorView* tv) {
     if (tv->hasComputeAt()) {
       mutated_tv->setComputeAt(
           computeAtView,
-          (int)tv->getThisComputeAtAxis(),
-          (int)(tv->getRelativeComputeAtAxis()));
+          (int)tv->getThisComputeAtAxis());
     }
     registerMutation(tv, mutated_tv);
     return mutated_tv;

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -46,17 +46,8 @@ Statement* OptOutMutator::mutate(TensorDomain* td) {
 Statement* OptOutMutator::mutate(TensorView* tv) {
   TensorDomain* td = mutateAsVal(tv->domain())->as<TensorDomain>();
 
-  TensorView* computeAtView = nullptr;
-  if (tv->hasComputeAt()) {
-    computeAtView = mutateAsVal(tv->getComputeAtView())->as<TensorView>();
-  }
-
-  if (!tv->domain()->sameAs(td) ||
-      (tv->hasComputeAt() && !tv->getComputeAtView()->sameAs(computeAtView))) {
+  if (!tv->domain()->sameAs(td)) {
     TensorView* mutated_tv = new TensorView(td, tv->getDataType().value());
-    if (tv->hasComputeAt()) {
-      mutated_tv->setComputeAt(computeAtView, (int)tv->getThisComputeAtAxis());
-    }
     registerMutation(tv, mutated_tv);
     return mutated_tv;
   }

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -167,7 +167,7 @@ IterDomain* TensorView::axis(int pos) const {
   return domain()->axis(pos);
 }
 
-void TensorView::setComputeAt(int thisPos) {
+void TensorView::setComputeAt(unsigned int thisPos) {
   TORCH_INTERNAL_ASSERT(
       thisPos > 0 && (unsigned)thisPos <= nDims(),
       "Invalid this computeAt position for T",

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -167,14 +167,14 @@ IterDomain* TensorView::axis(int pos) const {
   return domain()->axis(pos);
 }
 
-void TensorView::setComputeAt(unsigned int thisPos) {
+void TensorView::setComputeAt(unsigned int this_pos) {
   TORCH_INTERNAL_ASSERT(
-      thisPos > 0 && (unsigned)thisPos <= nDims(),
+      this_pos > 0 && (unsigned)this_pos <= nDims(),
       "Invalid this computeAt position for T",
       name(),
       ": ",
-      thisPos);
-  this_compute_at_axis_ = thisPos;
+      this_pos);
+  this_compute_at_axis_ = this_pos;
 }
 
 TensorView* TensorView::computeAt(TensorView* consumer, int axis) {

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -398,7 +398,7 @@ namespace {
 // TensorView if it's determined to be useful more generally.
 int getMappedConsumerAxis(
     TensorView* producer_tv,
-    int producer_axis,
+    unsigned int producer_axis,
     TensorView* consumer_tv) {
   auto c2p_root_map =
       PairwiseRootDomainMap(producer_tv, consumer_tv)
@@ -542,7 +542,7 @@ TensorView* TensorView::cache_before() {
       size_t producer_pos =
           getMappedConsumerAxis(
               producer_of_producer,
-              producer_of_producer->getThisComputeAtAxis() - 1,
+              int(producer_of_producer->getThisComputeAtAxis()) - 1,
               producer) +
           1;
       producer_this_pos = std::max(producer_this_pos, producer_pos);

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -409,7 +409,7 @@ int getMappedConsumerAxis(
                     c2p_root_map,
                     true)
                     .getReplay();
-  auto producer_id = producer_tv->axis(producer_axis);
+  auto producer_id = producer_tv->axis(int(producer_axis));
   IterDomain* consumer_id = nullptr;
   for (const auto& m : replay) {
     if (m.second == producer_id) {

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -396,18 +396,19 @@ namespace {
 
 // Note: This may be included as an independent member function
 // TensorView if it's determined to be useful more generally.
-int getMappedConsumerAxis(TensorView* producer_tv, int producer_axis,
-                             TensorView* consumer_tv) {
+int getMappedConsumerAxis(
+    TensorView* producer_tv,
+    int producer_axis,
+    TensorView* consumer_tv) {
   auto c2p_root_map =
       PairwiseRootDomainMap(producer_tv, consumer_tv)
-      .mapConsumerToProducer(
-          consumer_tv->domain(), producer_tv->domain());
+          .mapConsumerToProducer(consumer_tv->domain(), producer_tv->domain());
   auto replay = BestEffortReplay(
-      producer_tv->domain()->domain(),
-      consumer_tv->domain()->domain(),
-      c2p_root_map,
-      true)
-      .getReplay();
+                    producer_tv->domain()->domain(),
+                    consumer_tv->domain()->domain(),
+                    c2p_root_map,
+                    true)
+                    .getReplay();
   auto producer_id = producer_tv->axis(producer_axis);
   IterDomain* consumer_id = nullptr;
   for (const auto& m : replay) {
@@ -415,8 +416,8 @@ int getMappedConsumerAxis(TensorView* producer_tv, int producer_axis,
       consumer_id = m.first;
     }
   }
-  TORCH_INTERNAL_ASSERT(consumer_id != nullptr,
-                        "Mapped consumer IterDomain not found");
+  TORCH_INTERNAL_ASSERT(
+      consumer_id != nullptr, "Mapped consumer IterDomain not found");
   auto consumer_axis = std::distance(
       consumer_tv->domain()->domain().begin(),
       std::find(
@@ -538,10 +539,12 @@ TensorView* TensorView::cache_before() {
         cache_replayed = true;
       }
       TORCH_INTERNAL_ASSERT(producer_of_producer->getThisComputeAtAxis() > 0);
-      size_t producer_pos = getMappedConsumerAxis(
-          producer_of_producer,
-          producer_of_producer->getThisComputeAtAxis() - 1,
-          producer) + 1;
+      size_t producer_pos =
+          getMappedConsumerAxis(
+              producer_of_producer,
+              producer_of_producer->getThisComputeAtAxis() - 1,
+              producer) +
+          1;
       producer_this_pos = std::max(producer_this_pos, producer_pos);
     }
   }


### PR DESCRIPTION
Remove `TensorView::relative_ca_pos_` and `TensorView::compute_at_view_`. These are not necessary anymore since we construct and use the three `ComputeAtMap` maps instead.

Closes #641
