### PR TITLE
RMSNorm with tests/benchmarking (shapes based off of HuggingFace T5 on A100)

### DIFF
--- a/benchmarks/cpp/nvfuser/CMakeLists.txt
+++ b/benchmarks/cpp/nvfuser/CMakeLists.txt
@@ -10,6 +10,8 @@ if(USE_CUDA)
     instance_norm.cpp
     layer_norm.cpp
     layer_norm_backward.cpp
+    rms_norm.cpp
+    rms_norm_backward.cpp
     lstm_cell.cpp
     reduction.cpp
     softmax.cpp

--- a/benchmarks/cpp/nvfuser/layer_norm.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm.cpp
@@ -53,6 +53,73 @@ static void setupLayerNorm(Fusion* fusion, DataType dtype) {
   fusion->addOutput(output);
 }
 
+static void setupRMSNorm(Fusion* fusion, DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
+
+  FusionGuard fg(fusion);
+
+  const int kReductionAxis = 2;
+  const float kEps = 1e-6;
+
+  Double* eps_ptr = IrBuilder::create<Double>(kEps);
+
+  // setup fusion
+  auto input = makeContigTensor(3, dtype);
+  auto weight = makeContigTensor(1, dtype);
+  // auto bias = makeContigTensor(1, dtype);
+
+  fusion->addInput(input);
+  fusion->addInput(weight);
+  // fusion->addInput(bias);
+
+  if (dtype == DataType::Half) {
+    input = castOp(DataType::Float, input);
+    weight = castOp(DataType::Float, weight);
+    // bias = castOp(DataType::Float, bias);
+  }
+
+  // auto layer_norm_results = layer_norm(input, 1, weight, bias, eps_ptr);
+  auto rms_norm_results = rms_norm(input, 1, weight, eps_ptr);
+
+  auto output = rms_norm_results.output;
+
+  if (dtype == DataType::Half) {
+    output = castOp(DataType::Half, output);
+  }
+
+  fusion->addOutput(output);
+}
+
+
+static void NvFuserScheduler_RMSNorm(
+    benchmark::State& benchmark_state,
+    FusionExecutorCache* fusion_executor_cache,
+    DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
+
+  std::vector<int64_t> input_shape{
+      8, benchmark_state.range(0), 1024};
+  const float kEps = 1e-6;
+
+  // inputs
+  at::manual_seed(0);
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  at::Tensor input = at::randn(input_shape, options);
+  at::Tensor weight = at::randn({input_shape[2]}, options);
+  // at::Tensor bias = at::randn({input_shape[1]}, options);
+
+  std::vector<c10::IValue> aten_inputs({input, weight});
+
+  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
+
+  benchmark_state.SetBytesProcessed(
+      int64_t(benchmark_state.iterations()) *
+      (2 * input.numel() + weight.numel()) *
+      int64_t(dataTypeSize(dtype)));
+}
+
+
 static void NvFuserScheduler_LayerNorm(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
@@ -162,6 +229,36 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp32)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_fp32,
+    setupRMSNorm,
+    NvFuserScheduler_RMSNorm,
+    DataType::Float);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{18, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{22, 44}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_LayerNorm_fp16,
     setupLayerNorm,
     NvFuserScheduler_LayerNorm,
@@ -188,6 +285,66 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
     // ->RangeMultiplier(2)
     ->Ranges({{128, 1024 * 16}, {128, 1024 * 16}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_fp16,
+    setupRMSNorm,
+    NvFuserScheduler_RMSNorm,
+    DataType::Half);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{18, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{22, 44}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_bf16,
+    setupRMSNorm,
+    NvFuserScheduler_RMSNorm,
+    DataType::BFloat16);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{18, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{22, 44}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 

--- a/benchmarks/cpp/nvfuser/layer_norm.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm.cpp
@@ -66,19 +66,15 @@ static void setupRMSNorm(Fusion* fusion, DataType dtype) {
   // setup fusion
   auto input = makeContigTensor(3, dtype);
   auto weight = makeContigTensor(1, dtype);
-  // auto bias = makeContigTensor(1, dtype);
 
   fusion->addInput(input);
   fusion->addInput(weight);
-  // fusion->addInput(bias);
 
   if (dtype == DataType::Half) {
     input = castOp(DataType::Float, input);
     weight = castOp(DataType::Float, weight);
-    // bias = castOp(DataType::Float, bias);
   }
 
-  // auto layer_norm_results = layer_norm(input, 1, weight, bias, eps_ptr);
   auto rms_norm_results = rms_norm(input, 1, weight, eps_ptr);
 
   auto output = rms_norm_results.output;
@@ -107,7 +103,6 @@ static void NvFuserScheduler_RMSNorm(
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   at::Tensor input = at::randn(input_shape, options);
   at::Tensor weight = at::randn({input_shape[2]}, options);
-  // at::Tensor bias = at::randn({input_shape[1]}, options);
 
   std::vector<c10::IValue> aten_inputs({input, weight});
 

--- a/benchmarks/cpp/nvfuser/layer_norm.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm.cpp
@@ -46,74 +46,12 @@ static void setupLayerNorm(Fusion* fusion, DataType dtype) {
 
   auto output = layer_norm_results.output;
 
-  if (dtype == DataType::Half) {
-    output = castOp(DataType::Half, output);
+  if (dtype != DataType::Float) {
+    output = castOp(dtype, output);
   }
 
   fusion->addOutput(output);
 }
-
-static void setupRMSNorm(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
-
-  FusionGuard fg(fusion);
-
-  const int kReductionAxis = 2;
-  const float kEps = 1e-6;
-
-  Double* eps_ptr = IrBuilder::create<Double>(kEps);
-
-  // setup fusion
-  auto input = makeContigTensor(3, dtype);
-  auto weight = makeContigTensor(1, dtype);
-
-  fusion->addInput(input);
-  fusion->addInput(weight);
-
-  if (dtype == DataType::Half) {
-    input = castOp(DataType::Float, input);
-    weight = castOp(DataType::Float, weight);
-  }
-
-  auto rms_norm_results = rms_norm(input, 1, weight, eps_ptr);
-
-  auto output = rms_norm_results.output;
-
-  if (dtype == DataType::Half) {
-    output = castOp(DataType::Half, output);
-  }
-
-  fusion->addOutput(output);
-}
-
-
-static void NvFuserScheduler_RMSNorm(
-    benchmark::State& benchmark_state,
-    FusionExecutorCache* fusion_executor_cache,
-    DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
-
-  std::vector<int64_t> input_shape{
-      8, benchmark_state.range(0), 1024};
-  const float kEps = 1e-6;
-
-  // inputs
-  at::manual_seed(0);
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-  at::Tensor input = at::randn(input_shape, options);
-  at::Tensor weight = at::randn({input_shape[2]}, options);
-
-  std::vector<c10::IValue> aten_inputs({input, weight});
-
-  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
-
-  benchmark_state.SetBytesProcessed(
-      int64_t(benchmark_state.iterations()) *
-      (2 * input.numel() + weight.numel()) *
-      int64_t(dataTypeSize(dtype)));
-}
-
 
 static void NvFuserScheduler_LayerNorm(
     benchmark::State& benchmark_state,
@@ -224,36 +162,6 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp32)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_DEFINE(
-    NvFuserScheduler_RMSNorm_fp32,
-    setupRMSNorm,
-    NvFuserScheduler_RMSNorm,
-    DataType::Float);
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{16, 64}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{18, 56}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{22, 44}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{24, 48}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_LayerNorm_fp16,
     setupLayerNorm,
     NvFuserScheduler_LayerNorm,
@@ -280,66 +188,6 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
     // ->RangeMultiplier(2)
     ->Ranges({{128, 1024 * 16}, {128, 1024 * 16}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_DEFINE(
-    NvFuserScheduler_RMSNorm_fp16,
-    setupRMSNorm,
-    NvFuserScheduler_RMSNorm,
-    DataType::Half);
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{16, 64}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{18, 56}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{22, 44}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{24, 48}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_DEFINE(
-    NvFuserScheduler_RMSNorm_bf16,
-    setupRMSNorm,
-    NvFuserScheduler_RMSNorm,
-    DataType::BFloat16);
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{16, 64}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{18, 56}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{22, 44}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{24, 48}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 

--- a/benchmarks/cpp/nvfuser/layer_norm_backward.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm_backward.cpp
@@ -61,64 +61,19 @@ static void setupLayerNorm_BWD(Fusion* fusion, DataType dtype) {
   auto layer_norm_results = layer_norm_backward(
       grad_out, input, {1}, mean, rstd, weight, bias, {true, true, true});
 
-  if (dtype == DataType::Half) {
+  if (dtype != DataType::Float) {
     layer_norm_results.grad_input =
-        castOp(DataType::Half, layer_norm_results.grad_input);
+        castOp(dtype, layer_norm_results.grad_input);
     layer_norm_results.grad_bias =
-        castOp(DataType::Half, layer_norm_results.grad_bias);
+        castOp(dtype, layer_norm_results.grad_bias);
     layer_norm_results.grad_weight =
-        castOp(DataType::Half, layer_norm_results.grad_weight);
+        castOp(dtype, layer_norm_results.grad_weight);
   }
 
   fusion->addOutput(layer_norm_results.grad_input);
   fusion->addOutput(layer_norm_results.grad_bias);
   fusion->addOutput(layer_norm_results.grad_weight);
 }
-
-static void setupRMSNorm_BWD(Fusion* fusion, DataType dtype) {
-  FusionGuard fg(fusion);
-
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
-
-  const int kReductionAxis = 2;
-  Double* eps_ptr = IrBuilder::create<Double>(1e-6);
-
-  // setup fusion
-  auto grad_out = makeContigTensor(3, dtype);
-  auto input = makeContigTensor(3, dtype);
-  auto weight = makeContigTensor(1, dtype);
-  auto rstd = TensorViewBuilder()
-                  .contiguity({false, false, false})
-                  .shape({8, -1, 1})
-                  .dtype(dtype)
-                  .build();
-
-  fusion->addInput(grad_out);
-  fusion->addInput(input);
-  fusion->addInput(weight);
-  fusion->addInput(rstd);
-
-  if (dtype == DataType::Half) {
-    grad_out = castOp(DataType::Float, grad_out);
-    input = castOp(DataType::Float, input);
-    weight = castOp(DataType::Float, weight);
-    rstd = castOp(DataType::Float, rstd);
-  }
-
-  auto rms_norm_results = rms_norm_backward(
-      grad_out, input, {1}, rstd, weight, {true, true, true});
-
-  if (dtype == DataType::Half) {
-    rms_norm_results.grad_input =
-        castOp(DataType::Half, rms_norm_results.grad_input);
-    rms_norm_results.grad_weight =
-        castOp(DataType::Half, rms_norm_results.grad_weight);
-  }
-
-  fusion->addOutput(rms_norm_results.grad_input);
-  fusion->addOutput(rms_norm_results.grad_weight);
-}
-
 
 static void NvFuserScheduler_LayerNorm_BWD(
     benchmark::State& benchmark_state,
@@ -151,37 +106,6 @@ static void NvFuserScheduler_LayerNorm_BWD(
        rstd.numel()) *
       int64_t(dataTypeSize(dtype)));
 }
-
-static void NvFuserScheduler_RMSNorm_BWD(
-    benchmark::State& benchmark_state,
-    FusionExecutorCache* fusion_executor_cache,
-    DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
-
-  std::vector<int64_t> input_shape{
-      8, benchmark_state.range(0), 1024};
-
-  // inputs
-  at::manual_seed(0);
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-  at::Tensor grad_out = at::randn(input_shape, options);
-  at::Tensor input = at::randn(input_shape, options);
-  at::Tensor weight = at::randn({input_shape[2]}, options);
-  at::Tensor rstd = at::randn({input_shape[0], input_shape[1], 1}, options);
-
-  std::vector<c10::IValue> aten_inputs(
-      {grad_out, input, weight, rstd});
-
-  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
-
-  benchmark_state.SetBytesProcessed(
-      int64_t(benchmark_state.iterations()) *
-      (3 * input.numel() + weight.numel() +
-       rstd.numel()) *
-      int64_t(dataTypeSize(dtype)));
-}
-
 
 //------------------------------------------------------------------------------
 
@@ -272,30 +196,6 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp32)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_DEFINE(
-    NvFuserScheduler_RMSNorm_BWD_fp32,
-    setupRMSNorm_BWD,
-    NvFuserScheduler_RMSNorm_BWD,
-    DataType::Float);
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{16, 64}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{28, 56}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp32)
-    ->RangeMultiplier(2)
-    ->Ranges({{24, 48}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_LayerNorm_BWD_fp16,
     setupLayerNorm_BWD,
     NvFuserScheduler_LayerNorm_BWD,
@@ -324,55 +224,6 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp16)
     ->Ranges({{128, 1024 * 16}, {128, 1024 * 16}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
-
-NVFUSER_BENCHMARK_DEFINE(
-    NvFuserScheduler_RMSNorm_BWD_fp16,
-    setupRMSNorm_BWD,
-    NvFuserScheduler_RMSNorm_BWD,
-    DataType::Half);
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{16, 64}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{28, 56}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp16)
-    ->RangeMultiplier(2)
-    ->Ranges({{24, 48}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_DEFINE(
-    NvFuserScheduler_RMSNorm_BWD_bf16,
-    setupRMSNorm_BWD,
-    NvFuserScheduler_RMSNorm_BWD,
-    DataType::BFloat16);
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{16, 64}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{28, 56}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
-NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_bf16)
-    ->RangeMultiplier(2)
-    ->Ranges({{24, 48}})
-    ->Unit(benchmark::kMicrosecond)
-    ->UseManualTime();
-
 
 //------------------------------------------------------------------------------
 

--- a/benchmarks/cpp/nvfuser/layer_norm_backward.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm_backward.cpp
@@ -87,13 +87,6 @@ static void setupRMSNorm_BWD(Fusion* fusion, DataType dtype) {
   auto grad_out = makeContigTensor(3, dtype);
   auto input = makeContigTensor(3, dtype);
   auto weight = makeContigTensor(1, dtype);
-  // auto bias = makeContigTensor(1, dtype);
-
-  // auto mean = TensorViewBuilder()
-  //                 .contiguity({false, false})
-  //                 .shape({-1, 1})
-  //                 .dtype(dtype)
-  //                 .build();
   auto rstd = TensorViewBuilder()
                   .contiguity({false, false, false})
                   .shape({8, -1, 1})
@@ -103,16 +96,12 @@ static void setupRMSNorm_BWD(Fusion* fusion, DataType dtype) {
   fusion->addInput(grad_out);
   fusion->addInput(input);
   fusion->addInput(weight);
-  // fusion->addInput(bias);
-  // fusion->addInput(mean);
   fusion->addInput(rstd);
 
   if (dtype == DataType::Half) {
     grad_out = castOp(DataType::Float, grad_out);
     input = castOp(DataType::Float, input);
     weight = castOp(DataType::Float, weight);
-    // bias = castOp(DataType::Float, bias);
-    // mean = castOp(DataType::Float, mean);
     rstd = castOp(DataType::Float, rstd);
   }
 
@@ -188,7 +177,7 @@ static void NvFuserScheduler_RMSNorm_BWD(
 
   benchmark_state.SetBytesProcessed(
       int64_t(benchmark_state.iterations()) *
-      (3 * input.numel() + weight.numel() + 
+      (3 * input.numel() + weight.numel() +
        rstd.numel()) *
       int64_t(dataTypeSize(dtype)));
 }

--- a/benchmarks/cpp/nvfuser/rms_norm.cpp
+++ b/benchmarks/cpp/nvfuser/rms_norm.cpp
@@ -1,0 +1,169 @@
+#include <torch/csrc/jit/codegen/cuda/executor.h>
+#include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_builder.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
+#include <torch/csrc/jit/codegen/cuda/lower2device.h>
+#include <torch/csrc/jit/codegen/cuda/ops/all_ops.h>
+#include <torch/csrc/jit/codegen/cuda/scheduler/all_schedulers.h>
+
+#include <benchmark/benchmark.h>
+
+#include <cuda_runtime.h>
+
+#include "utils.h"
+
+using namespace torch::jit::fuser::cuda;
+
+//------------------------------------------------------------------------------
+
+static void setupRMSNorm(Fusion* fusion, DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
+
+  FusionGuard fg(fusion);
+
+  const int kReductionAxis = 2;
+  const float kEps = 1e-6;
+
+  Double* eps_ptr = IrBuilder::create<Double>(kEps);
+
+  // setup fusion
+  auto input = makeContigTensor(3, dtype);
+  auto weight = makeContigTensor(1, dtype);
+
+  fusion->addInput(input);
+  fusion->addInput(weight);
+
+  if (dtype == DataType::Half) {
+    input = castOp(DataType::Float, input);
+    weight = castOp(DataType::Float, weight);
+  }
+
+  auto rms_norm_results = rms_norm(input, 1, weight, eps_ptr);
+
+  auto output = rms_norm_results.output;
+
+  if (dtype != DataType::Float) {
+    output = castOp(dtype, output);
+  }
+
+  fusion->addOutput(output);
+}
+
+static void NvFuserScheduler_RMSNorm(
+    benchmark::State& benchmark_state,
+    FusionExecutorCache* fusion_executor_cache,
+    DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
+
+  std::vector<int64_t> input_shape{
+      8, benchmark_state.range(0), 1024};
+  const float kEps = 1e-6;
+
+  // inputs
+  at::manual_seed(0);
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  at::Tensor input = at::randn(input_shape, options);
+  at::Tensor weight = at::randn({input_shape[2]}, options);
+
+  std::vector<c10::IValue> aten_inputs({input, weight});
+
+  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
+
+  benchmark_state.SetBytesProcessed(
+      int64_t(benchmark_state.iterations()) *
+      (2 * input.numel() + weight.numel()) *
+      int64_t(dataTypeSize(dtype)));
+}
+
+//------------------------------------------------------------------------------
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_fp32,
+    setupRMSNorm,
+    NvFuserScheduler_RMSNorm,
+    DataType::Float);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{18, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{22, 44}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_fp16,
+    setupRMSNorm,
+    NvFuserScheduler_RMSNorm,
+    DataType::Half);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{18, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{22, 44}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_bf16,
+    setupRMSNorm,
+    NvFuserScheduler_RMSNorm,
+    DataType::BFloat16);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{18, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{22, 44}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();

--- a/benchmarks/cpp/nvfuser/rms_norm_backward.cpp
+++ b/benchmarks/cpp/nvfuser/rms_norm_backward.cpp
@@ -1,0 +1,166 @@
+#include <torch/csrc/jit/codegen/cuda/executor.h>
+#include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_builder.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
+#include <torch/csrc/jit/codegen/cuda/lower2device.h>
+#include <torch/csrc/jit/codegen/cuda/ops/all_ops.h>
+#include <torch/csrc/jit/codegen/cuda/scheduler/all_schedulers.h>
+
+#include <benchmark/benchmark.h>
+
+#include <cuda_runtime.h>
+
+#include "utils.h"
+
+using namespace torch::jit::fuser::cuda;
+
+//------------------------------------------------------------------------------
+
+static void setupRMSNorm_BWD(Fusion* fusion, DataType dtype) {
+  FusionGuard fg(fusion);
+
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
+
+  const int kReductionAxis = 2;
+  Double* eps_ptr = IrBuilder::create<Double>(1e-6);
+
+  // setup fusion
+  auto grad_out = makeContigTensor(3, dtype);
+  auto input = makeContigTensor(3, dtype);
+  auto weight = makeContigTensor(1, dtype);
+  auto rstd = TensorViewBuilder()
+                  .contiguity({false, false, false})
+                  .shape({-1, -1, 1})
+                  .dtype(dtype)
+                  .build();
+
+  fusion->addInput(grad_out);
+  fusion->addInput(input);
+  fusion->addInput(weight);
+  fusion->addInput(rstd);
+
+  if (dtype == DataType::Half) {
+    grad_out = castOp(DataType::Float, grad_out);
+    input = castOp(DataType::Float, input);
+    weight = castOp(DataType::Float, weight);
+    rstd = castOp(DataType::Float, rstd);
+  }
+
+  auto rms_norm_results = rms_norm_backward(
+      grad_out, input, {1}, rstd, weight, {true, true, true});
+
+  if (dtype != DataType::Float ) {
+    rms_norm_results.grad_input =
+        castOp(dtype, rms_norm_results.grad_input);
+    rms_norm_results.grad_weight =
+        castOp(dtype, rms_norm_results.grad_weight);
+  }
+
+  fusion->addOutput(rms_norm_results.grad_input);
+  fusion->addOutput(rms_norm_results.grad_weight);
+}
+
+static void NvFuserScheduler_RMSNorm_BWD(
+    benchmark::State& benchmark_state,
+    FusionExecutorCache* fusion_executor_cache,
+    DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half || dtype == DataType::BFloat16);
+
+  std::vector<int64_t> input_shape{
+      8, benchmark_state.range(0), 1024};
+
+  // inputs
+  at::manual_seed(0);
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  at::Tensor grad_out = at::randn(input_shape, options);
+  at::Tensor input = at::randn(input_shape, options);
+  at::Tensor weight = at::randn({input_shape[2]}, options);
+  at::Tensor rstd = at::randn({input_shape[0], input_shape[1], 1}, options);
+
+  std::vector<c10::IValue> aten_inputs(
+      {grad_out, input, weight, rstd});
+
+  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
+
+  benchmark_state.SetBytesProcessed(
+      int64_t(benchmark_state.iterations()) *
+      (3 * input.numel() + weight.numel() +
+       rstd.numel()) *
+      int64_t(dataTypeSize(dtype)));
+}
+
+//------------------------------------------------------------------------------
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_BWD_fp32,
+    setupRMSNorm_BWD,
+    NvFuserScheduler_RMSNorm_BWD,
+    DataType::Float);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{28, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_BWD_fp16,
+    setupRMSNorm_BWD,
+    NvFuserScheduler_RMSNorm_BWD,
+    DataType::Half);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{28, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_fp16)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_RMSNorm_BWD_bf16,
+    setupRMSNorm_BWD,
+    NvFuserScheduler_RMSNorm_BWD,
+    DataType::BFloat16);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{28, 56}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_RMSNorm_BWD_bf16)
+    ->RangeMultiplier(2)
+    ->Ranges({{24, 48}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8679,18 +8679,15 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
     outer_shape.push_back(1);
   }
 
-  // auto grad_out = makeSymbolicTensor(shape.size());
-  // auto input = makeSymbolicTensor(shape.size());
   auto grad_out = makeContigTensor(shape.size());
   auto input = makeContigTensor(shape.size());
   auto rstd = makeConcreteTensor(outer_shape);
-  // auto weight = makeSymbolicTensor(norm_shape.size());
   auto weight = makeContigTensor(norm_shape.size());
   fusion.addInput(grad_out);
   fusion.addInput(input);
   fusion.addInput(rstd);
   fusion.addInput(weight);
-  
+
   auto grads = rms_norm_backward(
       grad_out,
       input,
@@ -8716,7 +8713,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
 
   FusionExecutorCache fec(std::move(fusion_ptr));
   std::vector<IValue> aten_inputs = {
-      aten_grad_out, aten_input, /*aten_mean,*/ aten_rstd, aten_weight/*, aten_bias*/};
+      aten_grad_out, aten_input, aten_rstd, aten_weight};
   auto cg_outputs = fec.runFusionWithInputs(aten_inputs);
 
   auto in_mul_rstd = at::mul(aten_input, aten_rstd);
@@ -8806,10 +8803,9 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
   std::vector<int64_t> input_shape{8, 56, NORM_SIZE};
   std::vector<int64_t> norm_shape{NORM_SIZE};
 
-  // auto input = makeSymbolicTensor(input_shape.size());
   auto input = makeContigTensor(input_shape.size());
   fusion.addInput(input);
-  auto result = rms_norm(input, norm_shape, nullptr, /* nullptr, */ eps_ptr);
+  auto result = rms_norm(input, norm_shape, nullptr, eps_ptr);
 
   fusion.addOutput(result.output);
   fusion.addOutput(result.invstd);
@@ -8839,9 +8835,8 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-      {output,//std::get<0>(aten_outputs),
-       invstd},//std::get<1>(aten_outputs),
-       //std::get<2>(aten_outputs)},
+      {output,
+       invstd},
       __LINE__,
       __FILE__,
       "",

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8689,12 +8689,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
   fusion.addInput(weight);
 
   auto grads = rms_norm_backward(
-      grad_out,
-      input,
-      norm_shape,
-      rstd,
-      weight,
-      {true, true});
+      grad_out, input, norm_shape, rstd, weight, {true, true});
 
   fusion.addOutput(grads.grad_input);
   fusion.addOutput(grads.grad_weight);
@@ -8708,7 +8703,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
   const float kEps = 1e-6;
   auto pow2 = at::pow(aten_input, 2);
   auto sum = at::sum(pow2, -1, true);
-  auto var = at::mul(sum, 1.0/NORM_SIZE);
+  auto var = at::mul(sum, 1.0 / NORM_SIZE);
   auto aten_rstd = at::pow(at::add(var, kEps), -0.5);
 
   FusionExecutorCache fec(std::move(fusion_ptr));
@@ -8720,24 +8715,27 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
   auto grad_out_mul = at::mul(aten_grad_out, in_mul_rstd);
   auto aten_grad_weight = at::sum(grad_out_mul, c10::IntArrayRef{0, 1});
   auto sum_loss1 = at::sum(at::mul(aten_grad_out, aten_weight), -1, true);
-  auto sum_loss2 = at::sum(at::mul(at::mul(at::mul(aten_grad_out, aten_weight), aten_input), aten_rstd), -1, true);
+  auto sum_loss2 = at::sum(
+      at::mul(
+          at::mul(at::mul(aten_grad_out, aten_weight), aten_input), aten_rstd),
+      -1,
+      true);
 
   const float fH = NORM_SIZE;
-  auto term1 = at::mul(aten_rstd, 1.0/fH);
+  auto term1 = at::mul(aten_rstd, 1.0 / fH);
   auto aten_grad_input = at::mul(at::mul(aten_grad_out, fH), aten_weight);
   aten_grad_input = at::sub(aten_grad_input, sum_loss1);
-  aten_grad_input = at::sub(aten_grad_input, at::mul(at::mul(aten_input, aten_rstd), sum_loss2));
+  aten_grad_input = at::sub(
+      aten_grad_input, at::mul(at::mul(aten_input, aten_rstd), sum_loss2));
   aten_grad_input = at::mul(aten_grad_input, term1);
   testValidate(
       &fusion,
       cg_outputs,
       aten_inputs,
-      {aten_grad_input,
-       aten_grad_weight},
+      {aten_grad_input, aten_grad_weight},
       __LINE__,
       __FILE__);
 }
-
 
 TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormalization_CUDA) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
@@ -8817,7 +8815,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
   auto pow2 = at::pow(aten_input, 2);
 
   auto sum = at::sum(pow2, -1, true);
-  auto var = at::mul(sum, 1.0/NORM_SIZE);
+  auto var = at::mul(sum, 1.0 / NORM_SIZE);
   auto invstd = at::pow(at::add(var, kEps), -0.5);
   auto output = at::mul(aten_input, invstd);
   //// Check reduction axis is same for all reductions
@@ -8835,8 +8833,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-      {output,
-       invstd},
+      {output, invstd},
       __LINE__,
       __FILE__,
       "",

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8769,12 +8769,8 @@ TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormalization_CUDA) {
   auto reduction_params = getPersistentHeuristics(&fusion, {aten_input});
   TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
 
-  schedulePersistentKernel(&fusion, reduction_params.value());
-  auto lparams = reduction_params.value().lparams;
-
-  torch::jit::fuser::cuda::FusionExecutor fe;
-  fe.compileFusion(&fusion, {aten_input}, lparams);
-  auto cg_outputs = fe.runFusion({aten_input}, lparams);
+  FusionExecutorCache fec(std::move(fusion_ptr));
+  auto cg_outputs = fec.runFusionWithInputs({aten_input});
 
   testValidate(
       &fusion,
@@ -8785,8 +8781,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormalization_CUDA) {
        std::get<2>(aten_outputs)},
       __LINE__,
       __FILE__,
-      "",
-      lparams);
+      "");
 }
 
 TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
@@ -8822,12 +8817,9 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
   //// Generate Launch Parameters
   auto reduction_params = getPersistentHeuristics(&fusion, {aten_input});
   TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
-  schedulePersistentKernel(&fusion, reduction_params.value());
-  auto lparams = reduction_params.value().lparams;
 
-  torch::jit::fuser::cuda::FusionExecutor fe;
-  fe.compileFusion(&fusion);
-  auto cg_outputs = fe.runFusion({aten_input}, lparams);
+  FusionExecutorCache fec(std::move(fusion_ptr));
+  auto cg_outputs = fec.runFusionWithInputs({aten_input});
 
   testValidate(
       &fusion,
@@ -8836,8 +8828,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
       {output, invstd},
       __LINE__,
       __FILE__,
-      "",
-      lparams);
+      "");
 }
 
 TEST_F(NVFuserTest, FusionMagicSchedulerBatchNormalization_CUDA) {

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -8659,6 +8659,121 @@ TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormBackward_CUDA) {
       __FILE__);
 }
 
+TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+  const size_t NORM_SIZE = 67;
+  std::vector<int64_t> shape{20, 100, 35, NORM_SIZE};
+  std::vector<int64_t> norm_shape{NORM_SIZE};
+
+  const size_t kM = shape.size();
+  const size_t kN = norm_shape.size();
+  const size_t kOuterNumDims = kM - kN;
+
+  std::vector<int64_t> outer_shape;
+  for (const auto idx : c10::irange(kOuterNumDims)) {
+    outer_shape.push_back(shape[idx]);
+  }
+  for (const auto idx : c10::irange(kOuterNumDims, kM)) {
+    outer_shape.push_back(1);
+  }
+
+  auto grad_out = makeSymbolicTensor(shape.size());
+  auto input = makeSymbolicTensor(shape.size());
+  // auto mean = makeConcreteTensor(outer_shape);
+  auto rstd = makeConcreteTensor(outer_shape);
+  auto weight = makeSymbolicTensor(norm_shape.size());
+  // auto bias = makeSymbolicTensor(norm_shape.size());
+  fusion.addInput(grad_out);
+  fusion.addInput(input);
+  // fusion.addInput(mean);
+  fusion.addInput(rstd);
+  fusion.addInput(weight);
+  // fusion.addInput(bias);
+  
+  // auto grads = layer_norm_backward(
+  //     grad_out,
+  //     input,
+  //     norm_shape,
+  //     mean,
+  //     rstd,
+  //     weight,
+  //     bias,
+  //     {true, true, true});
+
+  auto grads = rms_norm_backward(
+      grad_out,
+      input,
+      norm_shape,
+      rstd,
+      weight,
+      // bias,
+      {true, true});
+
+  fusion.addOutput(grads.grad_input);
+  fusion.addOutput(grads.grad_weight);
+  // fusion.addOutput(grads.grad_bias);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor aten_grad_out = at::randn(shape, options);
+  at::Tensor aten_input = at::randn(shape, options);
+  at::Tensor aten_weight = at::randn(norm_shape, options);
+  // at::Tensor aten_bias = at::randn(norm_shape, options);
+  auto at_weight = c10::optional<at::Tensor>(aten_weight);
+  // auto at_bias = c10::optional<at::Tensor>(aten_bias);
+
+  const float kEps = 1e-6;
+  //auto aten_results =
+  //    at::native_layer_norm(aten_input, norm_shape, at_weight, at_bias, kEps);
+  //auto aten_output = std::get<0>(aten_results);
+  // auto aten_mean = std::get<1>(aten_results);
+  //auto aten_rstd = std::get<2>(aten_results);
+  auto pow2 = at::pow(aten_input, 2);
+  auto sum = at::sum(pow2, -1, true);
+  auto var = at::mul(sum, 1.0/NORM_SIZE);
+  auto aten_rstd = at::pow(at::add(var, kEps), -0.5);
+  // auto aten_output = at::mul(at::mul(aten_input, invstd), aten_weight);
+
+
+  FusionExecutorCache fec(std::move(fusion_ptr));
+  std::vector<IValue> aten_inputs = {
+      aten_grad_out, aten_input, /*aten_mean,*/ aten_rstd, aten_weight/*, aten_bias*/};
+  auto cg_outputs = fec.runFusionWithInputs(aten_inputs);
+
+  //auto aten_gradients = at::native_layer_norm_backward(
+  //    aten_grad_out.to(at::kDouble),
+  //    aten_input.to(at::kDouble),
+  //    norm_shape,
+  //    aten_mean.to(at::kDouble),
+  //    aten_rstd.to(at::kDouble),
+  //    c10::optional<at::Tensor>(aten_weight.to(at::kDouble)),
+  //    c10::optional<at::Tensor>(aten_bias.to(at::kDouble)),
+  //    {true, true, true});
+  auto in_mul_rstd = at::mul(aten_input, aten_rstd);
+  auto grad_out_mul = at::mul(aten_grad_out, in_mul_rstd);
+  auto aten_grad_weight = at::sum(grad_out_mul, c10::IntArrayRef{0, 1, 2});
+
+  auto sum_loss1 = at::sum(at::mul(aten_grad_out, aten_weight), -1, true);
+  auto sum_loss2 = at::sum(at::mul(at::mul(at::mul(aten_grad_out, aten_weight), aten_input), aten_rstd), -1, true);
+
+  const float fH = NORM_SIZE;
+  auto term1 = at::mul(aten_rstd, 1.0/fH);
+  auto aten_grad_input = at::mul(at::mul(aten_grad_out, fH), aten_weight);
+  aten_grad_input = at::sub(aten_grad_input, sum_loss1);
+  aten_grad_input = at::sub(aten_grad_input, at::mul(at::mul(aten_input, aten_rstd), sum_loss2));
+  aten_grad_input = at::mul(aten_grad_input, term1);
+  testValidate(
+      &fusion,
+      cg_outputs,
+      aten_inputs,
+      {aten_grad_input,
+       aten_grad_weight},
+      __LINE__,
+      __FILE__);
+}
+
+
 TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormalization_CUDA) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
