### PR TITLE
Add support for fp16<->int, bfloat16<->int conversions

### DIFF
--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -367,6 +367,15 @@ Val* castOp(DataType dtype, Val* v1) {
     return set(v1);
   }
 
+  // There are no direct cast for some combinations of dtypes
+  // for example integers to fp16, bfloat16 and back
+  // so we need to try doing a conversion to float first.
+  if (dtype != DataType::Float &&
+      cast_func_str(std::make_pair(v1->getDataType().value(), dtype)) ==
+          c10::nullopt) {
+    return castOp(dtype, castOp(DataType::Float, v1));
+  }
+
   if (cast_func_str(std::make_pair(v1->getDataType().value(), dtype)) ==
       c10::nullopt) {
     TORCH_CHECK(

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu.cpp
@@ -4524,6 +4524,35 @@ TEST_F(NVFuserTest, FusionCastOps_CUDA) {
       "\n");
 }
 
+TEST_F(NVFuserTest, FusionCastOpsInt_CUDA) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* tv0 = makeSymbolicTensor(2, DataType::Half);
+  TensorView* intrm1 = castOp(DataType::Int, tv0);
+  TensorView* out = castOp(DataType::Half, intrm1);
+
+  fusion->addInput(tv0);
+  fusion->addOutput(out);
+
+  auto options_half = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
+  auto options_int = at::TensorOptions().dtype(at::kInt).device(at::kCUDA, 0);
+
+  at::Tensor input1 = at::randn({1, 4}, options_half);
+  at::Tensor ref_output = input1.to(options_int).to(options_half);
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  auto outputs = executor_cache.runFusionWithInputs({input1});
+
+  testValidate(
+      executor_cache.fusion(),
+      outputs,
+      {input1},
+      {ref_output},
+      __LINE__,
+      __FILE__);
+}
+
 // Start off simple, block on the outer dim
 // block stride + thread all reduce + unrolling on inner dim
 TEST_F(NVFuserTest, FusionReduction1_CUDA) {


### PR DESCRIPTION
This PR fixes an error in torchbench:Super_SloMo benchmark and a few others.
```
RuntimeError: Illegal Cast value from  DataType: int64_t to DataType: __half
```