### PR TITLE
Fix predicate for reduction buffer init

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -13671,6 +13671,46 @@ TEST(NVFuserTest, FusionIOTensorTrivialReductionRepro_CUDA) {
   TORCH_CHECK(outputs[0].allclose(t0_ref.add(1)));
 }
 
+TEST(NVFuserTest, FusionReductionPredicate_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  auto tv1 = sum(tv0, {0});
+  fusion.addOutput(tv1);
+
+  auto tv2 = tv0->cache_after();
+
+  const int bdimx = 128;
+  tv1->split(1, bdimx);
+  tv1->split(1, 4);
+  tv1->split(1, 1);
+
+  tv1->axis(-1)->parallelize(ParallelType::TIDx);
+  tv1->axis(2)->parallelize(ParallelType::Unroll);
+  tv0->computeAt(tv1, 3);
+
+  tv2->axis(-1)->parallelize(ParallelType::TIDx);
+  tv2->axis(2)->parallelize(ParallelType::Unroll);
+
+  int numel_x = 650;
+  int numel_y = 102;
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor input = at::randn({numel_x, numel_y}, options);
+  at::Tensor cg_output = at::empty({numel_y}, options);
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  fe.runFusion({input}, {cg_output});
+
+  auto aten_output = input.to(at::kDouble).sum({0});
+
+  testValidate(
+      &fusion, {cg_output}, {input}, {aten_output}, __LINE__, __FILE__);
+}
+
 } // namespace jit
 } // namespace torch
 #endif // #if defined(USE_CUDA)

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -13689,10 +13689,10 @@ TEST(NVFuserTest, FusionReductionPredicate_CUDA) {
 
   tv1->axis(-1)->parallelize(ParallelType::TIDx);
   tv1->axis(2)->parallelize(ParallelType::Unroll);
-  tv0->computeAt(tv1, 3);
+  tv1->split(0, 10);
+  tv0->computeAt(tv1, 4);
 
   tv2->axis(-1)->parallelize(ParallelType::TIDx);
-  tv2->axis(2)->parallelize(ParallelType::Unroll);
 
   int numel_x = 650;
   int numel_y = 102;

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -1495,24 +1495,24 @@ std::pair<std::vector<kir::Val*>, bool> Index::getConsumerRootPredIndices(
 
   // If we are generating a predicate for initialization check if we should use
   // rfactor instead of root_dom
-  //bool use_rfactor = true;
-  bool buffer_init = true;
-  auto rfactor_dom = kir_consumer_tv->domain()->rfactorDomain();
-  for (auto rfactor_id : rfactor_dom) {
-    if (rfactor_id->isReduction()) {
-      if (consumer_indexing.indexMap().find(rfactor_id) !=
-          consumer_indexing.indexMap().end()) {
-        if (!consumer_indexing.indexMap().at(rfactor_id)->isZeroInt()) {
-          //use_rfactor = false;
-          buffer_init = false;
-          break;
+  bool use_rfactor = true;
+  if (kir_consumer_tv->domain()->hasRFactor()) {
+    auto rfactor_dom = kir_consumer_tv->domain()->rfactorDomain();
+    for (auto rfactor_id : rfactor_dom) {
+      if (rfactor_id->isReduction()) {
+        if (consumer_indexing.indexMap().find(rfactor_id) !=
+            consumer_indexing.indexMap().end()) {
+          if (!consumer_indexing.indexMap().at(rfactor_id)->isZeroInt()) {
+            use_rfactor = false;
+            break;
+          }
         }
       }
     }
   }
 
   const auto root_domain =
-      (buffer_init && kir_consumer_tv->domain()->hasRFactor())
+      (use_rfactor && kir_consumer_tv->domain()->hasRFactor())
       ? kir_consumer_tv->domain()->rfactorDomain()
       : kir_consumer_tv->domain()->rootDomain();
 
@@ -1530,7 +1530,7 @@ std::pair<std::vector<kir::Val*>, bool> Index::getConsumerRootPredIndices(
     }
   }
 
-  return {root_inds, buffer_init};
+  return {root_inds, use_rfactor};
 }
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -1495,24 +1495,24 @@ std::pair<std::vector<kir::Val*>, bool> Index::getConsumerRootPredIndices(
 
   // If we are generating a predicate for initialization check if we should use
   // rfactor instead of root_dom
-  bool use_rfactor = true;
-  if (kir_consumer_tv->domain()->hasRFactor()) {
-    auto rfactor_dom = kir_consumer_tv->domain()->rfactorDomain();
-    for (auto rfactor_id : rfactor_dom) {
-      if (rfactor_id->isReduction()) {
-        if (consumer_indexing.indexMap().find(rfactor_id) !=
-            consumer_indexing.indexMap().end()) {
-          if (!consumer_indexing.indexMap().at(rfactor_id)->isZeroInt()) {
-            use_rfactor = false;
-            break;
-          }
+  //bool use_rfactor = true;
+  bool buffer_init = true;
+  auto rfactor_dom = kir_consumer_tv->domain()->rfactorDomain();
+  for (auto rfactor_id : rfactor_dom) {
+    if (rfactor_id->isReduction()) {
+      if (consumer_indexing.indexMap().find(rfactor_id) !=
+          consumer_indexing.indexMap().end()) {
+        if (!consumer_indexing.indexMap().at(rfactor_id)->isZeroInt()) {
+          //use_rfactor = false;
+          buffer_init = false;
+          break;
         }
       }
     }
   }
 
   const auto root_domain =
-      (use_rfactor && kir_consumer_tv->domain()->hasRFactor())
+      (buffer_init && kir_consumer_tv->domain()->hasRFactor())
       ? kir_consumer_tv->domain()->rfactorDomain()
       : kir_consumer_tv->domain()->rootDomain();
 
@@ -1530,7 +1530,7 @@ std::pair<std::vector<kir::Val*>, bool> Index::getConsumerRootPredIndices(
     }
   }
 
-  return {root_inds, use_rfactor};
+  return {root_inds, buffer_init};
 }
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -48,11 +48,11 @@ kir::IterDomain* getTermIterDomainInMap(
 std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const kir::TensorView* tv,
     const std::vector<kir::Val*>& indices,
-    bool use_rfactor) {
+    bool buffer_init) {
   FUSER_PERF_SCOPE("computePredicates");
 
   const auto domain = tv->domain();
-  const auto& root = (use_rfactor && domain->hasRFactor())
+  const auto& root = (buffer_init && domain->hasRFactor())
       ? domain->rfactorDomain()
       : domain->rootDomain();
 
@@ -82,7 +82,7 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool zero_ind = indices[i]->isZeroInt();
     const bool simple_ind = indices[i]->definition() == nullptr;
 
-    if (root[i]->isBroadcast() || (use_rfactor && root[i]->isReduction()) ||
+    if (root[i]->isBroadcast() || (buffer_init && root[i]->isReduction()) ||
         gpu_lower->isDerivedFromTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {
@@ -228,21 +228,12 @@ kir::Bool* PredicateCompute::getInlinePredicate(
   auto pred_inds =
       Index::getConsumerRootPredIndices(out_tv, loops, pred_contiguity);
   auto root_indices = pred_inds.first;
-  bool use_maybe_rfactor = pred_inds.second;
+  const bool buffer_init = pred_inds.second;
 
-  if (out_tv->memoryType() == MemoryType::Local &&
-      out_tv->domain()->hasReduction() && !use_maybe_rfactor) {
-    const auto tv_filter_inp_view =
-        ir_utils::filterByType<kir::TensorView>(expr->inputs());
-    const auto has_tv_inputs =
-        tv_filter_inp_view.begin() != tv_filter_inp_view.end();
-    // If predicates doesn't need maybe_rfactor, but it has reduction axes, and
-    // expr has no inputs, we're pretty confident we're intializing a reduction
-    // buffer. If we're initing a reduction buffer don't generate an inline
-    // predicate.
-    if (!has_tv_inputs) {
-      return ir_builder.create<kir::Bool>(true);
-    }
+  // If we are indexing a buffer init expr, and the buffer is local
+  // memory, predicate is not needed as we allocate enough local memory.
+  if (out_tv->memoryType() == MemoryType::Local && buffer_init) {
+    return ir_builder.create<kir::Bool>(true);
   }
 
   // Don't generate predicates unless needed. This is just for
@@ -251,8 +242,8 @@ kir::Bool* PredicateCompute::getInlinePredicate(
     return thread_pred;
   }
 
-  auto all_preds = PredicateCompute::computePredicates(
-      out_tv, root_indices, use_maybe_rfactor);
+  auto all_preds =
+      PredicateCompute::computePredicates(out_tv, root_indices, buffer_init);
   // If we have thread predicates, add those
   if (thread_pred != nullptr) {
     all_preds.push_back(thread_pred);

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -82,7 +82,7 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool zero_ind = indices[i]->isZeroInt();
     const bool simple_ind = indices[i]->definition() == nullptr;
 
-    if (root[i]->isBroadcast() ||
+    if (root[i]->isBroadcast() || (use_rfactor && root[i]->isReduction()) ||
         gpu_lower->isDerivedFromTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -48,11 +48,11 @@ kir::IterDomain* getTermIterDomainInMap(
 std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const kir::TensorView* tv,
     const std::vector<kir::Val*>& indices,
-    bool use_rfactor) {
+    bool buffer_init) {
   FUSER_PERF_SCOPE("computePredicates");
 
   const auto domain = tv->domain();
-  const auto& root = (use_rfactor && domain->hasRFactor())
+  const auto& root = (buffer_init && domain->hasRFactor())
       ? domain->rfactorDomain()
       : domain->rootDomain();
 
@@ -82,7 +82,7 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool zero_ind = indices[i]->isZeroInt();
     const bool simple_ind = indices[i]->definition() == nullptr;
 
-    if (root[i]->isBroadcast() || (use_rfactor && root[i]->isReduction()) ||
+    if (root[i]->isBroadcast() || (buffer_init && root[i]->isReduction()) ||
         gpu_lower->isDerivedFromTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -48,11 +48,11 @@ kir::IterDomain* getTermIterDomainInMap(
 std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const kir::TensorView* tv,
     const std::vector<kir::Val*>& indices,
-    bool buffer_init) {
+    bool use_rfactor) {
   FUSER_PERF_SCOPE("computePredicates");
 
   const auto domain = tv->domain();
-  const auto& root = (buffer_init && domain->hasRFactor())
+  const auto& root = (use_rfactor && domain->hasRFactor())
       ? domain->rfactorDomain()
       : domain->rootDomain();
 
@@ -82,7 +82,7 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool zero_ind = indices[i]->isZeroInt();
     const bool simple_ind = indices[i]->definition() == nullptr;
 
-    if (root[i]->isBroadcast() || (buffer_init && root[i]->isReduction()) ||
+    if (root[i]->isBroadcast() || (use_rfactor && root[i]->isReduction()) ||
         gpu_lower->isDerivedFromTrivialReduction(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.h
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.h
@@ -40,7 +40,7 @@ class PredicateCompute {
   static std::vector<kir::Bool*> computePredicates(
       const kir::TensorView* tv,
       const std::vector<kir::Val*>& indices,
-      bool use_rfactor);
+      bool buffer_init);
 
   static kir::Bool* getInlinePredicate(
       const kir::Expr* expr,


### PR DESCRIPTION
A reduction axis is used to generate a predicate expression for buffer-init expressions, which isn't needed.
