### PR TITLE
InstanceNorm Channels Last 3D Benchmarks + InstanceNormBackward

### DIFF
--- a/benchmarks/cpp/nvfuser/instance_norm.cpp
+++ b/benchmarks/cpp/nvfuser/instance_norm.cpp
@@ -234,31 +234,31 @@ NVFUSER_BENCHMARK_DEFINE(
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{2, 8}, {128, 128}, {32, 32}})
+    ->Ranges({{1, 8}, {128, 128}, {32, 32}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{2, 8}, {64, 64}, {64, 64}})
+    ->Ranges({{1, 8}, {64, 64}, {64, 64}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{2, 8}, {32, 32}, {128, 128}})
+    ->Ranges({{1, 8}, {32, 32}, {128, 128}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{2, 8}, {16, 16}, {256, 256}})
+    ->Ranges({{1, 8}, {16, 16}, {256, 256}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{2, 8}, {4, 8}, {320, 320}})
+    ->Ranges({{1, 8}, {4, 8}, {320, 320}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 

--- a/benchmarks/cpp/nvfuser/instance_norm.cpp
+++ b/benchmarks/cpp/nvfuser/instance_norm.cpp
@@ -62,6 +62,56 @@ static void setupInstanceNorm(Fusion* fusion, DataType dtype) {
   fusion->addOutput(output);
 }
 
+static void setupInstanceNorm3d_channels_last(Fusion* fusion, DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+
+  FusionGuard fg(fusion);
+
+  auto input = makeContigTensor(5, dtype);
+  auto weight = makeContigTensor(1, dtype);
+  auto bias = makeContigTensor(1, dtype);
+  auto running_mean = makeContigTensor(1, DataType::Float);
+  auto running_var = makeContigTensor(1, DataType::Float);
+
+  fusion->addInput(input);
+  fusion->addInput(weight);
+  fusion->addInput(bias);
+  fusion->addInput(running_mean);
+  fusion->addInput(running_var);
+
+  if (dtype == DataType::Half) {
+    input = castOp(DataType::Float, input);
+    weight = castOp(DataType::Float, weight);
+    bias = castOp(DataType::Float, bias);
+  }
+
+  const bool kTraining = true;
+  const float kMomentum = 0.1;
+  const float kEps = 1e-5;
+  auto momentum_ptr = IrBuilder::create<Double>(kMomentum);
+  auto eps_ptr = IrBuilder::create<Double>(kEps);
+
+  auto norm = instance_norm(
+      input,
+      weight,
+      bias,
+      running_mean,
+      running_var,
+      kTraining,
+      momentum_ptr,
+      eps_ptr,
+      true);
+
+  auto output = unaryOp(UnaryOpType::Relu, norm.output);
+
+  if (dtype == DataType::Half) {
+    output = castOp(DataType::Half, output);
+  }
+
+  fusion->addOutput(output);
+}
+
+
 //------------------------------------------------------------------------------
 
 static void NvFuserScheduler_InstanceNorm(
@@ -105,6 +155,50 @@ static void NvFuserScheduler_InstanceNorm(
       ((kChannels * 2 + kSize * 2) * dataTypeSize(dtype) +
        (kChannels * 2 * 2) * dataTypeSize(DataType::Float)));
 }
+
+static void NvFuserScheduler_InstanceNorm3d_channels_last(
+    benchmark::State& benchmark_state,
+    FusionExecutorCache* fusion_executor_cache,
+    DataType dtype) {
+  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+
+  std::vector<int64_t> input_shape{
+      benchmark_state.range(0),
+      benchmark_state.range(1),
+      benchmark_state.range(1),
+      benchmark_state.range(1),
+      benchmark_state.range(2)};
+
+  // inputs
+  at::manual_seed(0);
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  auto fp32_options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor at_x = at::randn(input_shape, options);
+  at::Tensor at_weight = at::ones({benchmark_state.range(2)}, options);
+  at::Tensor at_bias = at::zeros({benchmark_state.range(2)}, options);
+  at::Tensor at_mean = at::zeros({benchmark_state.range(2)}, fp32_options);
+  at::Tensor at_var = at::ones({benchmark_state.range(2)}, fp32_options);
+
+  std::vector<c10::IValue> aten_inputs = {
+      at_x, at_weight, at_bias, at_mean, at_var};
+  std::vector<at::Tensor> outputs;
+
+  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
+
+  const size_t kSize =
+      input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3] * input_shape[4];
+  const size_t kChannels = benchmark_state.range(2);
+
+  // Read: x, weight, bias, running_mean, running_var
+  // Write: y, running_mean, running_var
+  benchmark_state.SetBytesProcessed(
+      benchmark_state.iterations() *
+      ((kChannels * 2 + kSize * 2) * dataTypeSize(dtype) +
+       (kChannels * 2 * 2) * dataTypeSize(DataType::Float)));
+}
+
 
 static void Baseline_InstanceNorm(
     benchmark::State& benchmark_state,
@@ -192,6 +286,42 @@ NVFUSER_BENCHMARK_DEFINE(
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm_fp32)
     // ->RangeMultiplier(2)
     ->Ranges({{8, 8}, {640, 640}, {64, 128}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_InstanceNorm3d_channels_last_fp32,
+    setupInstanceNorm3d_channels_last,
+    NvFuserScheduler_InstanceNorm3d_channels_last,
+    DataType::Float);
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{4, 16}, {128, 128}, {32, 32}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{4, 16}, {64, 64}, {64, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{4, 16}, {32, 32}, {128, 128}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{4, 16}, {16, 16}, {256, 256}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
+    ->RangeMultiplier(2)
+    ->Ranges({{4, 16}, {4, 8}, {320, 320}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 

--- a/benchmarks/cpp/nvfuser/instance_norm.cpp
+++ b/benchmarks/cpp/nvfuser/instance_norm.cpp
@@ -14,60 +14,15 @@
 
 using namespace torch::jit::fuser::cuda;
 
-static void setupInstanceNorm(Fusion* fusion, DataType dtype) {
+static void setupInstanceNorm(Fusion* fusion, DataType dtype, bool channels_last_3d = false) {
   TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
   auto input = makeContigTensor(4, dtype);
-  auto weight = makeContigTensor(1, dtype);
-  auto bias = makeContigTensor(1, dtype);
-  auto running_mean = makeContigTensor(1, DataType::Float);
-  auto running_var = makeContigTensor(1, DataType::Float);
-
-  fusion->addInput(input);
-  fusion->addInput(weight);
-  fusion->addInput(bias);
-  fusion->addInput(running_mean);
-  fusion->addInput(running_var);
-
-  if (dtype == DataType::Half) {
-    input = castOp(DataType::Float, input);
-    weight = castOp(DataType::Float, weight);
-    bias = castOp(DataType::Float, bias);
+  if (channels_last_3d) {
+    input = makeContigTensor(5, dtype);
   }
-
-  const bool kTraining = true;
-  const float kMomentum = 0.1;
-  const float kEps = 1e-5;
-  auto momentum_ptr = IrBuilder::create<Double>(kMomentum);
-  auto eps_ptr = IrBuilder::create<Double>(kEps);
-
-  auto norm = instance_norm(
-      input,
-      weight,
-      bias,
-      running_mean,
-      running_var,
-      kTraining,
-      momentum_ptr,
-      eps_ptr);
-
-  auto output = unaryOp(UnaryOpType::Relu, norm.output);
-
-  if (dtype == DataType::Half) {
-    output = castOp(DataType::Half, output);
-  }
-
-  fusion->addOutput(output);
-}
-
-static void setupInstanceNorm3d_channels_last(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
-
-  FusionGuard fg(fusion);
-
-  auto input = makeContigTensor(5, dtype);
   auto weight = makeContigTensor(1, dtype);
   auto bias = makeContigTensor(1, dtype);
   auto running_mean = makeContigTensor(1, DataType::Float);
@@ -100,7 +55,7 @@ static void setupInstanceNorm3d_channels_last(Fusion* fusion, DataType dtype) {
       kTraining,
       momentum_ptr,
       eps_ptr,
-      true);
+      channels_last_3d);
 
   auto output = unaryOp(UnaryOpType::Relu, norm.output);
 
@@ -111,13 +66,13 @@ static void setupInstanceNorm3d_channels_last(Fusion* fusion, DataType dtype) {
   fusion->addOutput(output);
 }
 
-
 //------------------------------------------------------------------------------
 
 static void NvFuserScheduler_InstanceNorm(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
-    DataType dtype) {
+    DataType dtype,
+    bool channels_last_3d = false) {
   TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
@@ -126,43 +81,7 @@ static void NvFuserScheduler_InstanceNorm(
       benchmark_state.range(1),
       benchmark_state.range(1)};
 
-  // inputs
-  at::manual_seed(0);
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-  auto fp32_options =
-      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at_x = at::randn(input_shape, options);
-  at::Tensor at_weight = at::ones({input_shape[1]}, options);
-  at::Tensor at_bias = at::zeros({input_shape[1]}, options);
-  at::Tensor at_mean = at::zeros({input_shape[1]}, fp32_options);
-  at::Tensor at_var = at::ones({input_shape[1]}, fp32_options);
-
-  std::vector<c10::IValue> aten_inputs = {
-      at_x, at_weight, at_bias, at_mean, at_var};
-  std::vector<at::Tensor> outputs;
-
-  runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
-
-  const size_t kSize =
-      input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3];
-  const size_t kChannels = input_shape[1];
-
-  // Read: x, weight, bias, running_mean, running_var
-  // Write: y, running_mean, running_var
-  benchmark_state.SetBytesProcessed(
-      benchmark_state.iterations() *
-      ((kChannels * 2 + kSize * 2) * dataTypeSize(dtype) +
-       (kChannels * 2 * 2) * dataTypeSize(DataType::Float)));
-}
-
-static void NvFuserScheduler_InstanceNorm3d_channels_last(
-    benchmark::State& benchmark_state,
-    FusionExecutorCache* fusion_executor_cache,
-    DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
-
-  std::vector<int64_t> input_shape{
+  std::vector<int64_t> input_shape_3d{
       benchmark_state.range(0),
       benchmark_state.range(1),
       benchmark_state.range(1),
@@ -175,7 +94,7 @@ static void NvFuserScheduler_InstanceNorm3d_channels_last(
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto fp32_options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at_x = at::randn(input_shape, options);
+  at::Tensor at_x = at::randn(channels_last_3d ? input_shape_3d : input_shape, options);
   at::Tensor at_weight = at::ones({benchmark_state.range(2)}, options);
   at::Tensor at_bias = at::zeros({benchmark_state.range(2)}, options);
   at::Tensor at_mean = at::zeros({benchmark_state.range(2)}, fp32_options);
@@ -187,8 +106,9 @@ static void NvFuserScheduler_InstanceNorm3d_channels_last(
 
   runBenchmarkIterations(benchmark_state, fusion_executor_cache, aten_inputs);
 
-  const size_t kSize =
-      input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3] * input_shape[4];
+  const size_t kSize = channels_last_3d ?
+      input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3] * input_shape[4]:
+      input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3];
   const size_t kChannels = benchmark_state.range(2);
 
   // Read: x, weight, bias, running_mean, running_var
@@ -199,10 +119,10 @@ static void NvFuserScheduler_InstanceNorm3d_channels_last(
        (kChannels * 2 * 2) * dataTypeSize(DataType::Float)));
 }
 
-
 static void Baseline_InstanceNorm(
     benchmark::State& benchmark_state,
-    DataType dtype) {
+    DataType dtype,
+    bool channels_last_3d = false) {
   TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
@@ -210,6 +130,14 @@ static void Baseline_InstanceNorm(
       benchmark_state.range(2),
       benchmark_state.range(1),
       benchmark_state.range(1)};
+  std::vector<int64_t> input_shape_3d{
+      benchmark_state.range(0),
+      benchmark_state.range(2),
+      benchmark_state.range(1),
+      benchmark_state.range(1),
+      benchmark_state.range(1),
+  };
+
   const float kMomentum = 0.1;
   const float kEps = 1e-5;
   const auto aten_dtype = data_type_to_aten(dtype);
@@ -220,10 +148,13 @@ static void Baseline_InstanceNorm(
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   at::Tensor at_x = at::randn(input_shape, options);
-  at::Tensor at_weight = at::ones({input_shape[1]}, options);
-  at::Tensor at_bias = at::zeros({input_shape[1]}, options);
-  at::Tensor at_mean = at::zeros({input_shape[1]}, fp32_options);
-  at::Tensor at_var = at::ones({input_shape[1]}, fp32_options);
+  if (channels_last_3d) {
+    at_x = at::randn(input_shape_3d, options.memory_format(c10::MemoryFormat::ChannelsLast3d));
+  }
+  at::Tensor at_weight = at::ones({benchmark_state.range(2)}, options);
+  at::Tensor at_bias = at::zeros({benchmark_state.range(2)}, options);
+  at::Tensor at_mean = at::zeros({benchmark_state.range(2)}, fp32_options);
+  at::Tensor at_var = at::ones({benchmark_state.range(2)}, fp32_options);
 
   auto ato_weight = c10::optional<at::Tensor>(at_weight);
   auto ato_bias = c10::optional<at::Tensor>(at_bias);
@@ -253,9 +184,10 @@ static void Baseline_InstanceNorm(
     cudaDeviceSynchronize();
   }
 
-  const size_t kSize =
+  const size_t kSize = channels_last_3d ?
+      input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3] * input_shape[4]:
       input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3];
-  const size_t kChannels = input_shape[1];
+  const size_t kChannels = benchmark_state.range(2);
 
   // Read: x, weight, bias, running_mean, running_var
   // Write: y, running_mean, running_var
@@ -275,6 +207,10 @@ static void Baseline_InstanceNorm_fp16(benchmark::State& benchmark_state) {
   Baseline_InstanceNorm(benchmark_state, DataType::Half);
 }
 
+static void Baseline_InstanceNorm_fp32_channels_last_3d(benchmark::State& benchmark_state) {
+  Baseline_InstanceNorm(benchmark_state, DataType::Float, true);
+}
+
 //------------------------------------------------------------------------------
 
 NVFUSER_BENCHMARK_DEFINE(
@@ -291,37 +227,38 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm_fp32)
 
 NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_InstanceNorm3d_channels_last_fp32,
-    setupInstanceNorm3d_channels_last,
-    NvFuserScheduler_InstanceNorm3d_channels_last,
-    DataType::Float);
+    setupInstanceNorm,
+    NvFuserScheduler_InstanceNorm,
+    DataType::Float,
+    true);
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{4, 16}, {128, 128}, {32, 32}})
+    ->Ranges({{2, 8}, {128, 128}, {32, 32}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{4, 16}, {64, 64}, {64, 64}})
+    ->Ranges({{2, 8}, {64, 64}, {64, 64}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{4, 16}, {32, 32}, {128, 128}})
+    ->Ranges({{2, 8}, {32, 32}, {128, 128}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{4, 16}, {16, 16}, {256, 256}})
+    ->Ranges({{2, 8}, {16, 16}, {256, 256}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_InstanceNorm3d_channels_last_fp32)
     ->RangeMultiplier(2)
-    ->Ranges({{4, 16}, {4, 8}, {320, 320}})
+    ->Ranges({{2, 8}, {4, 8}, {320, 320}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
@@ -349,5 +286,30 @@ BENCHMARK(Baseline_InstanceNorm_fp16)
     ->Ranges({{8, 8}, {640, 640}, {64, 256}})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
+
+BENCHMARK(Baseline_InstanceNorm_fp32_channels_last_3d)
+    ->RangeMultiplier(2)
+    ->Ranges({{2, 8}, {128, 128}, {32, 32}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(Baseline_InstanceNorm_fp32_channels_last_3d)
+    ->RangeMultiplier(2)
+    ->Ranges({{2, 8}, {64, 64}, {64, 64}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(Baseline_InstanceNorm_fp32_channels_last_3d)
+    ->RangeMultiplier(2)
+    ->Ranges({{2, 8}, {16, 16}, {256, 256}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+BENCHMARK(Baseline_InstanceNorm_fp32_channels_last_3d)
+    ->RangeMultiplier(2)
+    ->Ranges({{2, 8}, {4, 8}, {320, 320}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
 
 //------------------------------------------------------------------------------

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9083,6 +9083,177 @@ TEST_F(NVFuserTest, FusionMagicSchedulerBatchNormalization_CUDA) {
       "");
 }
 
+TEST_F(NVFuserTest, FusionMagicSchedulerInstanceNormalization_CUDA) {
+  if (!deviceMajorMinorCheck(7)) {
+    GTEST_SKIP() << "skipping tests on pre-Volta GPUs";
+    return;
+  }
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  const float kMomentum = 0.1;
+  const float kEps = 1e-5;
+  const bool kUseInputStats = true;
+  std::vector<int64_t> input_shape{20, 100, 35, 45};
+
+  auto input = makeSymbolicTensor(input_shape.size());
+  auto weight = makeSymbolicTensor(1);
+  auto bias = makeSymbolicTensor(1);
+  auto running_mean = makeSymbolicTensor(1);
+  auto running_var = makeSymbolicTensor(1);
+  fusion->addInput(input);
+  fusion->addInput(weight);
+  fusion->addInput(bias);
+  fusion->addInput(running_mean);
+  fusion->addInput(running_var);
+
+  Double* momentum = IrBuilder::create<Double>(kMomentum);
+  Double* eps = IrBuilder::create<Double>(kEps);
+
+  auto result = instance_norm(
+      input, weight, bias, running_mean, running_var, kUseInputStats, momentum, eps);
+
+  fusion->addOutput(result.output);
+  //fusion->addOutput(result.mean);
+  //fusion->addOutput(result.invstd);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto at_input = at::randn(input_shape, options);
+  auto at_weight = at::ones({input_shape[1]}, options);
+  auto at_bias = at::zeros({input_shape[1]}, options);
+  auto at_run_mean = at::zeros({input_shape[1]}, options);
+  auto at_run_var = at::ones({input_shape[1]}, options);
+
+  std::vector<IValue> aten_inputs = {
+      at_input, at_weight, at_bias, at_run_mean, at_run_var};
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+
+  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+
+  auto aten_outputs = at::instance_norm(
+      at_input,
+      c10::optional<at::Tensor>(at_weight),
+      c10::optional<at::Tensor>(at_bias),
+      c10::optional<at::Tensor>(at_run_mean),
+      c10::optional<at::Tensor>(at_run_var),
+      kUseInputStats,
+      kMomentum,
+      kEps,
+      false);
+
+  testValidate(
+      executor_cache.fusion(),
+      cg_outputs,
+      aten_inputs,
+      {at_run_mean,
+       at_run_var,
+       aten_outputs},
+      __LINE__,
+      __FILE__,
+      "");
+}
+
+TEST_F(NVFuserTest, FusionMagicSchedulerInstanceNormalizationBackward_CUDA) {
+  if (!deviceMajorMinorCheck(7)) {
+    GTEST_SKIP() << "skipping tests on pre-Volta GPUs";
+    return;
+  }
+  auto fusion_forward = std::make_unique<Fusion>();
+  FusionGuard fg_forward(fusion_forward.get());
+
+  const float kMomentum = 0.1;
+  const float kEps = 1e-5;
+  const bool kUseInputStats = true;
+  const bool channels_last = true;
+  const int B = 2;
+  const int C = 5;
+  const int S = 3;
+  std::vector<int64_t> input_shape{B, C, S, S, S};
+  // explicit channels-last for NVFuser
+  std::vector<int64_t> nvfuser_input_shape{B, S, S, S, C};
+
+  auto input = makeContigTensor(input_shape.size());
+  auto weight = makeContigTensor(1);
+  auto bias = makeContigTensor(1);
+  fusion_forward->addInput(input);
+  fusion_forward->addInput(weight);
+  fusion_forward->addInput(bias);
+
+  Double* momentum = IrBuilder::create<Double>(kMomentum);
+  Double* eps = IrBuilder::create<Double>(kEps);
+  auto result_forward = instance_norm(
+      input, weight, bias, nullptr, nullptr, kUseInputStats, momentum, eps, channels_last);
+  fusion_forward->addOutput(result_forward.output);
+  fusion_forward->addOutput(result_forward.mean);
+  fusion_forward->addOutput(result_forward.invstd);
+
+  FusionExecutorCache executor_cache_forward(std::move(fusion_forward));
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto at_input = at::randn(input_shape, options).to(at::MemoryFormat::ChannelsLast3d).set_requires_grad(true);
+  auto at_input_nvfuser = at_input.clone().detach().permute({0, 2, 3, 4, 1}); 
+  auto at_weight = at::ones({input_shape[1]}, options).set_requires_grad(true);
+  auto at_weight_nvfuser = at_weight.clone().detach();
+  auto at_bias = at::zeros({input_shape[1]}, options).set_requires_grad(true);
+  auto at_bias_nvfuser = at_bias.clone().detach();
+  std::vector<torch::jit::IValue> aten_inputs_forward = {at_input_nvfuser, at_weight_nvfuser, at_bias_nvfuser};
+  // out, mean, invstd
+  auto outputs_forward = executor_cache_forward.runFusionWithInputs(aten_inputs_forward);
+  auto at_out = at::instance_norm(
+     at_input,
+     c10::optional<at::Tensor>(at_weight),
+     c10::optional<at::Tensor>(at_bias),
+     c10::optional<at::Tensor>(c10::nullopt),
+     c10::optional<at::Tensor>(c10::nullopt),
+     kUseInputStats,
+     kMomentum,
+     kEps,
+     false);
+  auto at_grad = at::randn(input_shape, options).to(at::MemoryFormat::ChannelsLast3d);
+  auto at_grad_nvfuser = at_grad.clone().detach().permute({0, 2, 3, 4, 1});
+  at_out.backward(at_grad);
+  auto fusion_backward = std::make_unique<Fusion>();
+  FusionGuard fg_backward(fusion_backward.get());
+
+  input = makeContigTensor(input_shape.size());
+  auto grad_output = makeContigTensor(input_shape.size());
+  weight = makeContigTensor(1);
+  auto save_mean = makeContigTensor(2);
+  auto save_invstd = makeContigTensor(2);
+  auto dummy = makeContigTensor(0);
+
+  fusion_backward->addInput(input);
+  fusion_backward->addInput(grad_output);
+  fusion_backward->addInput(weight);
+  fusion_backward->addInput(dummy); // dummy for run_mean
+  fusion_backward->addInput(dummy); // dummy for run_var
+  fusion_backward->addInput(save_mean);
+  fusion_backward->addInput(save_invstd);
+
+  auto result_backward = instance_norm_backward(
+      input, grad_output, weight, nullptr, nullptr, save_mean, save_invstd, kUseInputStats, eps, {true, true, true}, channels_last);
+
+  fusion_backward->addOutput(result_backward.grad_input);
+          fusion_backward->addOutput(result_backward.grad_weight);
+          fusion_backward->addOutput(result_backward.grad_bias);
+
+  FusionExecutorCache executor_cache_backward(std::move(fusion_backward));
+  std::vector<torch::jit::IValue> aten_inputs_backward = {at_input_nvfuser, at_grad_nvfuser, at_weight_nvfuser, at::empty({}), at::empty({}), outputs_forward[1], outputs_forward[2]};
+  auto outputs_backward = executor_cache_backward.runFusionWithInputs(aten_inputs_backward);
+  outputs_backward[0] = outputs_backward[0].permute({0, 4, 1, 2, 3});
+  testValidate(
+      executor_cache_backward.fusion(),
+      outputs_backward,
+      aten_inputs_backward,
+      {at_input.grad(),
+       at_weight.grad(),
+       at_bias.grad()},
+      __LINE__,
+      __FILE__,
+      "");
+}
+
 TEST_F(NVFuserTest, FusionPersistentSoftmaxLocalSmem_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -9130,6 +9130,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerInstanceNormalization_CUDA) {
   FusionExecutorCache executor_cache(std::move(fusion));
 
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs_full = {at_run_mean, at_run_var, cg_outputs[0]};
 
   auto aten_outputs = at::instance_norm(
       at_input,
@@ -9146,9 +9147,9 @@ TEST_F(NVFuserTest, FusionMagicSchedulerInstanceNormalization_CUDA) {
       executor_cache.fusion(),
       cg_outputs,
       aten_inputs,
-      {at_run_mean,
-       at_run_var,
-       aten_outputs},
+      // TODO: can run_mean/run_var be checked here?
+      // fusion_outputs.size() == aten_outputs.size() && aten_outputs.size() == fusion->outputs().size() - output_alias_indices.size()
+      {aten_outputs},
       __LINE__,
       __FILE__,
       "");

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -702,10 +702,12 @@ ForwardNormResult instance_norm(
     if (running_mean != nullptr && running_var != nullptr) {
       auto _running_mean = running_mean;
       auto _running_var = running_var;
-      if (_running_mean->getDataType().value() != DataType::Float) {
+      if (_running_mean->getDataType().value() == DataType::Half ||
+          _running_mean->getDataType().value() == DataType::BFloat16) {
         _running_mean = castOp(DataType::Float, _running_mean);
       }
-      if (_running_var->getDataType().value() != DataType::Float) {
+      if (_running_var->getDataType().value() == DataType::Half ||
+          _running_var->getDataType().value() == DataType::BFloat16) {
         _running_var = castOp(DataType::Float, running_var);
       }
       auto rev_momentum =
@@ -718,7 +720,8 @@ ForwardNormResult instance_norm(
       // https://godbolt.org/z/6Prd77xYs
       auto new_mean_sum = sum(new_mean_hat, {static_cast<int>(kBatchDim)});
       auto new_mean_channels_only = mul(new_mean_sum, reciprocal(B));
-      if (running_mean->getDataType().value() != DataType::Float) {
+      if (running_mean->getDataType().value() == DataType::Half ||
+          running_mean->getDataType().value() == DataType::BFloat16) {
         new_mean_channels_only = castOp(running_mean->getDataType().value(), new_mean_channels_only);
       }
       fusion->addOutput(new_mean_channels_only);
@@ -735,7 +738,8 @@ ForwardNormResult instance_norm(
       // https://godbolt.org/z/6Prd77xYs
       auto new_var_sum = sum(new_var_hat, {static_cast<int>(kBatchDim)});
       auto new_var_channels_only = mul(new_var_sum, reciprocal(B));
-      if (running_var->getDataType().value() != DataType::Float) {
+      if (running_var->getDataType().value() == DataType::Half ||
+          running_var->getDataType().value() == DataType::BFloat16) {
         new_var_channels_only = castOp(running_var->getDataType().value(), new_var_channels_only);
       }
       fusion->addOutput(new_var_channels_only);

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -722,7 +722,8 @@ ForwardNormResult instance_norm(
       auto new_mean_channels_only = mul(new_mean_sum, reciprocal(B));
       if (running_mean->getDataType().value() == DataType::Half ||
           running_mean->getDataType().value() == DataType::BFloat16) {
-        new_mean_channels_only = castOp(running_mean->getDataType().value(), new_mean_channels_only);
+        new_mean_channels_only =
+            castOp(running_mean->getDataType().value(), new_mean_channels_only);
       }
       // fusion->addOutput(new_mean_channels_only);
       fusion->aliasOutputToInput(new_mean_channels_only, running_mean);
@@ -740,7 +741,8 @@ ForwardNormResult instance_norm(
       auto new_var_channels_only = mul(new_var_sum, reciprocal(B));
       if (running_var->getDataType().value() == DataType::Half ||
           running_var->getDataType().value() == DataType::BFloat16) {
-        new_var_channels_only = castOp(running_var->getDataType().value(), new_var_channels_only);
+        new_var_channels_only =
+            castOp(running_var->getDataType().value(), new_var_channels_only);
       }
       // fusion->addOutput(new_var_channels_only);
       fusion->aliasOutputToInput(new_var_channels_only, running_var);
@@ -818,7 +820,8 @@ BackwardNormResult instance_norm_backward(
 
   std::vector<int> reduction_axes;
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
-  // weight has its own broadcast mask as it is broadcast for the batch unlike mean/var
+  // weight has its own broadcast mask as it is broadcast for the batch unlike
+  // mean/var
   std::vector<bool> weight_broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
   for (const auto axis : c10::irange(kNumberOfDims)) {
@@ -828,12 +831,12 @@ BackwardNormResult instance_norm_backward(
         reduction_axes.push_back(axis);
         broadcast_mask[axis] = true;
         if (num_features == nullptr) {
-          num_features =
-            castOp(DataType::Double, input->domain()->domain()[axis]->extent());
+          num_features = castOp(
+              DataType::Double, input->domain()->domain()[axis]->extent());
         } else {
           num_features =
-            mul(num_features, input->domain()->domain()[axis]->extent());
-	}
+              mul(num_features, input->domain()->domain()[axis]->extent());
+        }
       }
     }
   }
@@ -867,8 +870,9 @@ BackwardNormResult instance_norm_backward(
         mul(broadcast(invstd, broadcast_mask),
             IrBuilder::create<Double>(input->container(), 1));
   } else {
-    grad_scale = mul(
-        broadcast(invstd, broadcast_mask), broadcast(weight, weight_broadcast_mask));
+    grad_scale =
+        mul(broadcast(invstd, broadcast_mask),
+            broadcast(weight, weight_broadcast_mask));
   }
 
   TensorView* grad_input = nullptr;
@@ -883,7 +887,8 @@ BackwardNormResult instance_norm_backward(
   TensorView* grad_weight_reduced = nullptr;
   if (output_mask[1]) {
     grad_weight = mul(dot_p, invstd);
-    // TODO: grad weight needs to be reduced across batch-dim but is this the most efficient place or can reduction happen earlier?
+    // TODO: grad weight needs to be reduced across batch-dim but is this the
+    // most efficient place or can reduction happen earlier?
     grad_weight_reduced = sum(grad_weight, {0});
   }
 

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -724,7 +724,7 @@ ForwardNormResult instance_norm(
           running_mean->getDataType().value() == DataType::BFloat16) {
         new_mean_channels_only = castOp(running_mean->getDataType().value(), new_mean_channels_only);
       }
-      fusion->addOutput(new_mean_channels_only);
+      // fusion->addOutput(new_mean_channels_only);
       fusion->aliasOutputToInput(new_mean_channels_only, running_mean);
 
       auto num_feature_decrement = sub(N, x->container()->oneVal());
@@ -742,7 +742,7 @@ ForwardNormResult instance_norm(
           running_var->getDataType().value() == DataType::BFloat16) {
         new_var_channels_only = castOp(running_var->getDataType().value(), new_var_channels_only);
       }
-      fusion->addOutput(new_var_channels_only);
+      // fusion->addOutput(new_var_channels_only);
       fusion->aliasOutputToInput(new_var_channels_only, running_var);
     }
 

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -642,7 +642,8 @@ ForwardNormResult instance_norm(
     TensorView* running_var,
     const bool kUseInputStats,
     Val* momentum,
-    Val* eps) {
+    Val* eps,
+    bool channels_last) {
   auto fusion = FusionGuard::getCurFusion();
 
   TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
@@ -666,9 +667,9 @@ ForwardNormResult instance_norm(
   // N = reduction = H * W * D
   // weight = bias = C tensor
   const size_t kBatchDim = 0;
-  const size_t kChannelsDim = 1;
   const size_t kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
+  const size_t kChannelsDim = channels_last ? kNumberOfDims - 1 : 1;
 
   std::vector<int> x_reduction_axes;
   std::vector<bool> x_broadcast_mask(kNumberOfDims, false);

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -876,16 +876,22 @@ BackwardNormResult instance_norm_backward(
   }
 
   TensorView* grad_weight = nullptr;
+  TensorView* grad_weight_reduced = nullptr;
   if (output_mask[1]) {
     grad_weight = mul(dot_p, invstd);
+    // TODO: grad weight needs to be reduced across batch-dim but is this the most efficient place or can reduction happen earlier?
+    grad_weight_reduced = sum(grad_weight, {0});
   }
 
   TensorView* grad_bias = nullptr;
+  TensorView* grad_bias_reduced = nullptr;
   if (output_mask[2]) {
     grad_bias = grad_output_sum;
+    // TODO: same as above for grad weight
+    grad_bias_reduced = sum(grad_bias, {0});
   }
 
-  return {grad_input, grad_weight, grad_bias};
+  return {grad_input, grad_weight_reduced, grad_bias_reduced};
 }
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -145,7 +145,8 @@ TORCH_CUDA_CU_API ForwardNormResult instance_norm(
     TensorView* running_var,
     const bool kUseInputStats,
     Val* momentum,
-    Val* eps);
+    Val* eps,
+    bool channels_last = false);
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -143,9 +143,22 @@ TORCH_CUDA_CU_API ForwardNormResult instance_norm(
     TensorView* bias,
     TensorView* running_mean,
     TensorView* running_var,
-    const bool kUseInputStats,
+    const bool kUseInputStats, // kTraining?
     Val* momentum,
     Val* eps,
+    bool channels_last = false);
+
+TORCH_CUDA_CU_API BackwardNormResult instance_norm_backward(
+    TensorView* x,
+    TensorView* dy,
+    TensorView* weight,
+    TensorView* running_mean,
+    TensorView* running_var,
+    TensorView* save_mean,
+    TensorView* save_invstd,
+    const bool kTraining,
+    Val* eps,
+    const std::vector<bool>& output_mask,
     bool channels_last = false);
 
 } // namespace cuda


### PR DESCRIPTION
Channels-last benchmarking with shapes extracted from a UNet-3D workload.
Includes channels-last support also in https://github.com/pytorch/pytorch/pull/69754. Currently trying to reconcile the difference between "channels last 3d" conventions in NVFuser vs. the aten baseline: NVFuser seems to want a tensor explicitly in NHWDC, while aten seems to want a tensor in NHWC, with `c10::MemoryFormat::ChannelsLast3d`.