### PR TITLE
Apply input caching first before other scheduling operations

### DIFF
--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -169,7 +169,9 @@ class TORCH_CUDA_CU_API Fusion final {
   //! Return in insertion order
   const std::deque<Val*>& deterministic_vals() const noexcept;
 
-  //! Return the set of Exprs registered with this fusion
+  //! Return the set of Exprs registered with this fusion. Warning: This will
+  //! return exprs outside inputs/outputs, so can be unsafe for use with
+  //! segmented fusions.
   const std::unordered_set<Expr*>& unordered_exprs() const noexcept;
 
   //! Return all Exprs that use val

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -1037,6 +1037,8 @@ void setupSharedMemory(
   }
 }
 
+// TODO: Review this. Seems we should be using a root map here, or we should
+// simply be replaying all tensors as a reduction tv.
 void organizeAxes(
     const std::vector<TensorView*>& reduction_tv,
     const std::vector<TensorView*>& all_tv) {
@@ -1185,7 +1187,9 @@ void scheduleNormalization(
   const auto& in_tv = ir_utils::filterByType<TensorView>(fusion->inputs());
   const auto& out_tv = ir_utils::filterByType<TensorView>(fusion->outputs());
 
-  cacheInputs(fusion, rparams, reduction_tv, other_tv);
+  if (rparams.fastest_dim && rparams.persistent_kernel) {
+    cacheInputs(fusion, rparams, reduction_tv, other_tv);
+  }
 
   std::vector<TensorView*> all_tv;
   for (auto input : in_tv) {


### PR DESCRIPTION
This makes sure all tensors including caches get the same scheduling operations applied.

See #663 
