### PR TITLE
Fix expression ordering

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -6370,6 +6370,42 @@ TEST(NVFuserTest, FusionComputeAtExprOrder2_CUDA) {
       &fusion, {cg_output}, {aten_input}, {aten_output}, __LINE__, __FILE__);
 }
 
+TEST(NVFuserTest, FusionComputeAtExprOrder3_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  const size_t dimx = 13;
+  const size_t dimy = 15;
+
+  TensorView* tv0 = makeConcreteTensor({dimx, dimy});
+  fusion.addInput(tv0);
+  TensorView* tv1 = add(tv0, new Double(1));
+  TensorView* tv2 = add(tv1, new Double(2));
+  TensorView* tv3 = add(tv2, new Double(3));
+  TensorView* tv4 = add(tv3, new Double(4));
+  TensorView* tv5 = mul(tv2, tv4);
+  fusion.addOutput(tv5);
+
+  tv1->computeAt(tv2, 2);
+  tv3->computeAt(tv4, 1);
+  tv4->computeAt(tv5, 2);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor aten_input = at::randn({dimx, dimy}, options);
+  auto t1 = aten_input.add(1.);
+  auto t2 = t1.add(2.);
+  auto t3 = t2.add(3.);
+  auto t4 = t3.add(4.);
+  auto aten_output = t2.mul(t4);
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion({aten_input});
+
+  testValidate(
+      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+}
+
 TEST(NVFuserTest, FusionZeroDimComputeAt_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -7184,12 +7184,13 @@ TEST(NVFuserTest, FusionCacheFork_CUDA) {
   //          TV2 = TV1 * 1
   // Output:  TV3, TV2
 
+  // cache_fork !!does not!! automatically apply ComputeAt to the cache
+  // TensorView TODO: enforce
+  auto tv3 = tv1->cache_fork();
+
   constexpr int BSX = 32;
   tv2->split(-1, BSX);
   tv0->computeAt(tv2, -1);
-
-  // cache_fork automatically applies ComputeAt to the cache TensorView
-  auto cf1 = tv1->cache_fork();
 
   // Thread and Block binding
   tv2->axis(0)->parallelize(ParallelType::BIDx);

--- a/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
@@ -57,8 +57,7 @@ class ExprSegmentationSorter;
 // Debug printing disabled due to clang tidy, see below for definitions
 // std::ostream& operator<<(std::ostream& os, const ExprGroupConnections* edge);
 // std::ostream& operator<<(std::ostream& os, const ExprGroup* group);
-// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter*
-// scf);
+// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter* scf);
 
 // Wrapper for values, these are edges between expr groups. Multiple edges can
 // exist between expr groups, and the same Val can show up more than once in
@@ -75,9 +74,11 @@ struct ExprGroupConnections {
 };
 
 struct ExprSortPayload : public PolymorphicBase {
-  // Track the active domains that start at the compute at point of the
-  // expression and increment outward
+  // Need to track compute at domains as well as produce at domains. Produce at
+  // domains will be matched to producers compute at domains. Track the active
+  // domains that will be matched from inner most dim to outer most.
   std::vector<IterDomain*> ca_domains_;
+  std::vector<IterDomain*> pa_domains_;
 
   // Maximum path distance from an input expr group required for
   // Theorem 4.2
@@ -301,6 +302,41 @@ class ExprSegmentationSorter {
   bool fallback_mode_enabled_ = false;
 };
 
+// Debug printing, disabled due to clang-tidy see above for declarations.
+// std::ostream& operator<<(std::ostream& os, ExprGroup* group) {
+//   os << "g{";
+//   for (size_t i = 0; i < group->exprs().size(); i++) {
+//     os << group->exprs()[i]->name();
+//     if (i + 1 != group->exprs().size())
+//       os << ", ";
+//   }
+//   os << "} (" << group->payload()->ca_domains_.size() << ", "
+//      << group->payload()->pa_domains_.size() << ")";
+//   os << " ca_ids {";
+//   for (size_t i = 0; i < group->payload()->ca_domains_.size(); i++) {
+//     os << group->payload()->ca_domains_[i];
+//     if (i + 1 != group->payload()->ca_domains_.size())
+//       os << ", ";
+//   }
+//   os << "} pa_ids {";
+//   for (size_t i = 0; i < group->payload()->pa_domains_.size(); i++) {
+//     os << group->payload()->pa_domains_[i];
+//     if (i + 1 != group->payload()->pa_domains_.size())
+//       os << ", ";
+//   }
+//   os << "}";
+//   return os;
+// }
+
+// std::ostream& operator<<(std::ostream& os, const ExprGroupConnections* edge) {
+//   os << "e{ " << edge->from << " -> " << edge->to << " }" << std::endl;
+//   return os;
+// }
+
+// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter* scf) {
+//   return os << scf->toString();
+// }
+
 std::vector<ExprGroup*> ExprGroup::getNeighbors() {
   std::vector<ExprGroup*> neighbors;
   for (auto inp : producer_edges_) {
@@ -488,11 +524,11 @@ ExprGroup* ExprSegmentationSorter::makeEmptyGroup(Expr* expr) {
   if (ir_utils::isTVOp(expr)) {
     auto out_tv = expr->outputs()[0]->as<TensorView>();
     // Grab all id's that are shared with other tensors.
-    for (size_t tv_i = 0; tv_i <
-         std::max(out_tv->getMaxProducerPosition(),
-                  out_tv->getComputeAtPosition());
-         tv_i++) {
+    for (size_t tv_i = 0; tv_i < out_tv->getComputeAtPosition(); tv_i++) {
       group->payload()->ca_domains_.push_back(out_tv->axis(tv_i));
+    }
+    for (size_t tv_i = 0; tv_i < out_tv->getMaxProducerPosition(); tv_i++) {
+      group->payload()->pa_domains_.push_back(out_tv->axis(tv_i));
     }
   }
   return group;
@@ -501,41 +537,42 @@ ExprGroup* ExprSegmentationSorter::makeEmptyGroup(Expr* expr) {
 // Debug function that prints the current state of the sorter.
 std::string ExprSegmentationSorter::toString(int verbosity) const {
   std::stringstream ss;
+  ss << "{\n";
   for (auto& group : groups_) {
-    ss << group.get() << "\n";
+    ss << "  " << group.get() << "\n";
 
     if (verbosity > 1) {
       if (group->producerEdges().size() > 0) {
-        ss << "  produced by groups: { \n";
+        ss << "    produced by groups: { \n";
         for (auto producer_edge : group->producerEdges()) {
-          ss << "    " << producer_edge->from << " via " << producer_edge->val
+          ss << "      " << producer_edge->from << " via " << producer_edge->val
              << "\n";
         }
-        ss << "  }"
+        ss << "    }"
            << "\n";
       }
     }
 
     if (verbosity > 0) {
       if (group->consumerEdges().size() > 0) {
-        ss << "  Consumed by groups: { \n";
+        ss << "    Consumed by groups: { \n";
         for (auto consumer_edge : group->consumerEdges()) {
-          ss << "    " << consumer_edge->to << "\n";
+          ss << "      " << consumer_edge->to << "\n";
         }
-        ss << "  }"
+        ss << "    }"
            << "\n";
       }
     }
 
     if (verbosity > 2) {
-      ss << "  Exprs{\n";
+      ss << "    Exprs{\n";
       for (auto expr : group->exprs()) {
-        ss << "    " << expr;
+        ss << expr;
       }
-      ss << "  }\n";
+      ss << "    }\n";
     }
   }
-
+  ss << "}\n";
   return ss.str();
 }
 
@@ -583,7 +620,7 @@ std::vector<ExprGroupConnections*> getMergedConsumerEdges(
 }
 
 // Assuming sg1 and sg2 are connected, figure out which is the consumer
-const ExprGroup* getProducer(const ExprGroup* sg1, const ExprGroup* sg2) {
+ExprGroup* getProducer(ExprGroup* sg1, ExprGroup* sg2) {
   for (auto producer_edge : sg1->producerEdges()) {
     if (producer_edge->from == sg2) {
       return sg2;
@@ -621,16 +658,10 @@ std::unordered_set<ExprGroupConnections*> ExprSegmentationSorter::
   return removed_edges;
 }
 
-// TODO: This function may be sub optimial. If we find that an iteration domain
-// matches later in the other domain, we will hold all other iteration domains
-// until that one matches. There may be cases where duplicating that iteration
-// domain, and moving on could be more efficient.
-ExprGroup* ExprSegmentationSorter::makeMergedNode(
-    ExprGroup* sg1,
-    ExprGroup* sg2) {
-  std::vector<IterDomain*> resulting_ca_axes;
-  auto& domain1 = sg1->payload()->ca_domains_;
-  auto& domain2 = sg2->payload()->ca_domains_;
+std::vector<IterDomain*> mergeDomains(
+    const std::vector<IterDomain*>& domain1,
+    const std::vector<IterDomain*>& domain2) {
+  std::vector<IterDomain*> resulting_domain;
   auto it1 = domain1.begin();
   auto it2 = domain2.begin();
 
@@ -645,13 +676,13 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
     // when not necessary.
     if (it1 == domain1.end()) { // NOLINT
       // domain1 has all been pushed, finish pushing domain 2
-      resulting_ca_axes.push_back(*it2++);
+      resulting_domain.push_back(*it2++);
     } else if (it2 == domain2.end()) { // NOLINT
       // domain2 has all been pushed, finish pushing domain 1
-      resulting_ca_axes.push_back(*it1++);
+      resulting_domain.push_back(*it1++);
     } else if (GpuLower::current()->caLoopMap().areMapped(
                    *it1, *it2)) { // NOLINT
-      resulting_ca_axes.push_back(*it1);
+      resulting_domain.push_back(*it1);
       ++it1;
       ++it2;
     } else if (std::any_of(it1 + 1, domain1.end(), [&](IterDomain* id1) {
@@ -659,29 +690,38 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
                })) { // NOLINT
       // Increment it1, as a later iter domain matches the current one in
       // domain2
-      resulting_ca_axes.push_back(*it1++);
+      resulting_domain.push_back(*it1++);
 
     } else if (std::any_of(it2 + 1, domain2.end(), [&](IterDomain* id2) {
                  return GpuLower::current()->caLoopMap().areMapped(id2, *it1);
                })) { // NOLINT
       // Increment it2, as a later iter domain matches the current one in
       // domain1
-      resulting_ca_axes.push_back(*it2++);
+      resulting_domain.push_back(*it2++);
     } else {
       // This should not be reachalble since the axes here only
       // include the shared axes between the two expr groups.
       TORCH_INTERNAL_ASSERT(false, "Should not be reachable.");
-      resulting_ca_axes.push_back(*it1++);
-      resulting_ca_axes.push_back(*it2++);
+      resulting_domain.push_back(*it1++);
+      resulting_domain.push_back(*it2++);
     }
   }
+  return resulting_domain;
+}
+
+// TODO: This function may be sub optimial. If we find that an iteration domain
+// matches later in the other domain, we will hold all other iteration domains
+// until that one matches. There may be cases where duplicating that iteration
+// domain, and moving on could be more efficient.
+ExprGroup* ExprSegmentationSorter::makeMergedNode(
+    ExprGroup* sg1,
+    ExprGroup* sg2) {
+  // Keep Expr's sorted in topological order.
+  const auto producer = getProducer(sg1, sg2);
+  const auto consumer = sg1 == producer ? sg2 : sg1;
 
   // Make the new joined node
   auto joined_groups = makeEmptyGroup();
-
-  // Keep Expr's sorted in topological order.
-  auto producer = getProducer(sg1, sg2);
-  auto consumer = sg1 == producer ? sg2 : sg1;
 
   TORCH_INTERNAL_ASSERT(
       producer != nullptr,
@@ -718,9 +758,86 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
     edge->to->addProducerEdge(edges_.back().get());
   }
 
-  joined_groups->payload()->ca_domains_ = resulting_ca_axes;
+  if (std::all_of(
+          producer->consumerEdges().begin(),
+          producer->consumerEdges().end(),
+          [&consumer](ExprGroupConnections* connection) {
+            return connection->to == consumer;
+          })) {
+    // If all consumers of producer were resolved (i.e. last consumer of
+    // producer is the one we're merging with), don't forward the compute at
+    // axes of producer
+    joined_groups->payload()->ca_domains_ = consumer->payload()->ca_domains_;
+  } else {
+    // Merge all compute at domains of producer and consumer
+    std::vector<IterDomain*> resulting_ca_axes =
+        mergeDomains(sg1->payload()->ca_domains_, sg2->payload()->ca_domains_);
+    joined_groups->payload()->ca_domains_ = resulting_ca_axes;
+  }
+
+  if (std::all_of(
+          consumer->producerEdges().begin(),
+          consumer->producerEdges().end(),
+          [&producer](ExprGroupConnections* connection) {
+            return connection->from == producer;
+          })) {
+    // If all producere edges were resolved (i.e. last producer of consumer is
+    // the one we're merging with), don't forward the produce at axes of
+    // consumer
+    joined_groups->payload()->pa_domains_ = producer->payload()->pa_domains_;
+  } else {
+    // Merge all produce at domains of producer and consumer
+    std::vector<IterDomain*> resulting_pa_axes =
+        mergeDomains(sg1->payload()->pa_domains_, sg2->payload()->pa_domains_);
+
+    joined_groups->payload()->pa_domains_ = resulting_pa_axes;
+  }
 
   return joined_groups;
+}
+
+bool canReduceCA(ExprGroup* group) {
+  IterDomain* g_last_id = nullptr;
+
+  if (group->payload()->ca_domains_.size() > 0) {
+    g_last_id = group->payload()->ca_domains_.back();
+  }
+  if (g_last_id == nullptr) {
+    return false;
+  }
+
+  for (auto consumer_edge : group->consumerEdges()) {
+    auto consumer = consumer_edge->to;
+    for (auto c_id : consumer->payload()->pa_domains_) {
+      if (GpuLower::current()->caLoopMap().areMapped(c_id, g_last_id)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool canReducePA(ExprGroup* group) {
+  IterDomain* g_last_id = nullptr;
+
+  if (group->payload()->pa_domains_.size() > 0) {
+    g_last_id = group->payload()->pa_domains_.back();
+  }
+  if (g_last_id == nullptr) {
+    return false;
+  }
+
+  for (auto producer_edge : group->producerEdges()) {
+    auto producer = producer_edge->from;
+    for (auto p_id : producer->payload()->ca_domains_) {
+      if (GpuLower::current()->caLoopMap().areMapped(p_id, g_last_id)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 // Update in between attempts to segment. This is called once no more groups
@@ -729,40 +846,25 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
 // merged after we've done this, we may need to stop as we could have multiple
 // disjoint groups that won't be merged.
 bool ExprSegmentationSorter::interIterUpdate() {
-  // Go through groups and lower compute at domain
-  bool lowered_ca_domain = false;
+  // Go through groups and lower either pa or ca domain return if anything was
+  // lowered
+  bool lowered_a_domain = false;
   for (auto& group : groups_) {
-    IterDomain* g_last_id = nullptr;
-    if (group->payload()->ca_domains_.size() > 0) {
-      g_last_id = group->payload()->ca_domains_.back();
-    }
-    if (g_last_id == nullptr) {
-      continue;
-    }
-
-    bool matching_neighbor = false;
-    for (auto neighbor : group->getNeighbors()) {
-      if (matching_neighbor) {
-        break;
-      }
-      for (auto p_id : neighbor->payload()->ca_domains_) {
-        if (GpuLower::current()->caLoopMap().areMapped(p_id, g_last_id)) {
-          matching_neighbor = true;
-          break;
-        }
-      }
-    }
-
-    if (!matching_neighbor) {
+    while (canReduceCA(group.get())) {
       group->payload()->ca_domains_.pop_back();
-      lowered_ca_domain = true;
+      lowered_a_domain = true;
+    }
+
+    if (canReducePA(group.get())) {
+      group->payload()->pa_domains_.pop_back();
+      lowered_a_domain = true;
     }
   }
 
   // If we couldn't lower compute at domain any further, and we haven't merged
   // any new groups after fallback_mode_enabled_ has been turned on, make sure
   // we've finished successfully
-  if (!lowered_ca_domain && n_groups_ == groups_.size()) {
+  if (!lowered_a_domain && n_groups_ == groups_.size()) {
     // Make sure none of the groups are still connected, as that would mean we
     // should have been able to merge them.
     bool successfully_finished = std::all_of(
@@ -816,19 +918,32 @@ void ExprSegmentationSorter::mergeNodes() {
 }
 
 bool ExprSegmentationSorter::supportedMerge(ExprGroup* sg1, ExprGroup* sg2) {
-  auto domain1 = sg1->payload()->ca_domains_;
-  auto domain2 = sg2->payload()->ca_domains_;
+  auto producer_group = getProducer(sg1, sg2);
+  auto consumer_group = sg1 == producer_group ? sg2 : sg1;
 
-  if (domain1.empty() && domain2.empty()) {
+  if (producer_group->payload()->ca_domains_.size() <
+      producer_group->payload()->pa_domains_.size()) {
+    return false;
+  }
+
+  if (consumer_group->payload()->pa_domains_.size() <
+      consumer_group->payload()->ca_domains_.size()) {
+    return false;
+  }
+
+  auto producer_domain = producer_group->payload()->ca_domains_;
+  auto consumer_domain = consumer_group->payload()->pa_domains_;
+
+  if (producer_domain.empty() && consumer_domain.empty()) {
     return true;
   }
 
-  if (domain1.empty() || domain2.empty()) {
+  if (producer_domain.empty() || consumer_domain.empty()) {
     return false;
   }
 
   return GpuLower::current()->caLoopMap().areMapped(
-      domain1.back(), domain2.back());
+      producer_domain.back(), consumer_domain.back());
 }
 
 bool ExprSegmentationSorter::testStillDag(ExprGroup* sg1, ExprGroup* sg2) {
@@ -969,25 +1084,35 @@ void ExprSegmentationSorter::sort() {
         }
 
         auto candidate_it = candidates.begin();
-        while (candidate_it != candidates.end() &&
-               !supportedMerge(group.get(), *candidate_it)) {
+
+        while (candidate_it != candidates.end()) {
+          while (candidate_it != candidates.end() &&
+                 !supportedMerge(group.get(), *candidate_it)) {
+            candidate_it++;
+          }
+
+          if (candidate_it == candidates.end()) {
+            break;
+          }
+
+          if (testStillDag(group.get(), *candidate_it)) {
+            // Mark in same style as default algorithm for convenience even
+            // though we will only merge once with the fallback
+            to_merge_.emplace(group.get());
+            to_merge_.emplace(*candidate_it);
+
+            group->payload()->merged = true;
+            group->payload()->merge_with = *candidate_it;
+
+            (*candidate_it)->payload()->merged = true;
+            (*candidate_it)->payload()->merge_with = group.get();
+            break;
+          }
+
           candidate_it++;
         }
-        if (candidate_it == candidates.end()) {
-          continue;
-        }
 
-        if (testStillDag(group.get(), *candidate_it)) {
-          // Mark in same style as default algorithm for convenience even though
-          // we will only merge once with the fallback
-          to_merge_.emplace(group.get());
-          to_merge_.emplace(*candidate_it);
-
-          group->payload()->merged = true;
-          group->payload()->merge_with = *candidate_it;
-
-          (*candidate_it)->payload()->merged = true;
-          (*candidate_it)->payload()->merge_with = group.get();
+        if (to_merge_.size() > 0) {
           break;
         }
       }
@@ -1004,36 +1129,6 @@ void ExprSegmentationSorter::sort() {
     }
   }
 }
-
-// Debug printing, disabled due to clang-tidy see above for declarations.
-//  std::ostream& operator<<(std::ostream& os, ExprGroup* group) {
-//   os << "g{";
-//   for (size_t i = 0; i < group->exprs().size(); i++) {
-//     os << group->exprs()[i]->name();
-//     if (i + 1 != group->exprs().size())
-//       os << ", ";
-//   }
-//   os << "} ca_ids {";
-//   for (size_t i = 0; i < group->payload()->ca_domains_.size(); i++) {
-//     os << group->payload()->ca_domains_[i];
-//     if (i + 1 != group->payload()->ca_domains_.size())
-//       os << ", ";
-//   }
-
-//   os << "}";
-//   return os;
-// }
-//
-// std::ostream& operator<<(std::ostream& os, const ExprGroupConnections* edge)
-// {
-//   os << "e{ " << edge->from << " -> " << edge->to << " }" << std::endl;
-//   return os;
-// }
-//
-// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter* scf)
-// {
-//   return os << scf->toString();
-// }
 
 std::vector<Expr*> ExprSegmentationSorter::getExprs() const {
   std::vector<Expr*> exprs;

--- a/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
@@ -57,7 +57,8 @@ class ExprSegmentationSorter;
 // Debug printing disabled due to clang tidy, see below for definitions
 // std::ostream& operator<<(std::ostream& os, const ExprGroupConnections* edge);
 // std::ostream& operator<<(std::ostream& os, const ExprGroup* group);
-// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter* scf);
+// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter*
+// scf);
 
 // Wrapper for values, these are edges between expr groups. Multiple edges can
 // exist between expr groups, and the same Val can show up more than once in
@@ -328,12 +329,14 @@ class ExprSegmentationSorter {
 //   return os;
 // }
 
-// std::ostream& operator<<(std::ostream& os, const ExprGroupConnections* edge) {
+// std::ostream& operator<<(std::ostream& os, const ExprGroupConnections* edge)
+// {
 //   os << "e{ " << edge->from << " -> " << edge->to << " }" << std::endl;
 //   return os;
 // }
 
-// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter* scf) {
+// std::ostream& operator<<(std::ostream& os, const ExprSegmentationSorter* scf)
+// {
 //   return os << scf->toString();
 // }
 

--- a/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
@@ -639,28 +639,6 @@ ExprGroup* getProducer(ExprGroup* sg1, ExprGroup* sg2) {
   return nullptr;
 }
 
-} // namespace
-
-// Disconect group from neighbors, and return edges that were disconnected
-std::unordered_set<ExprGroupConnections*> ExprSegmentationSorter::
-    disconnectGroup(ExprGroup* group) {
-  std::unordered_set<ExprGroupConnections*> removed_edges(
-      group->producerEdges().begin(), group->producerEdges().end());
-
-  for (auto edge : group->producerEdges()) {
-    edge->from->removeConsumerEdge(edge);
-  }
-
-  for (auto edge : group->consumerEdges()) {
-    edge->to->removeProducerEdge(edge);
-  }
-
-  group->clearProducerEdges();
-  group->clearConsumerEdges();
-
-  return removed_edges;
-}
-
 std::vector<IterDomain*> mergeDomains(
     const std::vector<IterDomain*>& domain1,
     const std::vector<IterDomain*>& domain2) {
@@ -710,6 +688,28 @@ std::vector<IterDomain*> mergeDomains(
     }
   }
   return resulting_domain;
+}
+
+} // namespace
+
+// Disconect group from neighbors, and return edges that were disconnected
+std::unordered_set<ExprGroupConnections*> ExprSegmentationSorter::
+    disconnectGroup(ExprGroup* group) {
+  std::unordered_set<ExprGroupConnections*> removed_edges(
+      group->producerEdges().begin(), group->producerEdges().end());
+
+  for (auto edge : group->producerEdges()) {
+    edge->from->removeConsumerEdge(edge);
+  }
+
+  for (auto edge : group->consumerEdges()) {
+    edge->to->removeProducerEdge(edge);
+  }
+
+  group->clearProducerEdges();
+  group->clearConsumerEdges();
+
+  return removed_edges;
 }
 
 // TODO: This function may be sub optimial. If we find that an iteration domain

--- a/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
@@ -809,16 +809,24 @@ bool canReduceCA(ExprGroup* group) {
     return false;
   }
 
+  // Compute at can sometimes get in a strange position as the update rules are
+  // not fool proof. All consumers should have a match to this groups inner most
+  // compute at axis, otherwise it should be lowered.
   for (auto consumer_edge : group->consumerEdges()) {
     auto consumer = consumer_edge->to;
+    bool has_match = false;
     for (auto c_id : consumer->payload()->pa_domains_) {
       if (GpuLower::current()->caLoopMap().areMapped(c_id, g_last_id)) {
-        return false;
+        has_match = true;
+        break;
       }
+    }
+    if (!has_match) {
+      return true;
     }
   }
 
-  return true;
+  return false;
 }
 
 bool canReducePA(ExprGroup* group) {


### PR DESCRIPTION
See added test for what was broken. General gist is that we need to set compute at domains and produce at domains separately when we do the ordering. Compute at of producer needs to check produce at of consumer. The inner most of those two domains must match to merge in the algorithm. Also if produce at of producer or compute at of consumer is larger than their complements, the group can't be merge.