### PR TITLE
Dynamic shape latency Step1 : Cache compile-time information in FusionExecutors

### DIFF
--- a/benchmarks/cpp/nvfuser/CMakeLists.txt
+++ b/benchmarks/cpp/nvfuser/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(nvfuser_bench
   broadcast.cpp
   gelu_backward.cpp
   heuristic_lookup.cpp
+  shape_inference.cpp
   instance_norm.cpp
   layer_norm.cpp
   lstm_cell.cpp

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -633,12 +633,12 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     executor_utils::validateVectorizedTensors(
         &fusion_, inputs, outputs, lowered_, compileTimeDataCache());
 
-    auto fusion = fusion_;
+    auto& fusion = fusion_;
 
     auto alias_indices_entry =
         executor_utils::caching::ExecutorCompileTimeEntry<
             executor_utils::caching::InputAliasIndices>(
-            compileTimeDataCache(), [fusion]() {
+            compileTimeDataCache(), [&fusion]() {
               return std::make_unique<std::vector<std::pair<int, int>>>(
                   fusion.getInputAliasIndices());
             });
@@ -651,7 +651,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
       auto output_alias_indices_entry =
           executor_utils::caching::ExecutorCompileTimeEntry<
               executor_utils::caching::OutputAliasIndices>(
-              compileTimeDataCache(), [fusion]() {
+              compileTimeDataCache(), [&fusion]() {
                 return std::make_unique<std::unordered_set<int>>(
                     fusion.getOutputAliasIndices());
               });

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -569,7 +569,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   GlobalBuffers global_buffers;
   uint64_t rand_offset = 0;
 
-  if (executor_entry && executor_entry->init) {
+  if (executor_entry && executor_entry->init && !disable_parameter_cache_) {
     {
       // context manager to disable auto grad for `empty_cuda` calls later
       at::AutoDispatchBelowADInplaceOrView non_variable_type_mode;

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -81,6 +81,9 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
     uint64_t rand_offset;
   };
 
+  using ExecutorCompileTimeInfoCache =
+      executor_utils::caching::ExecutorCompileTimeInfoCache;
+
   kir::Kernel* kernel() const {
     return lowered_.kernel();
   }
@@ -169,6 +172,10 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
     return used_tvs_;
   };
 
+  ExecutorCompileTimeInfoCache* compileTimeDataCache() {
+    return &compile_time_info_cache_;
+  }
+
  private:
   Fusion fusion_;
 
@@ -201,6 +208,9 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
 
   // Profiling support: knob to disable caching of launch params
   bool disable_parameter_cache_ = false;
+
+  // Compile time information caching
+  ExecutorCompileTimeInfoCache compile_time_info_cache_;
 };
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -117,6 +117,11 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
       const LaunchParams& launch_params,
       const std::vector<at::Tensor>& args);
 
+  //! Internal knob used for debugging/profiling only
+  void disableLaunchParamCache() {
+    disable_parameter_cache_ = true;
+  }
+
  private:
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct GlobalBuffers {
@@ -193,6 +198,9 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
 
   // The last kernel execution time, if measure_kernel_time_ is true
   float kernel_time_ms_ = 0;
+
+  // Profiling support: knob to disable caching of launch params
+  bool disable_parameter_cache_ = false;
 };
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/executor_utils.h
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.h
@@ -50,14 +50,6 @@ bool canVectorize(
     GpuLower& lower,
     kir::ExpressionEvaluator& expr_eval);
 
-// TODO(kir): rewrite in terms of Kernel tensors
-void validateVectorizedTensors(
-    Fusion* fusion,
-    const at::ArrayRef<IValue>& inputs,
-    const std::vector<at::Tensor>& outputs,
-    GpuLower& lower,
-    kir::ExpressionEvaluator& expr_eval);
-
 //! Bind kernel input values to runtime values
 kir::ExpressionEvaluator bindKernelInputs(
     const at::ArrayRef<IValue>& aten_inputs,
@@ -77,6 +69,186 @@ NvrtcFunction nvrtcCompile(
     const std::string& func_name,
     int id,
     c10::optional<int> opt_block_size = c10::nullopt);
+
+namespace caching {
+// TODO: Largely duplicated from heuristic
+//  caching look up and the purpose is also
+//  simliar. Could consider putting some of
+//  the logic in the common space and re-use
+
+enum class CompileTimeEntryType {
+  PARALLEL_BINDING_ITERDOMAINS,
+  PARALLEL_ITER_EXTENT_MAP,
+  WARP_PADDED_PARALLEL_EXTENTS,
+  VECTORIZED_TENSOR_VALIDATION,
+  INPUT_ALIAS_INDICES,
+  OUTPUT_ALIAS_INDICES
+};
+
+class ParallelBindingIterDomains {
+ public:
+  using DataType = std::vector<IterDomain*>;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::PARALLEL_BINDING_ITERDOMAINS;
+};
+
+class ParallelIterExtentMap {
+ public:
+  using DataType =
+      std::unordered_map<ParallelType, std::vector<const kir::Val*>, TypeHash>;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::PARALLEL_ITER_EXTENT_MAP;
+};
+
+struct WarpPaddedExtentsInfo {
+  std::unordered_set<const kir::Val*> warp_padded_extent_set;
+  std::unordered_map<const kir::Val*, int64_t> warp_padded_constant;
+};
+
+class WarpPaddedParallelExtents {
+ public:
+  using DataType = WarpPaddedExtentsInfo;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::WARP_PADDED_PARALLEL_EXTENTS;
+};
+
+struct VectorizedTensorInfo {
+  std::unordered_set<TensorView*> global_inp_misaligned_tv;
+  std::unordered_set<TensorView*> global_out_misaligned_tv;
+  std::unordered_map<TensorView*, int> tv_to_vector_word_size;
+  std::vector<int> inp_misaligned_tensors_pos;
+  std::vector<int> out_misaligned_tensors_pos;
+  std::unordered_map<int, int> inp_pos_to_word_size_map_to_verify;
+  std::unordered_map<int, int> out_pos_to_word_size_map_to_verify;
+};
+
+class VectorizedTensorValidation {
+ public:
+  using DataType = VectorizedTensorInfo;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::VECTORIZED_TENSOR_VALIDATION;
+};
+
+class InputAliasIndices {
+ public:
+  using DataType = std::vector<std::pair<int, int>>;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::INPUT_ALIAS_INDICES;
+};
+
+class OutputAliasIndices {
+ public:
+  using DataType = std::unordered_set<int>;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::OUTPUT_ALIAS_INDICES;
+};
+
+//! Base abstract class for unified storage in `HeuristicSummary`,
+//!  each entry in `HeuristicSummary` will be a subclass.
+class CompileTimeInfoBase : public PolymorphicBase {
+ public:
+  CompileTimeInfoBase(CompileTimeEntryType entry_type)
+      : entry_type_(entry_type) {}
+  CompileTimeEntryType type() {
+    return entry_type_;
+  }
+
+ private:
+  CompileTimeEntryType entry_type_;
+};
+
+//! Compile-time information cache
+class TORCH_CUDA_CU_API ExecutorCompileTimeInfoCache {
+  using Entry = CompileTimeInfoBase;
+  using EntryOwningPtr = std::unique_ptr<Entry>;
+  using EntryPtr = Entry*;
+  using EntryType = CompileTimeEntryType;
+
+ public:
+  void insert(EntryOwningPtr new_entry);
+
+  EntryPtr at(EntryType entry_type) {
+    return entry_type_map_.at(entry_type);
+  }
+
+  bool has(EntryType entry_type) {
+    return entry_type_map_.count(entry_type);
+  }
+
+ private:
+  std::vector<EntryOwningPtr> entries_;
+  std::unordered_map<EntryType, EntryPtr> entry_type_map_;
+};
+
+//! A utility class to facilitate accessing ExecutorCompileTimeInfoCache.
+template <typename EntryClass>
+class ExecutorCompileTimeEntry {
+  using EntryDataType = typename EntryClass::DataType;
+  using EntryDataTypeOwnPtr = std::unique_ptr<EntryDataType>;
+  using MakerFnType = std::function<EntryDataTypeOwnPtr()>;
+
+ public:
+  //! Creates a data entry with type defined in EntryClass,
+  //!  eg. EntryClass = VectorizableInputsAndOutputs;
+  //!
+  //! @param data_cache, a pointer to an instantiated compile-time
+  //!  info cache. The info data will be
+  //!    1. read from data cache if data cache is not recording.
+  //!    2. written into  data cache if data cache is recording.
+  //!    3. managed by owned_data_ if data cache is nullptr
+  //! @param fn:
+  //!   The factory function that needs to return a owning pointer
+  //!  i.e. std::unique_ptr<EntryClass::DataType>. It will only
+  //!  be called either when data cache is recording or when no data
+  //!  cache is given.
+  ExecutorCompileTimeEntry(
+      ExecutorCompileTimeInfoCache* data_cache,
+      MakerFnType fn);
+
+  //! Unified interface to get actual data, either from cache
+  //!  or from factory function.
+  EntryDataType& get() {
+    return *data_ptr_;
+  }
+
+ private:
+  //! Internal data owing pointer that will manage the computed
+  //!  data where there is no data cache.
+  EntryDataTypeOwnPtr owned_data_ = nullptr;
+
+  //! Pointer to the valid data entry that could be accessed.
+  EntryDataType* data_ptr_ = nullptr;
+};
+
+} // namespace caching
+
+//! Returns the vector of tensorviews that will be used to bind parallel
+//!  dimensions.
+std::vector<IterDomain*> getParallelBindingsIterDomains(
+    const std::vector<TensorView*>& used_tvs);
+
+//!
+using ParallelExtentMap =
+    std::unordered_map<ParallelType, std::vector<const kir::Val*>, TypeHash>;
+std::unique_ptr<ParallelExtentMap> getParallelIterExtents(
+    GpuLower& lower,
+    std::vector<IterDomain*>& parallel_binding_ids);
+
+std::unique_ptr<caching::WarpPaddedExtentsInfo> getWarpPaddedExtentsInfo(
+    GpuLower& lower,
+    std::vector<IterDomain*>& parallel_binding_ids);
+
+std::unique_ptr<caching::VectorizedTensorInfo> getVectorizedTensorValidationInfo(
+    Fusion* fusion,
+    GpuLower& lower);
+
+// TODO(kir): rewrite in terms of Kernel tensors
+void validateVectorizedTensors(
+    Fusion* fusion,
+    const at::ArrayRef<IValue>& inputs,
+    const std::vector<at::Tensor>& outputs,
+    GpuLower& lower,
+    caching::ExecutorCompileTimeInfoCache* data_cache = nullptr);
 
 } // namespace executor_utils
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -73,6 +73,20 @@ class TORCH_CUDA_CU_API FusionKernelRuntime {
     profiling_ = to_profile;
   }
 
+  //! Internal knob for profiling shape inference
+  void disableLaunchParamCache() {
+    for (auto& executor : executors_) {
+      executor.disableLaunchParamCache();
+    }
+  }
+
+  //! Internal knob for profiling shape inference
+  void disableKernelLaunch() {
+    for (auto& executor : executors_) {
+      executor.setExecuteKernelFlag(false);
+    }
+  }
+
   //! Returns if this runtime is segmented
   bool isSegmented() {
     return is_segmented_;
@@ -328,6 +342,24 @@ class TORCH_CUDA_CU_API FusionExecutorCache {
     for (auto& it : kernel_runtimes_) {
       for (auto& kernel_runtime : it.second) {
         kernel_runtime->profile(to_profile);
+      }
+    }
+  }
+
+  //! Internal knob for profiling shape inference
+  void disableLaunchParamCache() {
+    for (auto& it : kernel_runtimes_) {
+      for (auto& kernel_runtime : it.second) {
+        kernel_runtime->disableLaunchParamCache();
+      }
+    }
+  }
+
+  //! Internal knob for profiling shape inference
+  void disableKernelLaunch() {
+    for (auto& it : kernel_runtimes_) {
+      for (auto& kernel_runtime : it.second) {
+        kernel_runtime->disableKernelLaunch();
       }
     }
   }


### PR DESCRIPTION
Dynamic shape runtime latency mainly includes two parts:
1. Searching the `FusionExecutorCache` for compiled kernels
2. Run shape inference on input to derive launch bounds and output allocations. 

This PR speeds up Part 2, by caching the compile-time available information in the `FusionExecutor`'s so that they do not have to be re-computed at runtime. 


Perf comparison:

```
Before:
@ 9a1910add0c726f9f403d2444b321d2f30dc386b
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
LayerNormBackward_ShapeInference                       87.1 us         87.1 us         8171
LayerNormForward_ShapeInference                        42.9 us         42.9 us        15433
LayerNormBackward_NoShapeInferenceCachedBaseline       13.0 us         13.0 us        53089
LayerNormForward_NoShapeInferenceCachedBaseline        4.56 us         4.56 us       155398

After:
@ 96a2353b30e8874da80228407ff0ad92425d7072
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
LayerNormBackward_ShapeInference                       41.7 us         41.7 us        15225
LayerNormForward_ShapeInference                        22.7 us         22.7 us        28692
LayerNormBackward_NoShapeInferenceCachedBaseline       12.0 us         12.0 us        56930
LayerNormForward_NoShapeInferenceCachedBaseline        4.38 us         4.38 us       162971
```