### PR TITLE
Hacky heuristics to improve the number of kernels produced by fusion segmenter

### DIFF
--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
@@ -965,6 +965,8 @@ SegmentCandidateFinder::SegmentCandidateFinder(const Fusion* fusion) {
   // TODO: this is a heuristic hack, need to remove when actual heuristics are
   //       ready. see issue #744
   const int SEGMENTER_MAX_TRY = 10;
+  // Reset the rng
+  getRNG(true);
 
   std::unique_ptr<SegmentedFusion> best_solution;
   int best_number_of_kernels = -1;

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
@@ -963,7 +963,7 @@ ScheduleHeuristic SegmentCandidateFinder::deriveHeuristic(
 
 SegmentCandidateFinder::SegmentCandidateFinder(const Fusion* fusion) {
   // TODO: this is a heuristic hack, need to remove when actual heuristics are
-  //       ready. see issue #
+  //       ready. see issue #744
   const int SEGMENTER_MAX_TRY = 10;
 
   std::unique_ptr<SegmentedFusion> best_solution;
@@ -1072,7 +1072,7 @@ void SegmentCandidateFinder::findSegments() {
       }
 
       // TODO: once the candidate selection heuristics is
-      //       implemented, should remove this see issue #
+      //       implemented, should remove this see issue #744
       std::random_shuffle(
           candidates.begin(), candidates.end(), getRandomNumber);
 
@@ -1118,7 +1118,7 @@ void SegmentCandidateFinder::finalMerge() {
     //  can merge with one of its consumers
     for (auto producer_group : groups()) {
       // TODO: part of the heuristic hack, need to remove it once
-      //      actual heuristic is ready. see issue #
+      //      actual heuristic is ready. see issue #744
       std::vector<SegmentedGroup*> groups_to_visit(
           groups().begin(), groups().end());
       std::random_shuffle(

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
@@ -1116,16 +1116,16 @@ void SegmentCandidateFinder::finalMerge() {
 
   bool merged_nodes = true;
   while (merged_nodes) {
+    // TODO: part of the heuristic hack, need to remove it once
+    //      actual heuristic is ready. see issue #744
+    std::vector<SegmentedGroup*> groups_to_visit(
+        groups().begin(), groups().end());
+    std::random_shuffle(
+        groups_to_visit.begin(), groups_to_visit.end(), getRandomNumber);
+
     // Iterate all groups and check if a group
     //  can merge with one of its consumers
-    for (auto producer_group : groups()) {
-      // TODO: part of the heuristic hack, need to remove it once
-      //      actual heuristic is ready. see issue #744
-      std::vector<SegmentedGroup*> groups_to_visit(
-          groups().begin(), groups().end());
-      std::random_shuffle(
-          groups_to_visit.begin(), groups_to_visit.end(), getRandomNumber);
-
+    for (auto producer_group : groups_to_visit) {
       // Populate consumers and their corresponding consumer edges
       std::unordered_map<SegmentedGroup*, SegmentedEdge*> consumer_edge_map;
       std::vector<SegmentedGroup*> all_consumers_of_producer_group;

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.cpp
@@ -443,12 +443,10 @@ void detailGroupPrint(std::ostream& os, const SegmentedGroup* group) {
     o->print();
   }
 
-  os << "\n\n";
+  os << "\nexpressions:\n";
 
   for (size_t i = 0; i < group->exprs().size(); i++) {
     irp.handle(group->exprs()[i]);
-    if (i + 1 != group->exprs().size())
-      os << " , ";
   }
   os << "}\n\n";
 }
@@ -1075,8 +1073,7 @@ void SegmentCandidateFinder::findSegments() {
 
       // TODO: once the candidate selection heuristics is
       //       implemented, should remove this see issue #744
-      std::random_shuffle(
-          candidates.begin(), candidates.end(), getRandomNumber);
+      std::shuffle(candidates.begin(), candidates.end(), getRNG(false));
 
       auto candidate_it = candidates.begin();
       while (candidate_it != candidates.end() &&
@@ -1120,8 +1117,7 @@ void SegmentCandidateFinder::finalMerge() {
     //      actual heuristic is ready. see issue #744
     std::vector<SegmentedGroup*> groups_to_visit(
         groups().begin(), groups().end());
-    std::random_shuffle(
-        groups_to_visit.begin(), groups_to_visit.end(), getRandomNumber);
+    std::shuffle(groups_to_visit.begin(), groups_to_visit.end(), getRNG(false));
 
     // Iterate all groups and check if a group
     //  can merge with one of its consumers

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
@@ -8,6 +8,7 @@
 
 #include <deque>
 #include <list>
+#include <random>
 #include <unordered_set>
 #include <vector>
 
@@ -382,9 +383,18 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
 
   void finalize();
 
-  // Return the resulting heuristic corresponding to the merged
-  //  group built by merging the two groups connected by edge
+  //! Return the resulting heuristic corresponding to the merged
+  //!  group built by merging the two groups connected by edge
   ScheduleHeuristic deriveHeuristic(SegmentedGroup* edge);
+
+  //! Part of a heuristic hack, need to be removed once
+  //!  heuristics is ready, as well as the <random> header
+  //!  see issue #
+  static int getRandomNumber(int fromZeroTo) {
+    static std::mt19937 rng_(
+        1234); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+    return rng_() % fromZeroTo;
+  }
 
  protected:
   std::deque<SegmentedGroup*> to_visit_;

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
@@ -389,7 +389,7 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
 
   //! Part of a heuristic hack, need to be removed once
   //!  heuristics is ready, as well as the <random> header
-  //!  see issue #
+  //!  see issue #744
   static int getRandomNumber(int fromZeroTo) {
     static std::mt19937 rng_(
         1234); // NOLINT(cppcoreguidelines-avoid-magic-numbers)

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
@@ -399,13 +399,6 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
     return rng;
   }
 
-  //! Part of a heuristic hack, need to be removed once
-  //!  heuristics is ready, as well as the <random> header
-  //!  see issue #744
-  static int getRandomNumber(int fromZeroTo) {
-    return getRNG(false)() % fromZeroTo;
-  }
-
  protected:
   std::deque<SegmentedGroup*> to_visit_;
   std::vector<SegmentedGroup*> next_to_visit_;

--- a/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
+++ b/torch/csrc/jit/codegen/cuda/fusion_segmenter.h
@@ -390,10 +390,20 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
   //! Part of a heuristic hack, need to be removed once
   //!  heuristics is ready, as well as the <random> header
   //!  see issue #744
+  static std::mt19937& getRNG(bool reset = false) {
+    const int seed = 1234; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+    static std::mt19937 rng(seed);
+    if (reset) {
+      rng = std::mt19937(seed);
+    }
+    return rng;
+  }
+
+  //! Part of a heuristic hack, need to be removed once
+  //!  heuristics is ready, as well as the <random> header
+  //!  see issue #744
   static int getRandomNumber(int fromZeroTo) {
-    static std::mt19937 rng_(
-        1234); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-    return rng_() % fromZeroTo;
+    return getRNG(false)() % fromZeroTo;
   }
 
  protected:


### PR DESCRIPTION
Causes #744 

Temporarily use a randomized node-merging heuristic to get minimal number of kernels in layer norm backward. 

The actual deterministic heuristics implementation is WIP. 