### PR TITLE
Fix trivial reduction detection

### DIFF
--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9930,7 +9930,7 @@ TEST(NVFuserTest, FusionTrivialReduction3_CUDA) {
 
 // Make sure trivial reductions are correctly detected even with
 // scheduling applied.
-TEST(NVFuserTest, FusionDetectTrivialReduction_CUDA) {
+TEST(NVFuserTest, FusionDetectTrivialReduction1_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -9957,10 +9957,9 @@ TEST(NVFuserTest, FusionDetectTrivialReduction_CUDA) {
   auto tv11 = sum(tv10, {1});
   fusion.addOutput(tv11);
 
-  tv7->split(0, 3);
+  tv8->split(0, 3);
   tv10->split(1, 4);
   tv11->split(1, 5);
-  ;
 
   tv0->computeAt(tv2, -1);
   tv0->computeAt(tv8, -1);
@@ -9988,6 +9987,36 @@ TEST(NVFuserTest, FusionDetectTrivialReduction_CUDA) {
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {t0, t0, t0}, __LINE__, __FILE__);
+}
+
+// Test detection of partially trivial reduction
+TEST(NVFuserTest, FusionDetectTrivialReduction2_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  auto tv1 = sum(tv0, {1});
+  auto tv2 = add(tv1, new Double(1));
+  fusion.addOutput(tv2);
+
+  tv1->split(1, 1);
+  // tv1->axis(1): non-trivial
+  // tv1->axis(2): trivial
+
+  auto tv3 = tv1->rFactor({-1});
+
+  GpuLower gpulw(&fusion);
+
+  // tv3's reduction axis is a trivial reduction. The only
+  // kir::ReductionOp should be for tv1.
+  for (const auto& kir_node : gpulw.kernel()->irNodes()) {
+    if (kir_node->isA<kir::ReductionOp>()) {
+      auto reduction_out =
+          kir_node->as<kir::ReductionOp>()->outputs()[0]->as<kir::TensorView>();
+      TORCH_CHECK(reduction_out->fuserTv() == tv1);
+    }
+  }
 }
 
 TEST(NVFuserTest, FusionInputsIdLookup_CUDA) {
@@ -13709,34 +13738,6 @@ TEST(NVFuserTest, FusionReductionPredicate_CUDA) {
 
   testValidate(
       &fusion, {cg_output}, {input}, {aten_output}, __LINE__, __FILE__);
-}
-
-TEST(NVFuserTest, FusionDetectTrivialReduction2_CUDA) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  auto tv0 = makeSymbolicTensor(2);
-  fusion.addInput(tv0);
-  auto tv1 = sum(tv0, {1});
-  auto tv2 = add(tv1, new Double(1));
-  fusion.addOutput(tv2);
-
-  tv1->split(1, 1);
-  auto tv3 = tv1->rFactor({-1});
-
-  fusion.printMath();
-  fusion.printKernel();
-
-  GpuLower gpulw(&fusion);
-
-  // tv3's reduction axis is a trivial reduction. The only
-  // kir::ReductionOp should be for tv1.
-  for (const auto& kir_node : gpulw.kernel()->irNodes()) {
-    if (kir_node->isA<kir::ReductionOp>()) {
-      auto reduction_out = kir_node->as<kir::ReductionOp>()->outputs()[0]->as<kir::TensorView>();
-      TORCH_CHECK(reduction_out->fuserTv() == tv1);
-    }
-  }
 }
 
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
@@ -39,8 +39,8 @@ class ConcreteInputCounter : public IterVisitor {
     // were traversed, so manually insert their count
     for (auto id : domain) {
       if (count_map.find(id) == count_map.end()) {
-        count_map[id] =
-            (id->isBroadcast() || gpu_lower->isDerivedFromTrivialReduction(id))
+        count_map[id] = (id->isBroadcast() ||
+                         gpu_lower->trivialReductionInfo().isDerived(id))
             ? 0
             : 1;
       }
@@ -66,7 +66,7 @@ class ConcreteInputCounter : public IterVisitor {
               .emplace(std::make_pair(id, std::unordered_set<IterDomain*>()))
               .first;
       if (!id->isBroadcast() &&
-          !gpu_lower_->isDerivedFromTrivialReduction(id)) {
+          !gpu_lower_->trivialReductionInfo().isDerived(id)) {
         concrete_set_it->second.emplace(id);
       }
     }

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
@@ -12,9 +12,13 @@ namespace fuser {
 namespace cuda {
 namespace {
 
-// Class to figure out how many non-broadcast axes were used to produce an iter
-// domain. This is important for figuring out what the correct broadcasted
-// extent is of an iteration domain
+//! Class to figure out how many non-broadcast axes were used to produce an iter
+//! domain. This is important for figuring out what the correct broadcasted
+//! extent is of an iteration domain.
+//!
+//! When GpuLower is available, trivial reductions are not counted as
+//! concrete domains so that they should not be used to generate
+//! for-loops.
 class ConcreteInputCounter : public IterVisitor {
  public:
   // Returns number of non-braodcast non-reduction iteration domains used to
@@ -40,7 +44,7 @@ class ConcreteInputCounter : public IterVisitor {
     for (auto id : domain) {
       if (count_map.find(id) == count_map.end()) {
         count_map[id] = (id->isBroadcast() ||
-                         gpu_lower->trivialReductionInfo().isDerived(id))
+                         (gpu_lower && gpu_lower->trivialReductionInfo().isDerived(id)))
             ? 0
             : 1;
       }
@@ -66,7 +70,7 @@ class ConcreteInputCounter : public IterVisitor {
               .emplace(std::make_pair(id, std::unordered_set<IterDomain*>()))
               .first;
       if (!id->isBroadcast() &&
-          !gpu_lower_->trivialReductionInfo().isDerived(id)) {
+          (gpu_lower_ && !gpu_lower_->trivialReductionInfo().isDerived(id))) {
         concrete_set_it->second.emplace(id);
       }
     }

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
@@ -43,8 +43,9 @@ class ConcreteInputCounter : public IterVisitor {
     // were traversed, so manually insert their count
     for (auto id : domain) {
       if (count_map.find(id) == count_map.end()) {
-        count_map[id] = (id->isBroadcast() ||
-                         (gpu_lower && gpu_lower->trivialReductionInfo().isDerived(id)))
+        count_map[id] =
+            (id->isBroadcast() ||
+             (gpu_lower && gpu_lower->trivialReductionInfo().isDerived(id)))
             ? 0
             : 1;
       }

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -809,7 +809,7 @@ kir::TensorIndex* Index::getGlobalProducerIndex(
       // reduction, so the stride index should be incremented.
     } else if (
         root_dom[i]->getIterType() == IterType::BroadcastWithStride ||
-        gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
+        gpu_lower->trivialReductionInfo().isDerived(root_dom[i])) {
       stride_i++;
       continue;
     }
@@ -1048,7 +1048,7 @@ kir::TensorIndex* Index::getProducerIndex_impl(
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
     if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast() ||
-        gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
+        gpu_lower->trivialReductionInfo().isDerived(root_dom[i])) {
       continue;
     }
 
@@ -1074,7 +1074,7 @@ kir::TensorIndex* Index::getProducerIndex_impl(
     kir::Val* stride = nullptr;
     for (size_t j = i + 1; j < root_dom.size(); j++) {
       if (root_dom[j]->isBroadcast() || root_dom[j]->isReduction() ||
-          gpu_lower->isDerivedFromTrivialReduction(root_dom[j])) {
+          gpu_lower->trivialReductionInfo().isDerived(root_dom[j])) {
         continue;
       }
 
@@ -1174,7 +1174,7 @@ kir::TensorIndex* Index::getGlobalConsumerIndex(
       // See a comment in indexing to root domains in getGlobalProducerIndex.
     } else if (
         root_dom[i]->getIterType() == IterType::BroadcastWithStride ||
-        gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
+        gpu_lower->trivialReductionInfo().isDerived(root_dom[i])) {
       stride_i++;
       continue;
     }
@@ -1300,7 +1300,7 @@ kir::TensorIndex* Index::getConsumerIndex_impl(
   std::vector<kir::Val*> strided_inds;
   for (size_t i = 0; i < root_dom.size(); i++) {
     if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast() ||
-        gpu_lower->isDerivedFromTrivialReduction(root_dom[i])) {
+        gpu_lower->trivialReductionInfo().isDerived(root_dom[i])) {
       continue;
     }
 
@@ -1325,7 +1325,7 @@ kir::TensorIndex* Index::getConsumerIndex_impl(
     kir::Val* stride = nullptr;
     for (size_t j = i + 1; j < root_dom.size(); j++) {
       if (root_dom[j]->isBroadcast() || root_dom[j]->isReduction() ||
-          gpu_lower->isDerivedFromTrivialReduction(root_dom[j])) {
+          gpu_lower->trivialReductionInfo().isDerived(root_dom[j])) {
         continue;
       }
 
@@ -1523,7 +1523,7 @@ std::pair<std::vector<kir::Val*>, bool> Index::getConsumerRootPredIndices(
 
   for (size_t i = 0; i < root_domain.size(); i++) {
     if (root_domain[i]->isBroadcast() ||
-        gpu_lower->isDerivedFromTrivialReduction(root_domain[i])) {
+        gpu_lower->trivialReductionInfo().isDerived(root_domain[i])) {
       continue;
     }
     const auto it = consumer_indexing.indexMap().find(root_domain[i]);

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -6,6 +6,7 @@
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/kernel.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_ir.h>
+#include <torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h>
 #include <torch/csrc/jit/codegen/cuda/root_domain_map.h>
 
 #include <memory>
@@ -50,20 +51,8 @@ class TORCH_CUDA_CU_API GpuLower {
     return ca_parallel_map_;
   }
 
-  const auto& trivialReductions() const {
-    return trivial_reductions_;
-  }
-
-  const auto& kirTrivialReductions() const {
-    return kir_trivial_reductions_;
-  }
-
-  bool isDerivedFromTrivialReduction(IterDomain* id) const {
-    return trivialReductions().find(id) != trivialReductions().end();
-  }
-
-  bool isDerivedFromTrivialReduction(kir::IterDomain* id) const {
-    return kirTrivialReductions().find(id) != kirTrivialReductions().end();
+  const auto& trivialReductionInfo() const {
+    return trivial_reduction_info_;
   }
 
  private:
@@ -89,8 +78,7 @@ class TORCH_CUDA_CU_API GpuLower {
   ComputeAtMap ca_loop_map_;
   ComputeAtMap ca_index_map_;
   ComputeAtMap ca_parallel_map_;
-  std::unordered_set<IterDomain*> trivial_reductions_;
-  std::unordered_set<kir::IterDomain*> kir_trivial_reductions_;
+  TrivialReductionInfo trivial_reduction_info_;
 
   Fusion* fusion_ = nullptr;
 };

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -118,13 +118,16 @@ void LoopNestGenerator::handle(const Expr* expr) {
   // Fill the entire loop structure by Looking at each axis
   // individually in out's domain
   for (size_t out_i = 0; out_i < out_tv->nDims(); out_i++) {
+    auto out_id = out_tv->axis(out_i);
+    // If out_id is derived from trivial reductions and its root axes
+    // are also all the case, it's safe to skip this axis.
+    if (gpu_lower->trivialReductionInfo().isDerivedFromRoot(out_id)) {
+      continue;
+    }
     // Look up the concrete ID in the parallel map, not in the loop
     // map, which also maps non-CA axes.
     auto concrete_id =
         gpu_lower->caParallelMap().getConcreteMappedID(out_tv->axis(out_i));
-    if (gpu_lower->isDerivedFromTrivialReduction(concrete_id)) {
-      continue;
-    }
     loop_structure.push_back(concrete_id);
   }
 

--- a/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h
+++ b/torch/csrc/jit/codegen/cuda/lower_trivial_reductions.h
@@ -13,12 +13,45 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
-//! Detect all IterDomains that are derived only from trivial
-//! reductons, thus not necessary to appear in the final generated
-//! kernel. The returned set includes all domains from root to
-//! leaves. It also can include non-reduction, rfactor domains.
-std::unordered_set<IterDomain*> detectTrivialReductionDerivedDomains(
-    Fusion* fusion);
+class GpuLower;
+
+//! Detect almost all IterDomains that are derived from trivial
+//! reductons.
+class TORCH_CUDA_CU_API TrivialReductionInfo {
+ public:
+  void build(Fusion* fusion, GpuLower* gpu_lower);
+
+  bool isDerived(IterDomain* id) const;
+  bool isDerivedFromRoot(IterDomain* id) const;
+
+  bool isDerived(kir::IterDomain* id) const;
+  bool isDerivedFromRoot(kir::IterDomain* id) const;
+
+ private:
+  //! Convert the sets to KIR sets
+  void buildKir(Fusion* fusion, GpuLower* gpu_lower);
+
+ private:
+  //! IterDomains that are derived only from trivial
+  //! reductons. Included domains are not limited to reduction axes as
+  //! rfactor can make reductions to normal axes.
+  //!
+  //! Note that the set should cover almost all cases but there can be
+  //! undetected trivial domains. For example, split by one creates a
+  //! trivial reduction domain, which is detected. However, if it is
+  //! further split, both of the two resulting axes are also trivial,
+  //! however, only the inner axis is recognized as rivial. While this
+  //! is a limitation, it would have very little practical
+  //! implication.
+  std::unordered_set<IterDomain*> domains_;
+  //! Subset of domains_, whose input root axes are all derived from
+  //! trivial reductions. These domains do not need to manifest as
+  //! for-loops.
+  std::unordered_set<IterDomain*> domains_derived_from_root_;
+
+  std::unordered_set<kir::IterDomain*> kir_domains_;
+  std::unordered_set<kir::IterDomain*> kir_domains_derived_from_root_;
+};
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -202,6 +202,10 @@ std::pair<kir::ForLoop*, int64_t> getAllocPoint(
       }
     }
 
+    if (gpu_lower->trivialReductionInfo().isDerivedFromRoot(local_id)) {
+      continue;
+    }
+
     auto lowered_local_id =
         gpu_lower->lowerValue(local_id)->as<kir::IterDomain>();
     loops_it = std::find_if(

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -83,7 +83,7 @@ std::vector<kir::Bool*> PredicateCompute::computePredicates(
     const bool simple_ind = indices[i]->definition() == nullptr;
 
     if (root[i]->isBroadcast() || (buffer_init && root[i]->isReduction()) ||
-        gpu_lower->isDerivedFromTrivialReduction(root[i])) {
+        gpu_lower->trivialReductionInfo().isDerived(root[i])) {
       continue;
     } else if (simple_ind && !zero_ind) {
       extent = nullptr;


### PR DESCRIPTION
The detection logic of #733 misses some trivial reductions. For example,

```
tv0 = makeSymbolicTensor(1);
// tv0: [I1]

tv1 = sum(tv0, {0});
// tv1: [rI1]

tv1->split(0, 1);
// tv1: [r(ceilDiv(I1, 1)), r(1)]
```

The logic in #733 can't detect `tv1->axis(1)` is trivial, whereas `IterDomain::isTrivialReduction` can. That difference resulted in erroneous code generation in, e.g., the Python layer_norm_autodiff test.

This PR covers such trivial reductions as well. Unlike the ones detected by the previous logic, these domains, while trivial, need for-loops, so there are two domain sets: one including all domains derived from trivial reductions (`TrivialReductionInfo::domains_`); and another that are derived from root trivial reductions (`TrivialReductionInfo::domains_derived_from_root_`). The latter is a subset of the former. Only the domains in the latter do not need for-loops. The former set is used most of the time, but the latter needs to be used when generating for-loops.

This should fix the recent failure of the Python nightly test.