### PR TITLE
Improve divisible split detection

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -683,6 +683,7 @@ libtorch_cuda_core_sources = [
     "torch/csrc/jit/codegen/cuda/lower_alias_memory.cpp",
     "torch/csrc/jit/codegen/cuda/lower_allocation.cpp",
     "torch/csrc/jit/codegen/cuda/lower_double_buffer.cpp",
+    "torch/csrc/jit/codegen/cuda/lower_divisble_split.cpp",
     "torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp",
     "torch/csrc/jit/codegen/cuda/lower_fused_reduction.cpp",
     "torch/csrc/jit/codegen/cuda/lower_fusion_simplifier.cpp",

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.cpp
@@ -55,7 +55,11 @@ void mapMaybeSwizzleOp(
   }
 }
 
-bool IterDomainGraph::exprsMap(Expr* first, Expr* second, bool forward) {
+bool IterDomainGraph::exprsMap(
+    Expr* first,
+    Expr* second,
+    bool forward,
+    const DisjointSets<IterDomain*>& id_map) {
   if (first == nullptr || second == nullptr) {
     return false;
   }
@@ -101,8 +105,7 @@ bool IterDomainGraph::exprsMap(Expr* first, Expr* second, bool forward) {
             zipped_ids.begin(),
             zipped_ids.end(),
             [&](std::pair<IterDomain*, IterDomain*> id_pair) {
-              return !exact_nodes_.strictAreMapped(
-                  id_pair.first, id_pair.second);
+              return !id_map.strictAreMapped(id_pair.first, id_pair.second);
             })) {
       return false;
     }
@@ -151,7 +154,7 @@ void IterDomainGraph::mapThroughExpr(Expr* first, Expr* second, bool forward) {
     return;
   }
 
-  if (!exprsMap(first, second, forward)) {
+  if (!exprsMap(first, second, forward, exact_nodes_)) {
     return;
   }
 

--- a/torch/csrc/jit/codegen/cuda/compute_at_map.h
+++ b/torch/csrc/jit/codegen/cuda/compute_at_map.h
@@ -88,14 +88,20 @@ class TORCH_CUDA_CU_API IterDomainGraph {
     return view_rfactor_ids_;
   }
 
+  // Returns if first and second are expressions through which the provided
+  // id_map have matching inputs (if forward), or outputs (if not forward).
+  // Returning true means the expressions are "the same", in terms they modify
+  // matching original extents, by the same amount.
+  static bool exprsMap(
+      Expr* first,
+      Expr* second,
+      bool forward,
+      const DisjointSets<IterDomain*>& id_map);
+
  private:
   void build(Fusion* fusion);
 
   void initializeId(IterDomain* id, bool is_view_rfactor_id, bool is_leaf_id);
-
-  // Returns if first and second are expressions with inputs match through exact
-  // map (if forward), or outputs match (if not forward).
-  bool exprsMap(Expr* first, Expr* second, bool forward);
 
   // Checks if exprsMap then if forward will map outputs else inputs in exact
   // and permissive map.

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/codegen/cuda/ir_utils.h>
 #include <torch/csrc/jit/codegen/cuda/lower_alias_memory.h>
 #include <torch/csrc/jit/codegen/cuda/lower_allocation.h>
+#include <torch/csrc/jit/codegen/cuda/lower_divisible_split.h>
 #include <torch/csrc/jit/codegen/cuda/lower_double_buffer.h>
 #include <torch/csrc/jit/codegen/cuda/lower_expr_sort.h>
 #include <torch/csrc/jit/codegen/cuda/lower_fusion_simplifier.h>
@@ -255,6 +256,9 @@ void GpuLower::lower(Fusion* fusion, DataType index_type) {
   }
 
   compute_at_map_->validateAndPropagatePType();
+
+  // Uses compute_at_map, find all splits that are enforced to be divisible
+  divisible_splits_ = getAllDivisibleSplits(fusion_, compute_at_map_.get());
 
   // Used in parallel dimension map
   concretized_broadcast_domains_.build(fusion_);

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -132,6 +132,10 @@ class TORCH_CUDA_CU_API GpuLower : public NonCopyable {
     return non_divisible_split_info_;
   }
 
+  const auto& divisbleSplitSet() const {
+    return divisible_splits_;
+  }
+
   DoubleBufferInfo& doubleBufferInfo() {
     return double_buffer_info_;
   }
@@ -214,6 +218,7 @@ class TORCH_CUDA_CU_API GpuLower : public NonCopyable {
   FusedReductionInfo fused_reduction_info_;
   SyncMap sync_map_;
   kir::KernelPerformanceProfile profile_;
+  std::unordered_set<Split*> divisible_splits_;
 
   // Track which tensor views are inputs or outputs of a vectorized operation
   // and their maximum vectorized access size

--- a/torch/csrc/jit/codegen/cuda/lower_divisble_split.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_divisble_split.cpp
@@ -1,0 +1,124 @@
+
+#include <torch/csrc/jit/codegen/cuda/lower_divisible_split.h>
+
+#include <torch/csrc/jit/codegen/cuda/disjoint_set.h>
+#include <torch/csrc/jit/codegen/cuda/ir_utils.h>
+
+#include <unordered_set>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+std::unordered_set<Split*> getAllDivisibleSplits(Fusion* fusion) {
+  ComputeAtMap ca_map(fusion);
+  return getAllDivisibleSplits(fusion, &ca_map);
+}
+
+std::unordered_set<Split*> getAllDivisibleSplits(
+    Fusion* fusion,
+    const ComputeAtMap* ca_map) {
+  std::unordered_set<Split*> all_divisible_splits;
+
+  auto all_tvs = ir_utils::allTvs(fusion);
+  // Find all tensor views with a view like rfactor
+  for (auto tv : all_tvs) {
+    auto rfactor_dom = tv->getMaybeRFactorDomain();
+    // Not view if there's no rfactor axis
+    if (!tv->hasRFactor() ||
+        std::any_of(
+            rfactor_dom.begin(),
+            rfactor_dom.end(),
+            // Also not a view transform if there's a reduction dimension.
+            [](IterDomain* id) { return id->isReduction(); })) {
+      continue;
+    }
+
+    // Take the view transformations and add all the splits. Those splits are
+    // the only divisible splits.
+    auto view_exprs =
+        StmtSort::getExprs(fusion, {rfactor_dom.begin(), rfactor_dom.end()});
+    auto split_exprs = ir_utils::filterByType<Split>(view_exprs);
+    all_divisible_splits.insert(split_exprs.begin(), split_exprs.end());
+  }
+
+  for (auto tv : all_tvs) {
+    auto vec_id_it = std::find_if(
+        tv->domain()->domain().begin(),
+        tv->domain()->domain().end(),
+        // Also not a view transform if there's a reduction dimension.
+        [](IterDomain* id) {
+          return isParallelTypeVectorize(id->getParallelType());
+        });
+
+    if (vec_id_it == tv->domain()->domain().end()) {
+      continue;
+    }
+
+    // We could have a cass technically like:
+    // [8, 2] where we do:
+    // split(0, 2)
+    // merge(1)
+    // so it ends up as [4, 4]
+    // split(0, 2) must be a divisible, but for now we're not going to capture
+    // cases like this. Just look for direct split's producing a vectorize
+    // dimension.
+    auto vec_id = *vec_id_it;
+    if (vec_id->definition() != nullptr && vec_id->definition()->isA<Split>()) {
+      all_divisible_splits.emplace(vec_id->definition()->as<Split>());
+    }
+  }
+
+  // If there's no view like splits, there's nothing to find
+  if (all_divisible_splits.empty()) {
+    return all_divisible_splits;
+  }
+
+  // Track the concrete id in the exact map of the outer output of the split
+  // expressions. This is how we'll check if there are matching splits. This
+  // also gets rid of any splits that already match (for processing).
+  std::unordered_map<IterDomain*, Expr*> outer_concrete_id_to_expr;
+
+  for (auto split : all_divisible_splits) {
+    outer_concrete_id_to_expr[ca_map->getConcreteMappedID(
+        split->outer(), IdMappingMode::EXACT)] = split;
+  }
+
+  std::unordered_set<Expr*> visited(
+      all_divisible_splits.begin(), all_divisible_splits.end());
+
+  // Find splits that match what we already have:
+  for (auto entry : outer_concrete_id_to_expr) {
+    auto concrete_id = entry.first;
+    auto original_view_split = entry.second;
+
+    auto exact_mapped_ids =
+        ca_map->idGraph().exactNodes().getDisjointSetOf(concrete_id).vector();
+    for (auto other_id : exact_mapped_ids) {
+      if (other_id->definition() == nullptr) {
+        continue;
+      }
+
+      if (!visited.emplace(other_id->definition()).second) {
+        // Already visited
+        continue;
+      }
+
+      if (IterDomainGraph::exprsMap(
+              original_view_split,
+              other_id->definition(),
+              false,
+              ca_map->idGraph().exactNodes())) {
+        all_divisible_splits.emplace(other_id->definition()->as<Split>());
+      }
+    }
+  }
+
+  return all_divisible_splits;
+}
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/lower_divisible_split.h
+++ b/torch/csrc/jit/codegen/cuda/lower_divisible_split.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <c10/macros/Export.h>
+
+#include <torch/csrc/jit/codegen/cuda/compute_at_map.h>
+#include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+namespace cuda {
+
+// Looks through all transformations assocaited with view, or enforced divisible
+// vectorization splits and gathers all splits that provably don't have a
+// remainder, therefore the extents of the associated IterDomains do not require
+// a ceilDiv expressions.
+TORCH_CUDA_CU_API std::unordered_set<Split*> getAllDivisibleSplits(
+    Fusion* fusion);
+
+// Same as above but will use provided ComputeAtMap instead of building its own.
+std::unordered_set<Split*> getAllDivisibleSplits(
+    Fusion* fusion,
+    const ComputeAtMap* ca_map);
+
+} // namespace cuda
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/non_divisible_split.cpp
+++ b/torch/csrc/jit/codegen/cuda/non_divisible_split.cpp
@@ -53,7 +53,16 @@ void NonDivisibleSplitInfo::handle(Split* split) {
         splits_to_validate_.insert(split);
       } else {
         // Not proven to be a divisible split
-        splits_to_predicate_[current_tv_].push_back(split);
+        auto gpu_lower = GpuLower::current();
+        TORCH_INTERNAL_ASSERT(gpu_lower != nullptr);
+
+        // If we know this split must be divisible, it's either validated as
+        // above, exact matches to a case matching the above, or exact matches
+        // to a transformation from view which must be divisible.
+        if (gpu_lower->divisbleSplitSet().find(split) ==
+            gpu_lower->divisbleSplitSet().end()) {
+          splits_to_predicate_[current_tv_].push_back(split);
+        }
       }
 
       is_protected = true;

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu_view.cpp
@@ -23,6 +23,7 @@
 #include <torch/csrc/jit/codegen/cuda/kernel_ir.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_ir_dispatch.h>
 #include <torch/csrc/jit/codegen/cuda/lower2device.h>
+#include <torch/csrc/jit/codegen/cuda/lower_divisible_split.h>
 #include <torch/csrc/jit/codegen/cuda/mutator.h>
 #include <torch/csrc/jit/codegen/cuda/ops/all_ops.h>
 #include <torch/csrc/jit/codegen/cuda/root_domain_map.h>
@@ -1780,6 +1781,67 @@ TEST_F(NVFuserTest, FusionViewMapping_CUDA) {
   auto cg_outputs = fe.runFusion({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, {t6}, __LINE__, __FILE__);
+}
+
+TEST_F(NVFuserTest, FusionLowerDivisibleSplits_CUDA) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  int w = 15, x = 31, y = 49, z = 65;
+
+  auto tv0 = makeContigTensor(4);
+  fusion.addInput(tv0);
+  auto tv1 = sin(tv0);
+  auto tv2 = view(tv1, {w, x, y, z}, {z, y, x, w});
+
+  fusion.addOutput(tv2);
+
+  tv2->merge(0)->merge(0)->merge(0)->split(0, 4)->split(0, 8, false);
+
+  TransformPropagator propagator(tv2);
+  MaxRootDomainInfoSpanningTree spanning_tree(tv2);
+  spanning_tree.traverse(&propagator);
+  scheduler_utils::parallelizeAllLike(tv2);
+
+  // Inline the schedule
+  InlinePropagator inline_propagator(tv2, -1, ComputeAtMode::MostInlined);
+  spanning_tree.traverse(&inline_propagator);
+
+  auto divisible_splits = getAllDivisibleSplits(&fusion);
+
+  // Operations on all tensors are basically:
+  // [10] merge(0)          [9]->outer->definition
+  // [9] merge(0)           [8]->outer->definition
+  // [8] merge(0)           [7]->in->definition
+  // [7] split(0, z, false) [6]->in->definition
+  // [6] split(1, y, false) [5]->in->definition
+  // [5] split(2, x, false) [3]->inner->definition
+  // RFactor of tv2
+  // [4] merge(0)           [3]->outer->definition
+  // [3] merge(0)           [2]->outer->definition
+  // [2] merge(0)           [1]->in->definition
+  // [1] split(0, 4)        [0]->in->definition
+  // [0] split(0, 8, false) tv->axis(0)->definition
+
+  for (auto tv : std::vector<TensorView*>({tv2, tv1, tv0})) {
+    auto transform_0 = tv->axis(0)->definition()->as<Split>();
+    auto transform_1 = transform_0->in()->definition()->as<Split>();
+    auto transform_2 = transform_1->in()->definition()->as<Merge>();
+    auto transform_3 = transform_2->outer()->definition()->as<Merge>();
+
+    auto transform_5 = transform_3->inner()->definition()->as<Split>();
+    auto transform_6 = transform_5->in()->definition()->as<Split>();
+    auto transform_7 = transform_6->in()->definition();
+
+    TORCH_CHECK(
+        divisible_splits.find(transform_5) != divisible_splits.end(),
+        "Expecting: ",
+        transform_5->toString(),
+        "\nFrom TV: ",
+        tv,
+        "\nTo be a divisible split.");
+  }
 }
 
 } // namespace jit


