### PR TITLE
Add some more options to the reduction heuristic.

### DIFF
--- a/benchmarks/cpp/nvfuser/reduction.cpp
+++ b/benchmarks/cpp/nvfuser/reduction.cpp
@@ -10,6 +10,8 @@
 
 #include <cuda_runtime.h>
 
+#include <sstream>
+
 #include "utils.h"
 
 using namespace torch::jit::fuser::cuda;
@@ -24,7 +26,11 @@ static std::pair<TensorView*, TensorView*> setupReduction(
 
   bool is_fp16 = dtype == DataType::Half;
 
-  TensorView* tv0 = TensorViewBuilder().ndims(2).dtype(dtype).build();
+  TensorView* tv0 = TensorViewBuilder()
+                        .ndims(2)
+                        .dtype(dtype)
+                        .contiguity({true, true})
+                        .build();
   fusion->addInput(tv0);
 
   TensorView* tv0_cast = tv0;
@@ -49,25 +55,6 @@ static std::pair<TensorView*, TensorView*> setupReduction(
   return {tv1, output_of_reduction};
 }
 
-static LaunchParams ScheduleReduction(
-    Fusion* fusion,
-    at::Tensor aten_input,
-    TensorView* reduction_tv,
-    TensorView* output_of_reduction) {
-
-  auto reduction_params =
-      getReductionHeuristics(fusion, {aten_input}, reduction_tv);
-  TORCH_CHECK(reduction_params.has_value(), "Reduction is not found!");
-  std::vector<TensorView*> outputs_of_reduction;
-  if(output_of_reduction != nullptr){
-    outputs_of_reduction.push_back(output_of_reduction);
-  }
-  scheduleReduction(
-      fusion, reduction_params.value(), reduction_tv, outputs_of_reduction);
-
-  return reduction_params.value().lparams;
-}
-
 static void MagicScheduler_Reduction(benchmark::State& benchmark_state,
   DataType dtype,
   int reduction_dim) {
@@ -85,18 +72,66 @@ static void MagicScheduler_Reduction(benchmark::State& benchmark_state,
       (reduction_dim ? at::randn({iter_size, reduction_size}, options)
             : at::randn({reduction_size, iter_size}, options));
 
-  auto lparams = ScheduleReduction(
-      &fusion, aten_input, reduction_tvs.first, reduction_tvs.second);
+  auto reduction_tv = reduction_tvs.first;
+  auto out_of_reduction = reduction_tvs.second;
+
+  auto reduction_params =
+      getReductionHeuristics(&fusion, {aten_input}, reduction_tv);
+
+  TORCH_CHECK(reduction_params.has_value(), "Reduction is not found!");
+  
+  std::vector<TensorView*> outputs_of_reduction;
+  if(out_of_reduction != nullptr){
+    outputs_of_reduction.push_back(out_of_reduction);
+  }
+
+  auto rparams = reduction_params.value();
+  auto lparams = rparams.lparams;
+
+  scheduleReduction(
+      &fusion, rparams, reduction_tv, outputs_of_reduction);
+
+  std::stringstream ss;
+  if(rparams.fastest_dim){
+    ss << "Fastest dim";
+  } else {
+    ss << "Slow dim";
+  }
+  if(rparams.cross_block){
+    ss << "/cross block";
+  }
+  if(rparams.multiple_reds_per_blk){
+    ss << "/multiple reductions per block ";
+  }
+  if(rparams.cross_grid){
+    ss << "/cross grid";
+  }
+  if(rparams.loop_unroll > 1){
+    ss << "/Unroll "
+       << (rparams.reduction_unroll ? "reduction dim "
+                                                     : "iter dim ")
+       << rparams.loop_unroll;
+  }
+  ss << "/Launch (" << (rparams.fastest_dim ? lparams.gdimx() : lparams.gdimy())
+     << ", " << lparams.bdimy() << ", " << lparams.bdimx() << ")";
+
+  benchmark_state.SetLabel(ss.str());
+  
 
   FusionExecutor fe;
   fe.compileFusion(&fusion);
-
-
+  fe.setMeasureKernelTimeFlag(true);
+  // Sync everything up before we start
+  cudaDeviceSynchronize();
   for (auto _ : benchmark_state) {
     CudaKernelTimer timer;
     auto cg_outputs = fe.runFusion({aten_input}, lparams);
-    benchmark_state.SetIterationTime(timer.elapsed() / 1000.0);
+    benchmark_state.SetIterationTime(fe.kernelTimeMs() / 1000.0);
   }
+  // Sync everything up before we're finished, don't want to run ahead on the
+  // cpu while benchmarking.
+  cudaDeviceSynchronize();
+
   benchmark_state.SetBytesProcessed(
       int64_t(benchmark_state.iterations()) *
       (iter_size * reduction_size + iter_size) * int64_t(dataTypeSize(dtype)));
@@ -124,9 +159,15 @@ BENCHMARK(MagicScheduler_fp32_Outer_Reduction)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
-BENCHMARK(MagicScheduler_fp32_Inner_Reduction)
-    ->RangeMultiplier(8)
-    ->Ranges({{1, 1024 * 1024}, {160, 320}})
+BENCHMARK(MagicScheduler_fp32_Outer_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{32768, 128 * 1024 * 1024}, {2, 16}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp32_Outer_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{2, 16}, {32768, 128 * 1024 * 1024}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
@@ -136,8 +177,50 @@ BENCHMARK(MagicScheduler_fp16_Outer_Reduction)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
+BENCHMARK(MagicScheduler_fp16_Outer_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{32768, 128 * 1024 * 1024}, {2, 16}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp16_Outer_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{2, 16}, {32768, 128 * 1024 * 1024}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp32_Inner_Reduction)
+    ->RangeMultiplier(8)
+    ->Ranges({{1, 1024 * 1024}, {160, 320}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp32_Inner_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{32768, 128 * 1024 * 1024}, {2, 16}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp32_Inner_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{2, 16}, {32768, 128 * 1024 * 1024}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
 BENCHMARK(MagicScheduler_fp16_Inner_Reduction)
     ->RangeMultiplier(8)
     ->Ranges({{1, 1024 * 1024}, {160, 320}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp16_Inner_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{32768, 128 * 1024 * 1024}, {2, 16}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(MagicScheduler_fp16_Inner_Reduction)
+    ->RangeMultiplier(4)
+    ->Ranges({{2, 16}, {32768, 128 * 1024 * 1024}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();


### PR DESCRIPTION
Unroll reduction dictates which axis we want to reduce across
Split grid is to start working around grid dimension limitations when we try to bind an axis to something like BDIMy but its greater than the 64*1024 size limit.