### PR TITLE
Inline thread predicates even when unswitched

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_thread_predicate.h
+++ b/torch/csrc/jit/codegen/cuda/lower_thread_predicate.h
@@ -73,7 +73,23 @@ class TORCH_CUDA_CU_API ThreadPredicateMap {
   //! blockBroadcast unless it is predicated by limited_types_
   ParallelTypeBitmap getParallelBroadcastDomains(const TensorView* tv) const;
 
+  //! Get a PredicateInfo for a given tensor. If it's an output of
+  //! a parallel broadcast, unmask the limited_types_ bit of the
+  //! corresponding parallel type since it must join the broadcast
+  //! operation although the valid input is only available at one of
+  //! the threads/blocks.
+  PredicateInfo getPredicateInfo(const TensorView* tv) const;
+
   void print() const;
+
+  //! Merge two instances of PredicateInfo for unswitch predicates.
+  static c10::optional<PredicateInfo> mergeForUnswitch(
+      const PredicateInfo& info_x,
+      const PredicateInfo& info_y);
+
+  //! Generate a Bool value from PredicateInfo.
+  static kir::Bool* getPredicateFromPredicateInfo(
+      const ThreadPredicateMap::PredicateInfo& pred_info);
 
  private:
   // Update the thread_predicates bitset based on provided Expr
@@ -94,13 +110,6 @@ class TORCH_CUDA_CU_API ThreadPredicateMap {
 
   //! Insert a new mapping
   void insert(const TensorView* tv, const PredicateInfo& pred_and_src);
-
-  //! Get a PredicateInfo for a given tensor. If it's an output of
-  //! a parallel broadcast, unmask the limited_types_ bit of the
-  //! corresponding parallel type since it must join the broadcast
-  //! operation although the valid input is only available at one of
-  //! the threads/blocks.
-  PredicateInfo getPredicateInfo(const TensorView* tv) const;
 
  private:
   MapType thread_predicates_;

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.h
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/jit/codegen/cuda/index_compute.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_ir.h>
+#include <torch/csrc/jit/codegen/cuda/lower_thread_predicate.h>
 #include <torch/csrc/jit/codegen/cuda/lower_utils.h>
 #include <torch/csrc/jit/codegen/cuda/root_domain_map.h>
 
@@ -96,6 +97,10 @@ class TORCH_CUDA_CU_API UnswitchPredicate {
 
   // The predicates that have been generated.
   std::vector<kir::Bool*> predicates_;
+
+  //! Thread predicate for unswitched expressions. Predicate is false
+  //! if this optional value is null.
+  c10::optional<ThreadPredicateMap::PredicateInfo> merged_thread_pred_;
 
   std::vector<kir::ForLoop*> for_loops_;
 };


### PR DESCRIPTION
Fixes #1173 

Also, I moved the assignment to `non_trivial_pred_found_` forward in `UnrollPass::handle(kir::Expr* expr)` as the previous location means predicates for block reductions, e.g., are not considered non-trivial, which I don't think true.
