### PR TITLE
Correct nvfuser_bench cmake dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ cmake_dependent_option(
     "USE_CUDNN" OFF)
 cmake_dependent_option(
     BUILD_NVFUSER_BENCHMARK "Build C++ binaries for nvfuser benchmarks" ON
-    "USE_CUDA" OFF)
+    "USE_CUDA;BUILD_TEST" OFF)
 option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" ON)
 option(USE_KINETO "Use Kineto profiling library" ON)
 option(USE_CUPTI_SO "Use CUPTI as a shared library" OFF)


### PR DESCRIPTION
We really depend on both gtest and gbenchmark.
Without that gbenchmark (third_party/benchmark/benchmark) wont be built,
or added to include path.

I've hit that yesterday when cherry picking to other tree. Not that trivial to notice command line typo, since we got both BUILD_TEST and BUILD_TESTS while BUILD_BENCHMARK won't help.