### PR TITLE
Compute at "forward" (compute at producer->consumer)

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1878,7 +1878,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
-TEST(NVFuserTest, FusionAdvancedComputeAtFwd1_CUDA) {
+TEST(NVFuserTest, FusionAdvancedComputeWith1_CUDA) {
   // Case 1
   // tv1 = tv0 * 0.5
   // tv2 = tv1 * -1
@@ -1912,7 +1912,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd1_CUDA) {
 
   tv0->axis(0)->parallelize(ParallelType::BIDx);
 
-  tv0->computeAtForward(tv7, 1);
+  tv0->computeWith(tv7, 1);
 
   GpuLower gpulw(&fusion);
 
@@ -1957,7 +1957,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd1_CUDA) {
       &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
 }
 
-TEST(NVFuserTest, FusionAdvancedComputeAtFwd2_CUDA) {
+TEST(NVFuserTest, FusionAdvancedComputeWith2_CUDA) {
   // Case 2
   // tv1 = tv0 * -1
   // tv2 = tv0 + 3
@@ -1989,7 +1989,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd2_CUDA) {
 
   tv0->axis(0)->parallelize(ParallelType::BIDx);
 
-  tv0->computeAtForward(tv6, 1);
+  tv0->computeWith(tv6, 1);
 
   for (Val* val : fusion.vals()) {
     if (!fusion.hasInput(val) &&
@@ -2020,7 +2020,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd2_CUDA) {
   testValidate(&fusion, cg_outputs, {input}, aten_outputs, __LINE__, __FILE__);
 }
 
-TEST(NVFuserTest, FusionAdvancedComputeAtFwd3_CUDA) {
+TEST(NVFuserTest, FusionAdvancedComputeWith3_CUDA) {
   // Case 3
   // T2 = T1 * 0.979361
   // T3 = T2 * T0
@@ -2049,8 +2049,8 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd3_CUDA) {
   tv1->split(0, 128);
   tv1->split(0, 4);
 
-  tv0->computeAtForward(tv3, 1);
-  tv1->computeAtForward(tv3, 1);
+  tv0->computeWith(tv3, 1);
+  tv1->computeWith(tv3, 1);
 
   tv3->axis(0)->parallelize(ParallelType::BIDx);
 
@@ -2083,7 +2083,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd3_CUDA) {
       &fusion, {cg_output}, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
-TEST(NVFuserTest, FusionAdvancedComputeAtFwd4_CUDA) {
+TEST(NVFuserTest, FusionAdvancedComputeWith4_CUDA) {
   // Case 4
   // T4 = T2 - T3
   // T5 = T1 + T4
@@ -2116,7 +2116,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd4_CUDA) {
     }
     tv->split(0, 128);
     tv->split(0, 4);
-    tv->computeAtForward(tv6, 1);
+    tv->computeWith(tv6, 1);
   }
 
   tv6->axis(0)->parallelize(ParallelType::BIDx);
@@ -2151,7 +2151,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd4_CUDA) {
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
-TEST(NVFuserTest, FusionAdvancedComputeAtFwd5_CUDA) {
+TEST(NVFuserTest, FusionAdvancedComputeWith5_CUDA) {
   // Case 5
   // tv2 = tv0 + 2.0
   // tv3 = tv1 * tv2
@@ -2171,7 +2171,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd5_CUDA) {
   tv2->split(-1, 8);
   tv2->split(-1, 4);
 
-  tv2->computeAtForward(tv3, 1);
+  tv2->computeWith(tv3, 1);
   tv3->axis(0)->parallelize(ParallelType::BIDx);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -2191,7 +2191,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd5_CUDA) {
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
-TEST(NVFuserTest, FusionAdvancedComputeAtFwd6_CUDA) {
+TEST(NVFuserTest, FusionAdvancedComputeWith6_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -2209,7 +2209,7 @@ TEST(NVFuserTest, FusionAdvancedComputeAtFwd6_CUDA) {
   tv3->merge(0);
   tv3->split(-1, 8);
 
-  tv2->computeAtForward(tv3, 1);
+  tv2->computeWith(tv3, 1);
 
   tv3->axis(0)->parallelize(ParallelType::BIDx);
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -1878,6 +1878,358 @@ TEST(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 }
 
+TEST(NVFuserTest, FusionAdvancedComputeAtFwd1_CUDA) {
+  // Case 1
+  // tv1 = tv0 * 0.5
+  // tv2 = tv1 * -1
+  // tv3 = tv1 + 3
+  // tv4 = tv1 * 2
+  // tv5 = tv3 + tv2
+  // tv6 = tv5 + tv4
+  // tv7 = tv1 + tv4
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = mul(tv0, new Double(0.5));
+  TensorView* tv2 = mul(tv1, new Double(-1.0));
+  TensorView* tv3 = add(tv1, new Double(3.0));
+  TensorView* tv4 = mul(tv1, new Double(2.0));
+  TensorView* tv5 = add(tv3, tv2);
+
+  TensorView* tv6 = add(tv5, tv4);
+  TensorView* tv7 = add(tv1, tv4);
+
+  fusion.addOutput(tv6);
+  fusion.addOutput(tv7);
+
+  // Lets setup to actually run
+  tv0->merge(0);
+  tv0->split(0, 128);
+  tv0->split(0, 4);
+
+  tv0->axis(0)->parallelize(ParallelType::BIDx);
+
+  tv0->computeAtForward(tv7, 1);
+
+  GpuLower gpulw(&fusion);
+
+  // The this-position of the last tensor should be zero.
+  TORCH_CHECK(tv7->nDims() == 3 && tv7->getThisComputeAtAxis() == 0);
+  // The position of every other tensor should be 1.
+  for (auto tv : {tv1, tv2, tv3, tv4, tv5, tv6}) {
+    TORCH_CHECK(tv->nDims() == 3 && tv->getThisComputeAtAxis() == 1);
+    TORCH_CHECK(gpulw.caLoopMap().areMapped(tv7->axis(0), tv->axis(0)));
+  }
+
+  for (Val* val : fusion.vals()) {
+    if (!fusion.hasInput(val) &&
+        val->getValType().value() == ValType::TensorView) {
+      TensorView* tv = static_cast<TensorView*>(val);
+      tv->axis(1)->parallelize(ParallelType::Unroll);
+      tv->axis(-1)->parallelize(ParallelType::TIDx);
+    }
+  }
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  at::Tensor aten_input = at::randn({129, 127}, options);
+
+  auto t1 = aten_input.mul({0.5});
+  auto t2 = t1.mul({-1.0});
+  auto t3 = t1.add({3.0});
+  auto t4 = t1.mul({2.0});
+  auto t5 = t3.add(t2);
+  auto t6 = t5.add(t4);
+  auto t7 = t1.add(t4);
+
+  std::vector<at::Tensor> aten_outputs = {t6, t7};
+  std::vector<at::Tensor> cg_outputs = {
+      at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  fe.runFusion({aten_input}, cg_outputs);
+
+  testValidate(
+      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+}
+
+TEST(NVFuserTest, FusionAdvancedComputeAtFwd2_CUDA) {
+  // Case 2
+  // tv1 = tv0 * -1
+  // tv2 = tv0 + 3
+  // tv3 = tv0 * 2
+  // tv4 = tv2 + tv1
+  // tv5 = tv4 + tv3
+  // tv6 = tv5 + tv3
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = mul(tv0, new Double(-1.0));
+  TensorView* tv2 = add(tv0, new Double(3.0));
+  TensorView* tv3 = mul(tv0, new Double(2.0));
+  TensorView* tv4 = add(tv2, tv1);
+
+  TensorView* tv5 = add(tv4, tv3);
+  TensorView* tv6 = add(tv5, tv3);
+
+  fusion.addOutput(tv5);
+  fusion.addOutput(tv6);
+
+  // Lets setup to actually run
+  tv0->merge(0);
+  tv0->split(0, 128);
+  tv0->split(0, 4);
+
+  tv0->axis(0)->parallelize(ParallelType::BIDx);
+
+  tv0->computeAtForward(tv6, 1);
+
+  for (Val* val : fusion.vals()) {
+    if (!fusion.hasInput(val) &&
+        val->getValType().value() == ValType::TensorView) {
+      TensorView* tv = static_cast<TensorView*>(val);
+
+      tv->axis(1)->parallelize(ParallelType::Unroll);
+      tv->axis(-1)->parallelize(ParallelType::TIDx);
+    }
+  }
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::randn({129, 127}, options);
+
+  auto t1 = input.mul({-1.0});
+  auto t2 = input.add({3.0});
+  auto t3 = input.mul({2.0});
+  auto t4 = t2.add(t1);
+  auto t5 = t4.add(t3);
+  auto t6 = t5.add(t3);
+
+  std::vector<at::Tensor> aten_outputs = {t5, t6};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion({input});
+
+  testValidate(&fusion, cg_outputs, {input}, aten_outputs, __LINE__, __FILE__);
+}
+
+TEST(NVFuserTest, FusionAdvancedComputeAtFwd3_CUDA) {
+  // Case 3
+  // T2 = T1 * 0.979361
+  // T3 = T2 * T0
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeSymbolicTensor(4);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = makeSymbolicTensor(4);
+  fusion.addInput(tv1);
+
+  TensorView* tv2 = mul(tv1, new Double(.979361));
+  TensorView* tv3 = mul(tv2, tv0);
+
+  fusion.addOutput(tv3);
+
+  // Lets setup to actually run
+  while (tv0->nDims() > 1)
+    tv0->merge(0);
+  tv0->split(0, 128);
+  tv0->split(0, 4);
+
+  while (tv1->nDims() > 1)
+    tv1->merge(0);
+  tv1->split(0, 128);
+  tv1->split(0, 4);
+
+  tv0->computeAtForward(tv3, 1);
+  tv1->computeAtForward(tv3, 1);
+
+  tv3->axis(0)->parallelize(ParallelType::BIDx);
+
+  for (Val* val : fusion.vals()) {
+    if (!fusion.hasInput(val) &&
+        val->getValType().value() == ValType::TensorView) {
+      TensorView* tv = static_cast<TensorView*>(val);
+
+      tv->axis(1)->parallelize(ParallelType::Unroll);
+      tv->axis(-1)->parallelize(ParallelType::TIDx);
+    }
+  }
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({129, 127, 63, 65}, options);
+  at::Tensor t1 = at::rand_like(t0, options);
+
+  auto t2 = t1.mul({0.979361});
+  auto aten_output = t2.mul(t0);
+
+  std::vector<IValue> aten_inputs = {t0, t1};
+
+  at::Tensor cg_output = at::empty_like(t0, options);
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  fe.runFusion(aten_inputs, {cg_output});
+
+  testValidate(
+      &fusion, {cg_output}, aten_inputs, {aten_output}, __LINE__, __FILE__);
+}
+
+TEST(NVFuserTest, FusionAdvancedComputeAtFwd4_CUDA) {
+  // Case 4
+  // T4 = T2 - T3
+  // T5 = T1 + T4
+  // T6 = T5 - T0
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeSymbolicTensor(4);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = makeSymbolicTensor(4);
+  fusion.addInput(tv1);
+
+  TensorView* tv2 = makeSymbolicTensor(4);
+  fusion.addInput(tv2);
+
+  TensorView* tv3 = makeSymbolicTensor(4);
+  fusion.addInput(tv3);
+
+  TensorView* tv4 = sub(tv2, tv3);
+  TensorView* tv5 = add(tv1, tv4);
+  TensorView* tv6 = sub(tv5, tv0);
+
+  fusion.addOutput(tv6);
+  std::vector<TensorView*> tvs = {tv0, tv1, tv2};
+  for (auto tv : tvs) {
+    // Lets setup to actually run
+    while (tv->nDims() > 1) {
+      tv->merge(0);
+    }
+    tv->split(0, 128);
+    tv->split(0, 4);
+    tv->computeAtForward(tv6, 1);
+  }
+
+  tv6->axis(0)->parallelize(ParallelType::BIDx);
+
+  for (Val* val : fusion.vals()) {
+    if (!fusion.hasInput(val) &&
+        val->getValType().value() == ValType::TensorView) {
+      TensorView* tv = static_cast<TensorView*>(val);
+
+      tv->axis(1)->parallelize(ParallelType::Unroll);
+      tv->axis(-1)->parallelize(ParallelType::TIDx);
+    }
+  }
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({129, 127, 63, 65}, options);
+  at::Tensor t1 = at::rand_like(t0, options);
+  at::Tensor t2 = at::rand_like(t0, options);
+  at::Tensor t3 = at::rand_like(t0, options);
+
+  auto t4 = t2.sub(t3);
+  auto t5 = t1.add(t4);
+  auto aten_output = t5.sub(t0);
+
+  std::vector<IValue> aten_inputs = {t0, t1, t2, t3};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  testValidate(
+      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+}
+
+TEST(NVFuserTest, FusionAdvancedComputeAtFwd5_CUDA) {
+  // Case 5
+  // tv2 = tv0 + 2.0
+  // tv3 = tv1 * tv2
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // Set up your input tensor views
+  TensorView* tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  TensorView* tv1 = makeSymbolicTensor(2);
+  fusion.addInput(tv1);
+  TensorView* tv2 = add(tv0, new Double(2.0));
+  TensorView* tv3 = mul(tv1, tv2);
+  fusion.addOutput(tv3);
+
+  tv2->merge(0);
+  tv2->split(-1, 8);
+  tv2->split(-1, 4);
+
+  tv2->computeAtForward(tv3, 1);
+  tv3->axis(0)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({63, 65}, options);
+  at::Tensor t1 = at::rand_like(t0, options);
+
+  auto t2 = t0.add(2.0);
+  auto aten_output = t1.mul(t2);
+
+  std::vector<IValue> aten_inputs = {t0, t1};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  testValidate(
+      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+}
+
+TEST(NVFuserTest, FusionAdvancedComputeAtFwd6_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  TensorView* tv1 = makeSymbolicTensor(2);
+  fusion.addInput(tv1);
+  TensorView* tv2 = add(tv0, new Double(2.0));
+  TensorView* tv3 = mul(tv1, tv2);
+  fusion.addOutput(tv3);
+
+  tv2->merge(0);
+  tv2->split(-1, 8);
+  tv2->split(-1, 4);
+  tv3->merge(0);
+  tv3->split(-1, 8);
+
+  tv2->computeAtForward(tv3, 1);
+
+  tv3->axis(0)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({63, 65}, options);
+  at::Tensor t1 = at::rand_like(t0, options);
+
+  auto t2 = t0.add(2.0);
+  auto aten_output = t1.mul(t2);
+
+  std::vector<IValue> aten_inputs = {t0, t1};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  testValidate(
+      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+}
+
 TEST(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
   // tv1 = tv0 * 0.5
   // tv2 = tv1 * -1

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -148,7 +148,7 @@ std::deque<std::deque<TensorView*>> tvChains(
 
 } // namespace
 
-void ComputeAt::run(
+void ComputeAt::runAt(
     TensorView* producer,
     TensorView* consumer,
     unsigned int consumer_position) {
@@ -213,11 +213,11 @@ void ComputeAt::run(
   }
 }
 
-void ComputeAt::runForward(
+void ComputeAt::runWith(
     TensorView* producer,
     TensorView* consumer,
     unsigned int producer_position) {
-  FUSER_PERF_SCOPE("ComputeAt::runForward");
+  FUSER_PERF_SCOPE("ComputeAt::runWith");
 
   // Make sure the correct fusion is setup between this and consumer.
   TORCH_CHECK(

--- a/torch/csrc/jit/codegen/cuda/compute_at.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at.cpp
@@ -207,10 +207,31 @@ void ComputeAt::run(
   // Run computeAt on our potentially modified producer(s)
   if (!producers.empty()) {
     for (auto producer_to_run : producers) {
-      ComputeAt ca(producer_to_run, consumer, consumer_position);
+      ComputeAt ca(producer_to_run, consumer, consumer, consumer_position);
       ca.runPass();
     }
   }
+}
+
+void ComputeAt::runForward(
+    TensorView* producer,
+    TensorView* consumer,
+    unsigned int producer_position) {
+  FUSER_PERF_SCOPE("ComputeAt::runForward");
+
+  // Make sure the correct fusion is setup between this and consumer.
+  TORCH_CHECK(
+      producer->fusion() == consumer->fusion(),
+      producer,
+      " and ",
+      consumer,
+      " are not in the same fusion.");
+
+  // Make sure Fusion Guard is set appropriately
+  FusionGuard fg(producer->fusion());
+
+  ComputeAt ca(producer, consumer, producer, producer_position);
+  ca.runPass();
 }
 
 // Actually applies transformation
@@ -242,7 +263,9 @@ unsigned int ComputeAt::backwardComputeAt_impl(
   return replay.second;
 }
 
-// Actually applies transformation
+// Actually applies transformation, replay consumer based on producer, set
+// compute at of producer, set pass position of consumer, return position
+// relative to consumer
 unsigned int ComputeAt::forwardComputeAt_impl(
     TensorView* producer,
     TensorView* consumer,
@@ -271,7 +294,7 @@ unsigned int ComputeAt::forwardComputeAt_impl(
 
   consumer_entry.setPassPosition(replay.second);
   if (consumer_entry.shouldSetComputeAt(replay.second) &&
-      consumer != consumer_) {
+      !(consumer == consumer_ && reference_ == consumer_)) {
     const TensorDomain* current_domain = consumer->domain();
     TensorDomain* new_domain = replay.first;
     consumer->setDomain(new_domain);
@@ -338,6 +361,10 @@ void ComputeAt::setCommonConsumer() {
 // computeAt if it will increase computeAt positions.
 void ComputeAt::traverseBackward() {
   FUSER_PERF_SCOPE("ComputeAt::traverseBackward");
+  if (reference_ == producer_) {
+    // Forward compute at don't need to run backward traversal
+    return;
+  }
 
   // propagate *backward* through all *producer* use_chains or from *producer*
   // to common_consumer if common_consumer exists. Only apply transform if
@@ -348,7 +375,7 @@ void ComputeAt::traverseBackward() {
   for (auto tv_chain : chains) {
     TensorView* running_producer = tv_chain.back();
     TensorView* running_consumer = nullptr;
-    unsigned int running_consumer_pos = consumer_position_;
+    unsigned int running_consumer_pos = reference_position_;
     tv_chain.pop_back();
 
     TORCH_INTERNAL_ASSERT(running_producer == consumer_);
@@ -375,7 +402,9 @@ void ComputeAt::traverseForward() {
         DependencyCheck::getAllDependencyChains(producer_, common_consumer_));
   }
 
-  unsigned int producer_pos = tv_data.at(producer_).getNewPosition();
+  unsigned int producer_pos = reference_ == producer_
+      ? reference_position_
+      : tv_data.at(producer_).getNewPosition();
 
   // propagate forward through all chains
   for (auto tv_dep_chain : chains) {
@@ -390,7 +419,6 @@ void ComputeAt::traverseForward() {
       running_producer = running_consumer;
       running_consumer = tv_dep_chain.front();
       tv_dep_chain.pop_front();
-
       running_producer_pos = forwardComputeAt_impl(
           running_producer, running_consumer, running_producer_pos);
     }
@@ -432,14 +460,16 @@ void ComputeAt::runPass() {
     entry.second.validateNewComputeAt();
   }
 
-  TORCH_INTERNAL_ASSERT(
-      BestEffortReplay::findFirstMismatchedID(
-          consumer_->domain(), tv_data.at(consumer_).getOriginalDomain()) ==
-          (int)consumer_->domain()->nDims(),
-      "ComputeAt logic changed the consumer domain which should not happen. Domain was ",
-      tv_data.at(consumer_).getOriginalDomain(),
-      " but is now: ",
-      consumer_->domain());
+  if (reference_ == consumer_) {
+    TORCH_INTERNAL_ASSERT(
+        BestEffortReplay::findFirstMismatchedID(
+            consumer_->domain(), tv_data.at(consumer_).getOriginalDomain()) ==
+            (int)consumer_->domain()->nDims(),
+        "ComputeAt logic changed the consumer domain which should not happen. Domain was ",
+        tv_data.at(consumer_).getOriginalDomain(),
+        " but is now: ",
+        consumer_->domain());
+  }
 }
 
 void ComputeAt::setupOutputs() {
@@ -478,18 +508,29 @@ void ComputeAt::setupOutputs() {
 ComputeAt::ComputeAt(
     TensorView* _producer,
     TensorView* _consumer,
-    unsigned int _consumer_position)
+    TensorView* _reference,
+    unsigned int _reference_position)
     : producer_(_producer),
       consumer_(_consumer),
-      consumer_position_(_consumer_position) {
+      reference_(_reference),
+      reference_position_(_reference_position) {
   TORCH_INTERNAL_ASSERT(
-      consumer_position_ >= 0 && consumer_position_ <= consumer_->nDims(),
+      reference_ == producer_ || reference_ == consumer_,
+      "For compute at reference must be producer or consumer, it's neither.",
+      " reference: ",
+      reference_,
+      " consumer: ",
+      consumer_,
+      " producer: ",
+      producer_);
+  TORCH_INTERNAL_ASSERT(
+      reference_position_ >= 0 && reference_position_ <= reference_->nDims(),
       "Invalid computeAt axis, received ",
-      _consumer_position,
+      reference_position_,
       " but should be > -",
-      consumer_->nDims(),
+      reference_->nDims(),
       " and <= ",
-      consumer_->nDims(),
+      reference_->nDims(),
       ".");
 
   producer_use_chains_ = tvChains(DependencyCheck::getAllUseChains(producer_));

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -98,12 +98,16 @@ class ComputeAtData {
 
 class ComputeAt {
  public:
-  static void run(
+  // Runs the compute at pass making producer look like consumer, computing
+  // producer relative to consumer
+  static void runAt(
       TensorView* producer,
       TensorView* consumer,
       unsigned int consumer_position);
 
-  static void runForward(
+  // Runs the compute with pass making consumer look like producer, computing
+  // producer relative to consumer
+  static void runWith(
       TensorView* producer,
       TensorView* consumer,
       unsigned int producer_position);

--- a/torch/csrc/jit/codegen/cuda/compute_at.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at.h
@@ -99,14 +99,20 @@ class ComputeAtData {
 class ComputeAt {
  public:
   static void run(
-      TensorView* _producer,
-      TensorView* _consumer,
-      unsigned int _consumer_position);
+      TensorView* producer,
+      TensorView* consumer,
+      unsigned int consumer_position);
+
+  static void runForward(
+      TensorView* producer,
+      TensorView* consumer,
+      unsigned int producer_position);
 
  private:
   TensorView* producer_;
   TensorView* consumer_;
-  unsigned int consumer_position_;
+  TensorView* reference_;
+  unsigned int reference_position_;
   ComputeAtRootDomainMap root_map_;
 
   // Runs replayPasC and sets producer computeAt settings. Returns
@@ -154,7 +160,8 @@ class ComputeAt {
   ComputeAt(
       TensorView* _producer,
       TensorView* _consumer,
-      unsigned int _consumer_position);
+      TensorView* _reference,
+      unsigned int _reference_position);
 
   ComputeAt() = delete;
   ~ComputeAt() = default;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -194,8 +194,14 @@ class TORCH_CUDA_CU_API TensorView : public Val {
     return this_compute_at_axis_;
   }
 
-  // Compute this TensorView relative to another tensor at axis
-  TensorView* computeAt(TensorView* consumer, int axis);
+  // Compute this TensorView relative to a consumer relative to consumer
+  // position, -1 will compute tensors inline with eachother, 0 doesn't share
+  // any loop nests between the tensors
+  TensorView* computeAt(TensorView* consumer, int position);
+
+  // Compute this tensor to consumer, at local position, -1 will compute tensors
+  // inline with eachother, 0 doesn't share any loop nests between the tensors
+  TensorView* computeAtForward(TensorView* consumer, int position);
 
   void clearComputeAt() {
     this_compute_at_axis_ = 0;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -201,7 +201,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   // Compute this tensor to consumer, at local position, -1 will compute tensors
   // inline with eachother, 0 doesn't share any loop nests between the tensors
-  TensorView* computeAtForward(TensorView* consumer, int position);
+  TensorView* computeWith(TensorView* consumer, int position);
 
   void clearComputeAt() {
     this_compute_at_axis_ = 0;

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -190,12 +190,12 @@ TensorView* TensorView::computeAt(TensorView* consumer, int position) {
       position >= 0 && (unsigned int)position < consumer->nDims() + 1,
       "Compute at called on an position outside valid range.");
 
-  ComputeAt::run(this, consumer, (unsigned int)position);
+  ComputeAt::runAt(this, consumer, (unsigned int)position);
 
   return this;
 }
 
-TensorView* TensorView::computeAtForward(TensorView* consumer, int position) {
+TensorView* TensorView::computeWith(TensorView* consumer, int position) {
   // Make sure this and consumer are not the same tensor, that's illegal
   TORCH_CHECK(!sameAs(consumer), "Cannot call this->computeAt(this, ...)");
 
@@ -208,7 +208,7 @@ TensorView* TensorView::computeAtForward(TensorView* consumer, int position) {
       position >= 0 && (unsigned int)position < this->nDims() + 1,
       "Compute at called on an position outside valid range.");
 
-  ComputeAt::runForward(this, consumer, (unsigned int)position);
+  ComputeAt::runWith(this, consumer, (unsigned int)position);
 
   return this;
 }

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -177,20 +177,38 @@ void TensorView::setComputeAt(unsigned int this_pos) {
   this_compute_at_axis_ = this_pos;
 }
 
-TensorView* TensorView::computeAt(TensorView* consumer, int axis) {
+TensorView* TensorView::computeAt(TensorView* consumer, int position) {
   // Make sure this and consumer are not the same tensor, that's illegal
   TORCH_CHECK(!sameAs(consumer), "Cannot call this->computeAt(this, ...)");
 
   // We support negative axes, so increment it by consumer->nDims() + 1 and make
   // sure the result is within consumer->nDims() + 1. being at consumer->nDims()
   // means producer will be computed inline with consumer, hence the +1.
-  if (axis < 0)
-    axis += int(consumer->nDims()) + 1;
+  if (position < 0)
+    position += int(consumer->nDims()) + 1;
   TORCH_CHECK(
-      axis >= 0 && (unsigned int)axis < consumer->nDims() + 1,
-      "Compute at called on an axis outside valid range.");
+      position >= 0 && (unsigned int)position < consumer->nDims() + 1,
+      "Compute at called on an position outside valid range.");
 
-  ComputeAt::run(this, consumer, (unsigned int)axis);
+  ComputeAt::run(this, consumer, (unsigned int)position);
+
+  return this;
+}
+
+TensorView* TensorView::computeAtForward(TensorView* consumer, int position) {
+  // Make sure this and consumer are not the same tensor, that's illegal
+  TORCH_CHECK(!sameAs(consumer), "Cannot call this->computeAt(this, ...)");
+
+  // We support negative axes, so increment it by this->nDims() + 1 and make
+  // sure the result is within this->nDims() + 1. being at this->nDims()
+  // means producer will be computed inline with this, hence the +1.
+  if (position < 0)
+    position += int(this->nDims()) + 1;
+  TORCH_CHECK(
+      position >= 0 && (unsigned int)position < this->nDims() + 1,
+      "Compute at called on an position outside valid range.");
+
+  ComputeAt::runForward(this, consumer, (unsigned int)position);
 
   return this;
 }


### PR DESCRIPTION
Support the opposite traversal direction for computeAt.