### PR TITLE
Setting maximum register usage for codegen kernel

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -110,7 +110,9 @@ void FusionExecutor::debugCompileFusionFromStr(
       fusion_id_ > 0, "assign a fusion_id_ <= 0 is not accepted.");
 }
 
-void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
+void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options,
+    const at::ArrayRef<IValue>& inputs,
+    const LaunchParams& launch_constraints) {
   FUSER_PERF_SCOPE("compileFusion");
 
   TORCH_INTERNAL_ASSERT(
@@ -181,10 +183,19 @@ void FusionExecutor::compileFusion(Fusion* fusion, CompileOptions options) {
       !kernel_summary.has_grid_reduction_in_loop,
       "Grid reduction must not be placed inside a loop.");
 
+  // TODO: pass block_size here;
+  c10::optional<int> block_size = c10::nullopt;
+  if (!inputs.empty()) {
+    auto expr_eval = executor_utils::bindKernelInputs(inputs, kernel);
+    auto launch_params = computeLaunchParams(launch_constraints, expr_eval);
+    block_size = launch_params.nThreads();
+  }
+
   compiled_kernel_ = executor_utils::nvrtcCompile(
       structured_code,
       (kernelNamespace() + "::" + kernelName()).c_str(),
-      fusion_id_);
+      fusion_id_,
+      block_size);
   TORCH_INTERNAL_ASSERT(
       fusion_id_ > 0, "failed to assign a fusion_id_ after compilation.");
 }

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -32,7 +32,9 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
       int id,
       CompileOptions options = CompileOptions());
 
-  void compileFusion(Fusion* fusion, CompileOptions options = CompileOptions());
+  void compileFusion(Fusion* fusion, CompileOptions options = CompileOptions(),
+      const at::ArrayRef<IValue>& inputs = {},
+      const LaunchParams& launch_constraints = LaunchParams());
 
   std::vector<at::Tensor> runFusion(
       const at::ArrayRef<IValue>& inputs,

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -75,7 +75,8 @@ struct NvrtcFunction {
 NvrtcFunction nvrtcCompile(
     const std::string& code,
     const std::string& func_name,
-    int id);
+    int id,
+    c10::optional<int> opt_block_size = c10::nullopt);
 
 } // namespace executor_utils
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -393,14 +393,20 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
     options.device = c10::Device(DeviceType::CUDA, device_index);
     FusionGuard fg(fusion_to_run.get());
     scheduler_entry->schedule(fusion_to_run.get());
-    executors_[group_id].compileFusion(fusion_to_run.get(), options);
-  }
-
-  // Load launch params for reduction and normalization kernels
-  if (scheduler_entry->hasReductionParam()) {
-    launch_params = scheduler_entry->reductionParams().lparams;
+    // Load launch params for reduction and normalization kernels
+    if (scheduler_entry->hasReductionParam()) {
+      launch_params = scheduler_entry->reductionParams().lparams;
+    } else {
+      launch_params = scheduler_entry->pointwiseParams().lparams;
+    }
+    executors_[group_id].compileFusion(fusion_to_run.get(), options, inputs, launch_params);
   } else {
-    launch_params = scheduler_entry->pointwiseParams().lparams;
+    // Load launch params for reduction and normalization kernels
+    if (scheduler_entry->hasReductionParam()) {
+      launch_params = scheduler_entry->reductionParams().lparams;
+    } else {
+      launch_params = scheduler_entry->pointwiseParams().lparams;
+    }
   }
 
   if (profiling_) {


### PR DESCRIPTION
Fixes #865 

A very small PR that limits the register usage to ensure that we do not request more register than available.
Two changes:
1. prior to kernel compilation, we bind the inputs at compile time to compute launch param (blocksize)
2. based on the compile-time blocksize, we calculate the maximum register size per thread and use `--maxrregcount` to restrict register usage for compiler