### PR TITLE
Detect trivial reductions more comprehensively

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9942,8 +9942,7 @@ TEST(NVFuserTest, FusionDetectTrivialReduction_CUDA) {
   fe.compileFusion(&fusion);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, {t0}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST(NVFuserTest, FusionInputsIdLookup_CUDA) {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -3282,8 +3282,6 @@ TEST(NVFuserTest, FusionRootMappingTrivialReduction_CUDA) {
 
   tv2->computeAt(tv4, -1);
 
-  fusion.printKernel();
-
   const int x = 11;
   const int y = 12;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9932,7 +9932,7 @@ TEST(NVFuserTest, FusionTrivialReduction3_CUDA) {
 
 // Make sure trivial reductions are correctly detected even with
 // scheduling applied.
-TEST(NVFuserTest, FusionDetectTrivialReduction1_CUDA) {
+TEST(NVFuserTest, FusionDetectTrivialReduction_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -13550,6 +13550,7 @@ TEST(NVFuserTest, FusionBlockWelfordInSerialLoop_CUDA) {
       &fusion, outputs, aten_inputs, {aten_M2, aten_avg}, __LINE__, __FILE__);
 }
 
+// See Issue #716
 TEST(NVFuserTest, FusionIOTensorTrivialReductionRepro_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
@@ -13568,16 +13569,10 @@ TEST(NVFuserTest, FusionIOTensorTrivialReductionRepro_CUDA) {
   auto path1 = sum(path1_bcast, reduction_axes);
   fusion.addOutput(path1);
 
-#if true // set this to false to see the right result
   auto p = path1->split(1, 1);
-  path1->axis(0)->parallelize(ParallelType::BIDx);
   path1->rFactor({1});
+  path1->axis(0)->parallelize(ParallelType::BIDx);
   tv0->computeAt(path1, 1);
-#else
-  path1->axis(0)->parallelize(ParallelType::TIDx);
-  path1->axis(1)->parallelize(ParallelType::BIDx);
-  tv0->computeAt(path1, 1);
-#endif
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::manual_seed(0);
@@ -13588,14 +13583,10 @@ TEST(NVFuserTest, FusionIOTensorTrivialReductionRepro_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion);
 
-  // Error occurs at executor.cpp:321.
-  // TODO: Enable below.
-#if 0
   // inplace op, we are adding t0 to itself
   auto outputs = fe.runFusion(aten_inputs, {t0});
 
   TORCH_CHECK(outputs[0].allclose(t0_ref.add(1)));
-#endif
 }
 
 } // namespace jit

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -417,6 +417,7 @@ libtorch_cuda_core_sources = [
     "torch/csrc/jit/codegen/cuda/lower_insert_syncs.cpp",
     "torch/csrc/jit/codegen/cuda/lower_loops.cpp",
     "torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp",
+    "torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp",
     "torch/csrc/jit/codegen/cuda/lower_unroll.cpp",
     "torch/csrc/jit/codegen/cuda/lower_utils.cpp",
     "torch/csrc/jit/codegen/cuda/lower_validation.cpp",

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
@@ -20,12 +20,13 @@ class ConcreteInputCounter : public IterVisitor {
   // Returns number of non-braodcast non-reduction iteration domains used to
   // generate the iteration domains in provided target domain.
   static std::unordered_map<IterDomain*, int> produceCounts(
-      const std::vector<IterDomain*>& domain) {
+      const std::vector<IterDomain*>& domain,
+      GpuLower* gpu_lower) {
     std::unordered_map<IterDomain*, int> count_map;
     if (domain.empty()) {
       return count_map;
     }
-    ConcreteInputCounter counter(domain);
+    ConcreteInputCounter counter(domain, gpu_lower);
     std::transform(
         counter.concrete_domain_set_.begin(),
         counter.concrete_domain_set_.end(),
@@ -38,14 +39,18 @@ class ConcreteInputCounter : public IterVisitor {
     // were traversed, so manually insert their count
     for (auto id : domain) {
       if (count_map.find(id) == count_map.end()) {
-        count_map[id] = id->isBroadcast() ? 0 : 1;
+        count_map[id] =
+            (id->isBroadcast() || gpu_lower->isTrivialReduction(id)) ? 0 : 1;
       }
     }
     return count_map;
   }
 
  private:
-  ConcreteInputCounter(const std::vector<IterDomain*>& domain_) {
+  ConcreteInputCounter(
+      const std::vector<IterDomain*>& domain_,
+      GpuLower* gpu_lower)
+      : gpu_lower_(gpu_lower) {
     traverseFrom(
         domain_[0]->fusion(),
         std::vector<Val*>(domain_.begin(), domain_.end()));
@@ -58,7 +63,7 @@ class ConcreteInputCounter : public IterVisitor {
           concrete_domain_set_
               .emplace(std::make_pair(id, std::unordered_set<IterDomain*>()))
               .first;
-      if (!id->isBroadcast()) {
+      if (!id->isBroadcast() && !gpu_lower_->isTrivialReduction(id)) {
         concrete_set_it->second.emplace(id);
       }
     }
@@ -91,6 +96,7 @@ class ConcreteInputCounter : public IterVisitor {
 
   std::unordered_map<IterDomain*, std::unordered_set<IterDomain*>>
       concrete_domain_set_;
+  GpuLower* gpu_lower_ = nullptr;
 };
 
 // Only used once, consider removing.
@@ -301,13 +307,14 @@ void ComputeAtMap::build(Fusion* fusion, GpuLower* gpu_lower) {
   std::unordered_map<IterDomain*, int> n_concrete_ids_;
 
   for (auto c_tv : consumer_tvs) {
-    auto counts = ConcreteInputCounter::produceCounts(c_tv->domain()->domain());
+    auto counts = ConcreteInputCounter::produceCounts(
+        c_tv->domain()->domain(), gpu_lower);
     n_concrete_ids_.insert(counts.begin(), counts.end());
   }
 
   for (auto inp_tv : ir_utils::filterByType<TensorView>(fusion->inputs())) {
-    auto counts =
-        ConcreteInputCounter::produceCounts(inp_tv->domain()->domain());
+    auto counts = ConcreteInputCounter::produceCounts(
+        inp_tv->domain()->domain(), gpu_lower);
     n_concrete_ids_.insert(counts.begin(), counts.end());
   }
 

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
@@ -40,7 +40,9 @@ class ConcreteInputCounter : public IterVisitor {
     for (auto id : domain) {
       if (count_map.find(id) == count_map.end()) {
         count_map[id] =
-            (id->isBroadcast() || gpu_lower->isTrivialReduction(id)) ? 0 : 1;
+            (id->isBroadcast() || gpu_lower->isDerivedFromTrivialReduction(id))
+            ? 0
+            : 1;
       }
     }
     return count_map;
@@ -63,7 +65,8 @@ class ConcreteInputCounter : public IterVisitor {
           concrete_domain_set_
               .emplace(std::make_pair(id, std::unordered_set<IterDomain*>()))
               .first;
-      if (!id->isBroadcast() && !gpu_lower_->isTrivialReduction(id)) {
+      if (!id->isBroadcast() &&
+          !gpu_lower_->isDerivedFromTrivialReduction(id)) {
         concrete_set_it->second.emplace(id);
       }
     }

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -1042,7 +1042,8 @@ kir::TensorIndex* Index::getProducerIndex_impl(
   auto root_dom = producer_tv->getMaybeRFactorDomain();
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
-    if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast()) {
+    if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast() ||
+        gpu_lower->isTrivialReduction(root_dom[i])) {
       continue;
     }
 
@@ -1067,7 +1068,8 @@ kir::TensorIndex* Index::getProducerIndex_impl(
     // Compute striding for this index.
     kir::Val* stride = nullptr;
     for (size_t j = i + 1; j < root_dom.size(); j++) {
-      if (root_dom[j]->isBroadcast() || root_dom[j]->isReduction()) {
+      if (root_dom[j]->isBroadcast() || root_dom[j]->isReduction() ||
+          gpu_lower->isTrivialReduction(root_dom[j])) {
         continue;
       }
 
@@ -1289,7 +1291,8 @@ kir::TensorIndex* Index::getConsumerIndex_impl(
   auto root_dom = consumer_tv->getMaybeRFactorDomain();
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
-    if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast()) {
+    if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast() ||
+        gpu_lower->isTrivialReduction(root_dom[i])) {
       continue;
     }
 
@@ -1313,7 +1316,8 @@ kir::TensorIndex* Index::getConsumerIndex_impl(
     // Compute striding for this index.
     kir::Val* stride = nullptr;
     for (size_t j = i + 1; j < root_dom.size(); j++) {
-      if (root_dom[j]->isBroadcast() || root_dom[j]->isReduction()) {
+      if (root_dom[j]->isBroadcast() || root_dom[j]->isReduction() ||
+          gpu_lower->isTrivialReduction(root_dom[j])) {
         continue;
       }
 

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -804,13 +804,12 @@ kir::TensorIndex* Index::getGlobalProducerIndex(
     if (root_dom[i]->isReduction() ||
         root_dom[i]->getIterType() == IterType::BroadcastWithoutStride) {
       continue;
-    } else if (root_dom[i]->getIterType() == IterType::BroadcastWithStride) {
-      stride_i++;
-      continue;
-    } else if (gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
       // If the domain is derived from a trivial reduction, no indexing to
       // create. Also, the domain at this branch must not be a
       // reduction, so the stride index should be incremented.
+    } else if (
+        root_dom[i]->getIterType() == IterType::BroadcastWithStride ||
+        gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
       stride_i++;
       continue;
     }
@@ -1172,11 +1171,10 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
     if (root_dom[i]->isReduction() ||
         root_dom[i]->getIterType() == IterType::BroadcastWithoutStride) {
       continue;
-    } else if (root_dom[i]->getIterType() == IterType::BroadcastWithStride) {
-      stride_i++;
-      continue;
-    } else if (gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
       // See a comment in indexing to root domains in getGlobalProducerIndex.
+    } else if (
+        root_dom[i]->getIterType() == IterType::BroadcastWithStride ||
+        gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
       stride_i++;
       continue;
     }

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -335,7 +335,7 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
   IterDomain* clone() const {
     return new IterDomain(
         start(),
-        extent(),
+        rawExtent(),
         getParallelType(),
         getIterType(),
         isRFactorProduct());

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -425,9 +425,12 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
 
   //! Check if IterDomain is a reduction axis with size of 1, i.e.
   //! a "squeeze" operator.
-  //! TODO: Consider removing this as it does not detect trivial
-  //! reduction always. Trivial reductions are detected at the
-  //! lowering time.
+  //!
+  //! NOTE: Detection of trivial reduction here is not
+  //! comprehensive. See detectTrivialReductionDerivedDomains for more
+  //! comprehensive analysis. We typically use this for root domain trivial
+  //! reduction checks. So we ship to the correct scheduler. It may
+  //! not be incredibly robust, but it makes sense to keep it for now.
   bool isTrivialReduction() const {
     return isReduction() && rawExtent()->isOneInt();
   }

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -425,7 +425,10 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
 
   //! Check if IterDomain is a reduction axis with size of 1, i.e.
   //! a "squeeze" operator.
-  bool isDerivedFromTrivialReduction() const {
+  //! TODO: Consider removing this as it does not detect trivial
+  //! reduction always. Trivial reductions are detected at the
+  //! lowering time.
+  bool isTrivialReduction() const {
     return isReduction() && rawExtent()->isOneInt();
   }
 

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -425,7 +425,7 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
 
   //! Check if IterDomain is a reduction axis with size of 1, i.e.
   //! a "squeeze" operator.
-  bool isTrivialReduction() const {
+  bool isDerivedFromTrivialReduction() const {
     return isReduction() && rawExtent()->isOneInt();
   }
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1056,7 +1056,7 @@ bool TensorDomain::hasReduction(const std::vector<IterDomain*>& td) {
 
 bool TensorDomain::hasNontrivialReduction(const std::vector<IterDomain*>& td) {
   for (auto id : td) {
-    if (id->isReduction() && !id->isTrivialReduction()) {
+    if (id->isReduction() && !id->isDerivedFromTrivialReduction()) {
       return true;
     }
   }

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -1056,7 +1056,7 @@ bool TensorDomain::hasReduction(const std::vector<IterDomain*>& td) {
 
 bool TensorDomain::hasNontrivialReduction(const std::vector<IterDomain*>& td) {
   for (auto id : td) {
-    if (id->isReduction() && !id->isDerivedFromTrivialReduction()) {
+    if (id->isReduction() && !id->isTrivialReduction()) {
       return true;
     }
   }

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/jit/codegen/cuda/lower_insert_syncs.h>
 #include <torch/csrc/jit/codegen/cuda/lower_loops.h>
 #include <torch/csrc/jit/codegen/cuda/lower_thread_predicate.h>
+#include <torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h>
 #include <torch/csrc/jit/codegen/cuda/lower_unroll.h>
 #include <torch/csrc/jit/codegen/cuda/lower_utils.h>
 #include <torch/csrc/jit/codegen/cuda/lower_validation.h>
@@ -108,6 +109,8 @@ void GpuLower::lower() {
   // prepare for lowering
   validateIr(fusion_);
   replaceSymbolicSizes();
+
+  trivial_reductions_ = detectTrivialReductions(fusion_);
 
   // In the future we may directly use this map, but for now it will propagate
   // and validate (to some extent) the parallelization strategy.
@@ -299,9 +302,21 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
   }
 
   void handle(const ReductionOp* node) final {
+    auto out_tv = node->out()->as<TensorView>();
     // If trivial reduction operation lower to set operation.
-    if (!TensorDomain::hasNontrivialReduction(
-            node->out()->as<TensorView>()->getRootDomain())) {
+    if (std::all_of(
+            out_tv->domain()->domain().begin(),
+            out_tv->domain()->domain().end(),
+            [&](IterDomain* id) {
+              // If id is a reduction axis, is it a trivial reduction?
+              if (id->isReduction()) {
+                return gpu_lower_->trivial_reductions_.find(id) !=
+                    gpu_lower_->trivial_reductions_.end();
+              } else {
+                return true;
+              }
+            })) {
+      std::cerr << "Trivial reduction detected: " << node << std::endl;
       const auto lowered_node = ir_builder_.create<kir::UnaryOp>(
           UnaryOpType::Set, lowerValue(node->out()), lowerValue(node->in()));
       TORCH_CHECK(

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -300,8 +300,8 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
 
   void handle(const ReductionOp* node) final {
     // If trivial reduction operation lower to set operation.
-    if (!node->out()->as<TensorView>()->hasReduction() &&
-        node->out()->as<TensorView>()->hasAnyReduction()) {
+    if (!TensorDomain::hasNontrivialReduction(
+            node->out()->as<TensorView>()->getRootDomain())) {
       const auto lowered_node = ir_builder_.create<kir::UnaryOp>(
           UnaryOpType::Set, lowerValue(node->out()), lowerValue(node->in()));
       TORCH_CHECK(

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -111,6 +111,10 @@ void GpuLower::lower() {
   replaceSymbolicSizes();
 
   trivial_reductions_ = detectTrivialReductions(fusion_);
+  for (auto id : trivial_reductions_) {
+    auto kir_trivial_id = lowerValue(id)->as<kir::IterDomain>();
+    kir_trivial_reductions_.insert(kir_trivial_id);
+  }
 
   // In the future we may directly use this map, but for now it will propagate
   // and validate (to some extent) the parallelization strategy.

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -320,7 +320,6 @@ class GpuLower::KernelIrMapper : private OptInConstDispatch {
                 return true;
               }
             })) {
-      std::cerr << "Trivial reduction detected: " << node << std::endl;
       const auto lowered_node = ir_builder_.create<kir::UnaryOp>(
           UnaryOpType::Set, lowerValue(node->out()), lowerValue(node->in()));
       TORCH_CHECK(

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -110,7 +110,7 @@ void GpuLower::lower() {
   validateIr(fusion_);
   replaceSymbolicSizes();
 
-  trivial_reductions_ = detectTrivialReductions(fusion_);
+  trivial_reductions_ = detectTrivialReductionDerivedDomains(fusion_);
   for (auto id : trivial_reductions_) {
     auto kir_trivial_id = lowerValue(id)->as<kir::IterDomain>();
     kir_trivial_reductions_.insert(kir_trivial_id);

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -73,6 +73,7 @@ class TORCH_CUDA_CU_API GpuLower {
   ComputeAtMap ca_loop_map_;
   ComputeAtMap ca_index_map_;
   ComputeAtMap ca_parallel_map_;
+  std::unordered_set<IterDomain*> trivial_reductions_;
 
   Fusion* fusion_ = nullptr;
 };

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -54,8 +54,16 @@ class TORCH_CUDA_CU_API GpuLower {
     return trivial_reductions_;
   }
 
+  const auto& kirTrivialReductions() const {
+    return kir_trivial_reductions_;
+  }
+
   bool isTrivialReduction(IterDomain* id) const {
     return trivialReductions().find(id) != trivialReductions().end();
+  }
+
+  bool isTrivialReduction(kir::IterDomain* id) const {
+    return kirTrivialReductions().find(id) != kirTrivialReductions().end();
   }
 
  private:
@@ -82,6 +90,7 @@ class TORCH_CUDA_CU_API GpuLower {
   ComputeAtMap ca_index_map_;
   ComputeAtMap ca_parallel_map_;
   std::unordered_set<IterDomain*> trivial_reductions_;
+  std::unordered_set<kir::IterDomain*> kir_trivial_reductions_;
 
   Fusion* fusion_ = nullptr;
 };

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -50,6 +50,14 @@ class TORCH_CUDA_CU_API GpuLower {
     return ca_parallel_map_;
   }
 
+  const auto& trivialReductions() const {
+    return trivial_reductions_;
+  }
+
+  bool isTrivialReduction(IterDomain* id) const {
+    return trivialReductions().find(id) != trivialReductions().end();
+  }
+
  private:
   void lower();
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -58,11 +58,11 @@ class TORCH_CUDA_CU_API GpuLower {
     return kir_trivial_reductions_;
   }
 
-  bool isTrivialReduction(IterDomain* id) const {
+  bool isDerivedFromTrivialReduction(IterDomain* id) const {
     return trivialReductions().find(id) != trivialReductions().end();
   }
 
-  bool isTrivialReduction(kir::IterDomain* id) const {
+  bool isDerivedFromTrivialReduction(kir::IterDomain* id) const {
     return kirTrivialReductions().find(id) != kirTrivialReductions().end();
   }
 

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -122,7 +122,7 @@ void LoopNestGenerator::handle(const Expr* expr) {
     // map, which also maps non-CA axes.
     auto concrete_id =
         gpu_lower->caParallelMap().getConcreteMappedID(out_tv->axis(out_i));
-    if (gpu_lower->isTrivialReduction(concrete_id)) {
+    if (gpu_lower->isDerivedFromTrivialReduction(concrete_id)) {
       continue;
     }
     loop_structure.push_back(concrete_id);

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -122,6 +122,9 @@ void LoopNestGenerator::handle(const Expr* expr) {
     // map, which also maps non-CA axes.
     auto concrete_id =
         gpu_lower->caParallelMap().getConcreteMappedID(out_tv->axis(out_i));
+    if (gpu_lower->isTrivialReduction(concrete_id)) {
+      continue;
+    }
     loop_structure.push_back(concrete_id);
   }
 

--- a/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp
@@ -75,7 +75,14 @@ std::unordered_set<IterDomain*> detectTrivialReductions(Fusion* fusion) {
   for (auto tv : ir_utils::filterByType<TensorView>(used_vals)) {
     for (auto id : tv->domain()->domain()) {
       if (isTrivialReduction(tv, id)) {
-        trivial_reductions.insert(id);
+        // If id is a trivial reduction, all of its ancestor vals are
+        // also trivial reductions.
+        for (auto dep_id : DependencyCheck::getAllValsBetween(
+                 std::unordered_set<Val*>(
+                     tv->getRootDomain().begin(), tv->getRootDomain().end()),
+                 {id})) {
+          trivial_reductions.insert(dep_id->as<IterDomain>());
+        }
       }
     }
   }

--- a/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp
@@ -1,0 +1,89 @@
+#include <torch/csrc/jit/codegen/cuda/dispatch.h>
+#include <torch/csrc/jit/codegen/cuda/instrumentation.h>
+#include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
+#include <torch/csrc/jit/codegen/cuda/iter_visitor.h>
+#include <torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h>
+#include <torch/csrc/jit/codegen/cuda/root_domain_map.h>
+
+#include <unordered_set>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+namespace {
+
+bool isTrivialReduction(TensorView* tv, IterDomain* id);
+
+bool traverseToRFactorTensor(TensorView* tv, IterDomain* root_id) {
+  TORCH_INTERNAL_ASSERT(
+      root_id->definition() == nullptr, "Not root IterDomain: ", root_id);
+
+  if (tv->definition() == nullptr) {
+    return false;
+  }
+
+  const auto& inputs = tv->definition()->inputs();
+
+  if (inputs.size() != 1 || !inputs[0]->isA<TensorView>()) {
+    return false;
+  }
+
+  auto producer = inputs[0]->as<TensorView>();
+
+  if (!producer->hasRFactor()) {
+    return false;
+  }
+
+  auto c2p = PairwiseRootDomainMap(producer, tv)
+                 .mapConsumerToProducer(tv->domain(), producer->domain());
+
+  auto producer_id_it = c2p.find(root_id);
+  if (producer_id_it == c2p.end()) {
+    // No matching producer is found. Stop traversing.
+    return false;
+  }
+
+  auto producer_root_id = producer_id_it->second;
+
+  return isTrivialReduction(producer, producer_root_id);
+}
+
+bool isTrivialReduction(TensorView* tv, IterDomain* id) {
+  auto id_inputs = InputsOf::output(id->fusion(), id);
+  for (auto root_id : ir_utils::filterByType<IterDomain>(id_inputs)) {
+    if (root_id->isReduction() && root_id->rawExtent()->isOneInt()) {
+      continue;
+    }
+    if (!traverseToRFactorTensor(tv, root_id)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+std::unordered_set<IterDomain*> detectTrivialReductions(Fusion* fusion) {
+  auto used_vals = DependencyCheck::getAllValsBetween(
+      {fusion->inputs().begin(), fusion->inputs().end()}, fusion->outputs());
+
+  std::unordered_set<IterDomain*> trivial_reductions;
+
+  for (auto tv : ir_utils::filterByType<TensorView>(used_vals)) {
+    for (auto id : tv->domain()->domain()) {
+      if (isTrivialReduction(tv, id)) {
+        trivial_reductions.insert(id);
+      }
+    }
+  }
+
+  return trivial_reductions;
+}
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.cpp
@@ -15,7 +15,7 @@ namespace cuda {
 
 namespace {
 
-bool isTrivialReduction(TensorView* tv, IterDomain* id);
+bool isDerivedFromTrivialReduction(TensorView* tv, IterDomain* id);
 
 bool traverseToRFactorTensor(TensorView* tv, IterDomain* root_id) {
   TORCH_INTERNAL_ASSERT(
@@ -48,10 +48,10 @@ bool traverseToRFactorTensor(TensorView* tv, IterDomain* root_id) {
 
   auto producer_root_id = producer_id_it->second;
 
-  return isTrivialReduction(producer, producer_root_id);
+  return isDerivedFromTrivialReduction(producer, producer_root_id);
 }
 
-bool isTrivialReduction(TensorView* tv, IterDomain* id) {
+bool isDerivedFromTrivialReduction(TensorView* tv, IterDomain* id) {
   auto id_inputs = InputsOf::output(id->fusion(), id);
   for (auto root_id : ir_utils::filterByType<IterDomain>(id_inputs)) {
     if (root_id->isReduction() && root_id->rawExtent()->isOneInt()) {
@@ -74,7 +74,7 @@ std::unordered_set<IterDomain*> detectTrivialReductions(Fusion* fusion) {
 
   for (auto tv : ir_utils::filterByType<TensorView>(used_vals)) {
     for (auto id : tv->domain()->domain()) {
-      if (isTrivialReduction(tv, id)) {
+      if (isDerivedFromTrivialReduction(tv, id)) {
         // If id is a trivial reduction, all of its ancestor vals are
         // also trivial reductions.
         for (auto dep_id : DependencyCheck::getAllValsBetween(

--- a/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h
+++ b/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h
@@ -13,7 +13,12 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-std::unordered_set<IterDomain*> detectTrivialReductions(Fusion* fusion);
+//! Detect all IterDomains that are derived only from trivial
+//! reductons, thus not necessary to appear in the final generated
+//! kernel. The returned set includes all domains from root to
+//! leaves. It also can include non-reduction, rfactor domains.
+std::unordered_set<IterDomain*> detectTrivialReductionDerivedDomains(
+    Fusion* fusion);
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h
+++ b/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+#include <torch/csrc/jit/codegen/cuda/dispatch.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/kernel_ir.h>
+
+#include <unordered_set>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+std::unordered_set<IterDomain*> detectTrivialReductions(Fusion* fusion);
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -84,7 +84,7 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
 
     if (root[i]->isBroadcast()) {
       continue;
-    } else if (gpu_lower->isTrivialReduction(root[i])) {
+    } else if (gpu_lower->isDerivedFromTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {
       extent = nullptr;

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
 #include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_ir_builder.h>
+#include <torch/csrc/jit/codegen/cuda/kernel_ir_printer.h>
 #include <torch/csrc/jit/codegen/cuda/lower2device.h>
 #include <torch/csrc/jit/codegen/cuda/transform_iter.h>
 
@@ -82,6 +83,8 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool simple_ind = indices[i]->definition() == nullptr;
 
     if (root[i]->isBroadcast()) {
+      continue;
+    } else if (gpu_lower->isTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {
       extent = nullptr;

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -82,9 +82,8 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool zero_ind = indices[i]->isZeroInt();
     const bool simple_ind = indices[i]->definition() == nullptr;
 
-    if (root[i]->isBroadcast()) {
-      continue;
-    } else if (gpu_lower->isDerivedFromTrivialReduction(root[i])) {
+    if (root[i]->isBroadcast() ||
+        gpu_lower->isDerivedFromTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {
       extent = nullptr;


### PR DESCRIPTION
This PR addresses the issues around trivial reductions (#727):

1. Detect IterDomains that are derived from trivial reductions (lower_trivial_reduction.cpp)
2. In ComputeAtMap, avoid choosing trivial-reduction domains as concrete domains
3. When generating kir::ForLoops, do not generate loops with trivial-reduction IterDomains

Currently, trivial reductions are only detected when the extent of reduced axis is literal one, and it does not work, e.g., if the axis is split. This PR should find all such domains by backward-traversing IterDomain expressions to root domains.

The second problem in issue #727 is solved by not choosing trivial-reduction IterDomains over other domains as concrete IDs in ComputeAtMap.

Finally, trivial-reduction domains may still show up as a concrete ID for loop generation when no other mappable domain is found. In such case, since no loop is needed, it is simply skipped when generating loops.

Fixes #727 