@@ -8705,6 +8820,65 @@ TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormalization_CUDA) {
       {std::get<0>(aten_outputs),
        std::get<1>(aten_outputs),
        std::get<2>(aten_outputs)},
+      __LINE__,
+      __FILE__,
+      "",
+      lparams);
+}
+
+TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  // const float kEps = 1e-5;
+  size_t NORM_SIZE = 67;
+  const float kEps = 1e-6;
+  Double* eps_ptr = IrBuilder::create<Double>(kEps);
+
+  std::vector<int64_t> input_shape{20, 100, 35, NORM_SIZE};
+  std::vector<int64_t> norm_shape{NORM_SIZE};
+
+  auto input = makeSymbolicTensor(input_shape.size());
+  fusion.addInput(input);
+  // auto result = layer_norm(input, norm_shape, nullptr, nullptr, eps_ptr);
+  auto result = rms_norm(input, norm_shape, nullptr, /* nullptr, */ eps_ptr);
+
+  fusion.addOutput(result.output);
+  // fusion.addOutput(result.mean);
+  fusion.addOutput(result.invstd);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor aten_input = at::randn(input_shape, options);
+  c10::optional<at::Tensor> aten_weight = c10::nullopt;
+
+  // c10::optional<at::Tensor> aten_bias = c10::nullopt;
+  // auto aten_outputs = at::native_layer_norm(
+  //    aten_input, norm_shape, aten_weight, aten_bias, kEps);
+  auto pow2 = at::pow(aten_input, 2);
+
+  auto sum = at::sum(pow2, -1, true);
+  auto var = at::mul(sum, 1.0/NORM_SIZE);
+  auto invstd = at::pow(at::add(var, kEps), -0.5);
+  auto output = at::mul(aten_input, invstd);
+  //// Check reduction axis is same for all reductions
+  //// Generate Launch Parameters
+  auto reduction_params = getPersistentHeuristics(&fusion, {aten_input});
+  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  schedulePersistentKernel(&fusion, reduction_params.value());
+  auto lparams = reduction_params.value().lparams;
+
+  torch::jit::fuser::cuda::FusionExecutor fe;
+  fe.compileFusion(&fusion);
+  auto cg_outputs = fe.runFusion({aten_input}, lparams);
+
+  testValidate(
+      &fusion,
+      cg_outputs,
+      {aten_input},
+      {output,//std::get<0>(aten_outputs),
+       invstd},//std::get<1>(aten_outputs),
+       //std::get<2>(aten_outputs)},
       __LINE__,
       __FILE__,
       "",

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -329,7 +329,7 @@ BackwardNormResult layer_norm_backward(
 
   TensorView* dw = nullptr;
   if (output_mask[1] && weight != nullptr) {
-    dw = sum(mul(dy, x_hat),r.outer_reduction_axes);
+    dw = sum(mul(dy, x_hat), r.outer_reduction_axes);
   }
 
   TensorView* db = nullptr;

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -212,7 +212,6 @@ ForwardNormResult layer_norm(
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
 
-  Val* num_features;
   auto r = norm_properties_from_num_dims(x, kNormShapeNumDims);
 
   // Main algorithm
@@ -261,7 +260,6 @@ ForwardRMSNormResult rms_norm(
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
 
-  Val* num_features;
   auto r = norm_properties_from_num_dims(x, kNormShapeNumDims);
 
   // Main algorithm
@@ -296,7 +294,6 @@ BackwardNormResult layer_norm_backward(
   TORCH_INTERNAL_ASSERT(mean != nullptr, "Mean is invalid.");
   TORCH_INTERNAL_ASSERT(invstd != nullptr, "Inv std is invalid.");
 
-  Val* num_features;
   auto r = norm_properties_from_num_dims(x, norm_shape.size());
 
   auto x_hat = mul(sub(x, mean), invstd);
@@ -320,7 +317,7 @@ BackwardNormResult layer_norm_backward(
   auto c3 = mul(x_hat, bcast_c2);
 
   auto inner = sub(sub(a, bcast_b), c3);
-  auto reciprocal_size = reciprocal(num_features);
+  auto reciprocal_size = reciprocal(r.num_features);
 
   TensorView* dx = nullptr;
   if (output_mask[0]) {
@@ -350,11 +347,6 @@ BackwardRMSNormResult rms_norm_backward(
   TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
   TORCH_INTERNAL_ASSERT(invstd != nullptr, "Inv std is invalid.");
 
-  std::vector<int> outer_reduction_axes;
-  std::vector<bool> outer_broadcast_mask;
-  std::vector<int> inner_reduction_axes;
-  std::vector<bool> inner_broadcast_mask;
-  Val* num_features;
   auto r = norm_properties_from_num_dims(x, norm_shape.size());
 
   auto x_hat = mul(x, invstd);

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -190,7 +190,7 @@ auto norm_properties_from_num_dims(
     std::vector<bool> outer_broadcast_mask;
     std::vector<int> inner_reduction_axes;
     std::vector<bool> inner_broadcast_mask;
-    Val* num_features = NULL;
+    Val* num_features = nullptr;
   } r;
   r.outer_reduction_axes = outer_reduction_axes;
   r.outer_broadcast_mask = outer_broadcast_mask;

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -190,7 +190,7 @@ auto norm_properties_from_num_dims(
     std::vector<bool> outer_broadcast_mask;
     std::vector<int> inner_reduction_axes;
     std::vector<bool> inner_broadcast_mask;
-    Val* num_features;
+    Val* num_features = NULL;
   } r;
   r.outer_reduction_axes = outer_reduction_axes;
   r.outer_broadcast_mask = outer_broadcast_mask;

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -221,7 +221,7 @@ ForwardNormResult layer_norm(
   return {y, mean_bcast, invstd};
 }
 
-ForwardNormResult rms_norm(
+ForwardRMSNormResult rms_norm(
     TensorView* x,
     const std::vector<int64_t>& norm_shape,
     TensorView* weight,
@@ -230,7 +230,7 @@ ForwardNormResult rms_norm(
   return rms_norm(x, norm_shape.size(), weight, /* bias, */ eps);
 }
 
-ForwardNormResult rms_norm(
+ForwardRMSNormResult rms_norm(
     TensorView* x,
     const size_t kNormShapeNumDims,
     TensorView* weight,
@@ -381,7 +381,7 @@ BackwardNormResult layer_norm_backward(
   return {dx, dw, db};
 }
 
-BackwardNormResult rms_norm_backward(
+BackwardRMSNormResult rms_norm_backward(
     TensorView* dy,
     TensorView* x,
     const std::vector<int64_t>& norm_shape,

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -156,13 +156,14 @@ ForwardNormResult layer_norm(
   return layer_norm(x, norm_shape.size(), weight, bias, eps);
 }
 
-void layer_norm_axes(const TensorView* x,
-		     const size_t kNormShapeNumDims,
-		     std::vector<int> & outer_reduction_axes,
-		     std::vector<bool> & outer_broadcast_mask,
-		     std::vector<int> & inner_reduction_axes,
-		     std::vector<bool> & inner_broadcast_mask,
-		     Val* &num_features) {
+void layer_norm_axes(
+    const TensorView* x,
+    const size_t kNormShapeNumDims,
+    std::vector<int>& outer_reduction_axes,
+    std::vector<bool>& outer_broadcast_mask,
+    std::vector<int>& inner_reduction_axes,
+    std::vector<bool>& inner_broadcast_mask,
+    Val*& num_features) {
   // (B, C, H, W, D) tensor
   // norm_shape = [H, W, D]
   // M = outer = product of remaining dimensions = B * C
@@ -208,7 +209,14 @@ ForwardNormResult layer_norm(
   std::vector<int> inner_reduction_axes;
   std::vector<bool> inner_broadcast_mask;
   Val* num_features;
-  layer_norm_axes(x, kNormShapeNumDims, outer_reduction_axes, outer_broadcast_mask, inner_reduction_axes, inner_broadcast_mask, num_features);
+  layer_norm_axes(
+      x,
+      kNormShapeNumDims,
+      outer_reduction_axes,
+      outer_broadcast_mask,
+      inner_reduction_axes,
+      inner_broadcast_mask,
+      num_features);
 
   // Main algorithm
   auto welford_out = Welford(x, inner_reduction_axes);
@@ -261,7 +269,14 @@ ForwardRMSNormResult rms_norm(
   std::vector<int> inner_reduction_axes;
   std::vector<bool> inner_broadcast_mask;
   Val* num_features;
-  layer_norm_axes(x, kNormShapeNumDims, outer_reduction_axes, outer_broadcast_mask, inner_reduction_axes, inner_broadcast_mask, num_features);
+  layer_norm_axes(
+      x,
+      kNormShapeNumDims,
+      outer_reduction_axes,
+      outer_broadcast_mask,
+      inner_reduction_axes,
+      inner_broadcast_mask,
+      num_features);
 
   // Main algorithm
   // auto welford_out = Welford(x, inner_reduction_axes);
@@ -287,7 +302,6 @@ ForwardRMSNormResult rms_norm(
   return {y, invstd};
 }
 
-
 BackwardNormResult layer_norm_backward(
     TensorView* dy,
     TensorView* x,
@@ -307,7 +321,14 @@ BackwardNormResult layer_norm_backward(
   std::vector<int> inner_reduction_axes;
   std::vector<bool> inner_broadcast_mask;
   Val* num_features;
-  layer_norm_axes(x, norm_shape.size(), outer_reduction_axes, outer_broadcast_mask, inner_reduction_axes, inner_broadcast_mask, num_features);
+  layer_norm_axes(
+      x,
+      norm_shape.size(),
+      outer_reduction_axes,
+      outer_broadcast_mask,
+      inner_reduction_axes,
+      inner_broadcast_mask,
+      num_features);
 
   auto x_hat = mul(sub(x, mean), invstd);
 
@@ -365,7 +386,14 @@ BackwardRMSNormResult rms_norm_backward(
   std::vector<int> inner_reduction_axes;
   std::vector<bool> inner_broadcast_mask;
   Val* num_features;
-  layer_norm_axes(x, norm_shape.size(), outer_reduction_axes, outer_broadcast_mask, inner_reduction_axes, inner_broadcast_mask, num_features);
+  layer_norm_axes(
+      x,
+      norm_shape.size(),
+      outer_reduction_axes,
+      outer_broadcast_mask,
+      inner_reduction_axes,
+      inner_broadcast_mask,
+      num_features);
 
   auto x_hat = mul(x, invstd);
 
@@ -402,7 +430,6 @@ BackwardRMSNormResult rms_norm_backward(
 
   return {dx, dw};
 }
-
 
 ForwardNormResult batch_norm(
     TensorView* x,

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -73,6 +73,20 @@ TORCH_CUDA_CU_API ForwardNormResult layer_norm(
     TensorView* bias,
     Val* eps);
 
+TORCH_CUDA_CU_API ForwardNormResult rms_norm(
+    TensorView* x,
+    const std::vector<int64_t>& norm_shape,
+    TensorView* weight,
+    // TensorView* bias,
+    Val* eps);
+
+TORCH_CUDA_CU_API ForwardNormResult rms_norm(
+    TensorView* x,
+    const size_t kNormShapeNumDims,
+    TensorView* weight,
+    // TensorView* bias,
+    Val* eps);
+
 TORCH_CUDA_CU_API BackwardNormResult layer_norm_backward(
     TensorView* dy,
     TensorView* x,
@@ -82,6 +96,17 @@ TORCH_CUDA_CU_API BackwardNormResult layer_norm_backward(
     TensorView* weight,
     TensorView* bias,
     const std::vector<bool>& output_mask);
+
+TORCH_CUDA_CU_API BackwardNormResult rms_norm_backward(
+    TensorView* dy,
+    TensorView* x,
+    const std::vector<int64_t>& norm_shape,
+    // TensorView* mean,
+    TensorView* rstd,
+    TensorView* weight,
+    // TensorView* bias,
+    const std::vector<bool>& output_mask);
+
 
 TORCH_CUDA_CU_API ForwardNormResult batch_norm(
     TensorView* x,

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -87,14 +87,12 @@ TORCH_CUDA_CU_API ForwardRMSNormResult rms_norm(
     TensorView* x,
     const std::vector<int64_t>& norm_shape,
     TensorView* weight,
-    // TensorView* bias,
     Val* eps);
 
 TORCH_CUDA_CU_API ForwardRMSNormResult rms_norm(
     TensorView* x,
     const size_t kNormShapeNumDims,
     TensorView* weight,
-    // TensorView* bias,
     Val* eps);
 
 TORCH_CUDA_CU_API BackwardNormResult layer_norm_backward(
@@ -111,10 +109,8 @@ TORCH_CUDA_CU_API BackwardRMSNormResult rms_norm_backward(
     TensorView* dy,
     TensorView* x,
     const std::vector<int64_t>& norm_shape,
-    // TensorView* mean,
     TensorView* rstd,
     TensorView* weight,
-    // TensorView* bias,
     const std::vector<bool>& output_mask);
 
 

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -28,6 +28,16 @@ struct BackwardNormResult {
   TensorView* grad_bias = nullptr;
 };
 
+struct ForwardRMSNormResult {
+  TensorView* output = nullptr;
+  TensorView* invstd = nullptr;
+};
+
+struct BackwardRMSNormResult {
+  TensorView* grad_input = nullptr;
+  TensorView* grad_weight = nullptr;
+};
+
 TORCH_CUDA_CU_API TensorView* mean(
     TensorView* x,
     const std::vector<int>& dims,
@@ -73,14 +83,14 @@ TORCH_CUDA_CU_API ForwardNormResult layer_norm(
     TensorView* bias,
     Val* eps);
 
-TORCH_CUDA_CU_API ForwardNormResult rms_norm(
+TORCH_CUDA_CU_API ForwardRMSNormResult rms_norm(
     TensorView* x,
     const std::vector<int64_t>& norm_shape,
     TensorView* weight,
     // TensorView* bias,
     Val* eps);
 
-TORCH_CUDA_CU_API ForwardNormResult rms_norm(
+TORCH_CUDA_CU_API ForwardRMSNormResult rms_norm(
     TensorView* x,
     const size_t kNormShapeNumDims,
     TensorView* weight,
@@ -97,7 +107,7 @@ TORCH_CUDA_CU_API BackwardNormResult layer_norm_backward(
     TensorView* bias,
     const std::vector<bool>& output_mask);
 
-TORCH_CUDA_CU_API BackwardNormResult rms_norm_backward(
+TORCH_CUDA_CU_API BackwardRMSNormResult rms_norm_backward(
     TensorView* dy,
     TensorView* x,
     const std::vector<int64_t>& norm_shape,

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -113,7 +113,6 @@ TORCH_CUDA_CU_API BackwardRMSNormResult rms_norm_backward(
     TensorView* weight,
     const std::vector<bool>& output_mask);
 
-
 TORCH_CUDA_CU_API ForwardNormResult batch_norm(
     TensorView* x,
     TensorView* weight,


### PR DESCRIPTION
Implementation pattern-matched from LayerNorm; observed performance:
```
-----------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                           Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------------------------------------------
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/16/manual_time               8.10 us         81.2 us        82877 bytes_per_second=121.009G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/32/manual_time               8.59 us         81.6 us        81560 bytes_per_second=227.885G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/64/manual_time               9.88 us         82.7 us        71129 bytes_per_second=395.833G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/18/manual_time               8.55 us         81.3 us        76431 bytes_per_second=128.886G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/32/manual_time               8.60 us         81.5 us        79412 bytes_per_second=227.535G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/56/manual_time               9.52 us         82.3 us        73688 bytes_per_second=359.31G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/22/manual_time               8.59 us         81.4 us        81418 bytes_per_second=156.69G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/32/manual_time               8.64 us         81.5 us        79424 bytes_per_second=226.586G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/44/manual_time               9.06 us         81.8 us        77213 bytes_per_second=296.727G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/24/manual_time               8.46 us         81.2 us        82789 bytes_per_second=173.629G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/32/manual_time               8.60 us         81.4 us        81436 bytes_per_second=227.5G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp32___GRAPH/NvFuserScheduler_RMSNorm_fp32/48/manual_time               9.29 us         82.1 us        75856 bytes_per_second=315.79G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/16/manual_time               7.99 us         80.9 us        87693 bytes_per_second=61.3367G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/32/manual_time               8.05 us         80.8 us        87003 bytes_per_second=121.598G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/64/manual_time               8.56 us         81.4 us        81710 bytes_per_second=228.521G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/18/manual_time               7.95 us         80.9 us        88078 bytes_per_second=69.3566G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/32/manual_time               8.05 us         80.8 us        86977 bytes_per_second=121.581G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/56/manual_time               8.40 us         81.2 us        83532 bytes_per_second=203.591G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/22/manual_time               7.97 us         80.9 us        87940 bytes_per_second=84.4878G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/32/manual_time               8.05 us         80.9 us        86939 bytes_per_second=121.578G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/44/manual_time               8.32 us         81.2 us        84073 bytes_per_second=161.554G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/24/manual_time               7.89 us         80.7 us        88845 bytes_per_second=93.1251G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/32/manual_time               8.08 us         81.0 us        86983 bytes_per_second=121.118G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_fp16___GRAPH/NvFuserScheduler_RMSNorm_fp16/48/manual_time               8.35 us         81.2 us        83830 bytes_per_second=175.692G/s Red On Fastest Dim // Persistent Kernel // Project Persistent Buffers //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 8/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/16/manual_time               8.14 us         81.0 us        86026 bytes_per_second=60.2552G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/32/manual_time               9.69 us         82.5 us        72250 bytes_per_second=100.936G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/64/manual_time               10.2 us         82.3 us        68965 bytes_per_second=191.581G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/18/manual_time               8.11 us         80.9 us        86347 bytes_per_second=67.9699G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/32/manual_time               9.69 us         82.5 us        72222 bytes_per_second=100.981G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/56/manual_time               9.99 us         81.9 us        70104 bytes_per_second=171.342G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/22/manual_time               8.44 us         81.4 us        83161 bytes_per_second=79.7854G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/32/manual_time               9.69 us         82.5 us        72232 bytes_per_second=100.951G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/44/manual_time               9.92 us         82.0 us        70595 bytes_per_second=135.614G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/24/manual_time               8.46 us         81.2 us        82734 bytes_per_second=86.8294G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/32/manual_time               9.69 us         82.5 us        72135 bytes_per_second=100.966G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_bf16___GRAPH/NvFuserScheduler_RMSNorm_bf16/48/manual_time               10.2 us         82.4 us        69139 bytes_per_second=144.141G/s Red On Fastest Dim // Persistent Kernel //  // Iteration Domain: unroll / factor 2 // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(1/1/1)/grid(1/1/1)/0]
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/16/manual_time       18.3 us         90.4 us        38268 bytes_per_second=80.2964G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/32/manual_time       19.9 us         91.8 us        35258 bytes_per_second=147.782G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/64/manual_time       23.2 us         94.8 us        30211 bytes_per_second=253.072G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/28/manual_time       19.5 us         91.6 us        35964 bytes_per_second=131.934G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/32/manual_time       19.9 us         91.6 us        35262 bytes_per_second=147.786G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/56/manual_time       22.9 us         94.8 us        30877 bytes_per_second=224.138G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/24/manual_time       19.1 us         91.2 us        36673 bytes_per_second=115.343G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/32/manual_time       19.9 us         91.9 us        35267 bytes_per_second=147.811G/s
NvFuserScheduler_RMSNorm_BWD_fp32___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp32/48/manual_time       21.4 us         93.2 us        32733 bytes_per_second=205.749G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/16/manual_time       19.9 us         92.2 us        35183 bytes_per_second=36.8949G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/32/manual_time       22.4 us         94.5 us        31299 bytes_per_second=65.5921G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/64/manual_time       24.5 us         96.3 us        28513 bytes_per_second=119.472G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/28/manual_time       21.5 us         93.7 us        32996 bytes_per_second=59.7153G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/32/manual_time       22.3 us         94.3 us        31363 bytes_per_second=65.7543G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/56/manual_time       23.9 us         95.8 us        29332 bytes_per_second=107.538G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/24/manual_time       19.3 us         91.5 us        36254 bytes_per_second=57.0066G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/32/manual_time       22.3 us         94.3 us        31361 bytes_per_second=65.7369G/s
NvFuserScheduler_RMSNorm_BWD_fp16___GRAPH/NvFuserScheduler_RMSNorm_BWD_fp16/48/manual_time       21.0 us         93.1 us        33389 bytes_per_second=104.927G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/16/manual_time       20.7 us         92.9 us        33868 bytes_per_second=35.5392G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/32/manual_time       23.5 us         95.8 us        30101 bytes_per_second=62.4383G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/64/manual_time       25.9 us         96.5 us        27056 bytes_per_second=113.344G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/28/manual_time       21.9 us         94.2 us        31931 bytes_per_second=58.5835G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/32/manual_time       23.3 us         95.3 us        30098 bytes_per_second=63.07G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/56/manual_time       25.1 us         95.8 us        27941 bytes_per_second=102.408G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/24/manual_time       20.0 us         92.3 us        34917 bytes_per_second=54.9171G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/32/manual_time       23.3 us         95.3 us        30088 bytes_per_second=63.0847G/s
NvFuserScheduler_RMSNorm_BWD_bf16___GRAPH/NvFuserScheduler_RMSNorm_BWD_bf16/48/manual_time       22.2 us         93.1 us        31632 bytes_per_second=99.0774G/s
```