### PR DESCRIPTION
Adds propagation of divisible split information, as well as add divisible splits from view based transformations.

Tangibly NVFuserTest.FusionNonDivisibleSplitVectorize2_CUDA before:
```.cpp
__global__ void CUDAGeneratedKernel(Tensor<float, 1> T0, Tensor<float, 0> T3) {
  alignas(16) extern __shared__ char array[];
  void* shared_mem = array;
  NVFUSER_DEFINE_MAGIC_ZERO
  Array<float, (8 * 4), 4> T1;
  #pragma unroll
  for(nvfuser_index_t i21 = 0; i21 < 8; ++i21) {
    if (((((i21 + nvfuser_zero) * (ceilDiv(T0.size[0], 8))) + ((((nvfuser_index_t)threadIdx.x) * 4) + 3)) < T0.size[0])) {
      loadGlobalToLocal<float, 4, false>(&T1[(i21 * 4)],  &T0[(((i21 + nvfuser_zero) * (ceilDiv(T0.size[0], 8))) + (((nvfuser_index_t)threadIdx.x) * 4))]);
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO
  // Alias Allocation - register
  auto& T2 = T1;
  #pragma unroll
  for(nvfuser_index_t i23 = 0; i23 < 8; ++i23) {
    #pragma unroll
    for(nvfuser_index_t i24 = 0; i24 < 4; ++i24) {
      if ((((i23 * (ceilDiv(T0.size[0], 8))) + ((((nvfuser_index_t)threadIdx.x) * 4) + (i24 + nvfuser_zero))) < T0.size[0])) {
        T2[((i23 * 4) + i24)]
          = T1[((i23 * 4) + i24)]
          + (float) 1.00000000000000000e+00;
      }
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO
  T3[0] = 0.00000000000000000e+00;
  #pragma unroll
  for(nvfuser_index_t i25 = 0; i25 < 8; ++i25) {
    #pragma unroll
    for(nvfuser_index_t i26 = 0; i26 < 4; ++i26) {
      blockReduce<true, false, false>(
        T3[0],
        T2[((i25 * 4) + i26)],
        [](float &a, float b) { a = a + b; },
        threadIdx,
        blockDim,
        static_cast<float*>(shared_mem),
        (((i25 * (ceilDiv(T0.size[0], 8))) + ((((nvfuser_index_t)threadIdx.x) * 4) + (i26 + nvfuser_zero))) < T0.size[0]),
        float(0.00000000000000000e+00));
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO
}
```
After:
```.cpp
__global__ void CUDAGeneratedKernel(Tensor<float, 1> T0, Tensor<float, 0> T3) {
  alignas(16) extern __shared__ char array[];
  void* shared_mem = array;
  NVFUSER_DEFINE_MAGIC_ZERO
  Array<float, (8 * 4), 4> T1;
  #pragma unroll
  for(nvfuser_index_t i21 = 0; i21 < 8; ++i21) {
    T1.set(0);
  }
  NVFUSER_UPDATE_MAGIC_ZERO
  #pragma unroll
  for(nvfuser_index_t i21 = 0; i21 < 8; ++i21) {
    if (((((i21 + nvfuser_zero) * (ceilDiv(T0.size[0], 8))) + ((((nvfuser_index_t)threadIdx.x) * 4) + 3)) < T0.size[0])) {
      loadGlobalToLocal<float, 4, false>(&T1[(i21 * 4)],  &T0[(((i21 + nvfuser_zero) * (ceilDiv(T0.size[0], 8))) + (((nvfuser_index_t)threadIdx.x) * 4))]);
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO
  // Alias Allocation - register
  auto& T2 = T1;
  #pragma unroll
  for(nvfuser_index_t i23 = 0; i23 < 8; ++i23) {
    #pragma unroll
    for(nvfuser_index_t i24 = 0; i24 < 4; ++i24) {
      T2[((i23 * 4) + i24)]
        = T1[((i23 * 4) + i24)]
        + (float) 1.00000000000000000e+00;
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO
  T3[0] = 0.00000000000000000e+00;
  #pragma unroll
  for(nvfuser_index_t i25 = 0; i25 < 8; ++i25) {
    #pragma unroll
    for(nvfuser_index_t i26 = 0; i26 < 4; ++i26) {
      blockReduce<true, false, false>(
        T3[0],
        T2[((i25 * 4) + i26)],
        [](float &a, float b) { a = a + b; },
        threadIdx,
        blockDim,
        static_cast<float*>(shared_mem),
        (((i25 * (ceilDiv(T0.size[0], 8))) + ((((nvfuser_index_t)threadIdx.x) * 4) + (i26 + nvfuser_zero))) < T0.size[0]),
        float(0.00000000000000000e+00));
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO
}
```

Specifically this predicate is successfully removed:
```
      if ((((i23 * (ceilDiv(T0.size[0], 8))) + ((((nvfuser_index_t)threadIdx.x) * 4) + (i24 + nvfuser_zero))) < T0.size[0])) {
        T2[((i23 * 4) + i24)]
          = T1[((i23 * 4) + i24)]
          + (float) 1.00000000000000000e+00;
      }
```