### PR TITLE
Fix potential segfault and misaligned vector error.

### DIFF
--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -241,8 +241,10 @@ void IndexCompute::handle(Split* split) {
   const bool outer_bcast = outer_id->isBroadcast();
   const bool inner_bcast = inner_id->isBroadcast();
 
-  const bool outer_vect = outer_id->parallelType() == ParallelType::Vectorize;
-  const bool inner_vect = inner_id->parallelType() == ParallelType::Vectorize;
+  const bool outer_vect =
+      split->outer()->getParallelType() == ParallelType::Vectorize;
+  const bool inner_vect =
+      split->inner()->getParallelType() == ParallelType::Vectorize;
 
   // We want to mark as zero merged in if we're working with shared or local
   // memory, and the dimension we're working with is not part of the allocation,

--- a/torch/csrc/jit/codegen/cuda/lower_validation.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_validation.cpp
@@ -250,9 +250,10 @@ void validateVectorize(Fusion* fusion) {
     }
     if (has_vectorize_dim) {
       TORCH_INTERNAL_ASSERT(
-          tv->definition()->isA<UnaryOp>() &&
-              tv->definition()->as<UnaryOp>()->getUnaryOpType() ==
-                  UnaryOpType::Set,
+          tv->definition() == nullptr ||
+              (tv->definition()->isA<UnaryOp>() &&
+               tv->definition()->as<UnaryOp>()->getUnaryOpType() ==
+                   UnaryOpType::Set),
           "Vectorized accesses cannot be inline with computation, they are only supported with a Set operation.");
       VectorizeValidator::validate(tv);
     }


### PR DESCRIPTION
Was checking definition when didn't exist, and was checking parallel type on a lowered node although it ended up being lowered before we modified the type and didn't reflect the changes.