### PR TITLE
Change FLT_MIN and DBL_MIN to use numeric_limits::lowest()

### DIFF
--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -684,10 +684,10 @@ TensorView* max(
   Val* init = nullptr;
   switch (v1->getDataType().value()) {
     case (DataType::Double):
-      init = new Double(DBL_MIN);
+      init = new Double(std::numeric_limits<double>::lowest());
       break;
     case (DataType::Float):
-      init = new Double(FLT_MIN);
+      init = new Double(std::numeric_limits<float>::lowest());
       break;
     case (DataType::Int):
       init = new Int(INT_MIN);


### PR DESCRIPTION
There was a bug in the Max operation initialization where the lowest value used was only the lowest positive value.  C++ is slightly misleading in using `FLT_MIN` to suggest the lowest float when it is actually the minimum positive float.  I changed this too use `std::numeric_limits<float>::lowest()`.  

This was found because Bert was seeing NaNs due to Softmax Forward with padding.