### PR TITLE
Fix expand printing

### DIFF
--- a/third_party/nvfuser/csrc/ir_nodes.cpp
+++ b/third_party/nvfuser/csrc/ir_nodes.cpp
@@ -1434,10 +1434,12 @@ std::string ExpandOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << out()->toString() << " = expand( " << in()
                           << ", {";
+  bool comma = false;
   for (auto expanded_extent : expanded_extents()) {
-    if (ss.tellp()) {
+    if (comma) {
       ss << ", ";
     }
+    comma = true;
     ss << expanded_extent;
   }
   ss << "} )\n";


### PR DESCRIPTION
This fixes a small printing bug where expand operations are currently printed like so:
```
T2_l[ bS6{i3}, bS7{i4}, iS8{i1} ] = expand( T0_g[ bS0{1}, bS1{1}, iS2{i1} ], {, i3, i4, i1} )
```
Note the leading comma in the expanded size argument. This was due to a logic error in the check for whether to skip the comma that this PR fixes.