### PR TITLE
[Scatter 1] Add override_index parameter for lowerDstIndex

### DIFF
--- a/third_party/nvfuser/csrc/index_compute.cpp
+++ b/third_party/nvfuser/csrc/index_compute.cpp
@@ -1876,14 +1876,20 @@ std::vector<Val*> Index::getStrides(const TensorView* tv) {
 std::vector<Val*> Index::getRootIndices(
     const TensorView* tv,
     const std::vector<kir::ForLoop*>& loops,
-    const IndexFromIdGraph& index_from_id_graph) {
+    const IndexFromIdGraph& index_from_id_graph,
+    bool from_concrete) {
   auto root_dom = tv->getMaybeRFactorDomain();
-  auto indexing = index_from_id_graph.index;
+  auto indexing = from_concrete ? index_from_id_graph.concrete_index
+                                : index_from_id_graph.index;
 
   std::vector<Val*> root_inds(
       root_dom.size(), GpuLower::current()->kernel()->zeroVal());
   for (const auto i : c10::irange(root_dom.size())) {
     // See a comment in indexing to root domains in getGlobalProducerIndex.
+    if (from_concrete) {
+      root_dom[i] = GpuLower::current()->caMap()->getConcreteMappedID(
+          root_dom[i], IdMappingMode::EXACT);
+    }
     if (root_dom[i]->isReduction() || root_dom[i]->isBroadcast() ||
         root_dom[i]->isStride()) {
       continue;
@@ -1909,13 +1915,16 @@ std::vector<Val*> Index::getRootIndices(
 
 std::vector<Val*> Index::getGlobalConsumerStridedIndices(
     const TensorView* consumer_tv,
-    const std::vector<kir::ForLoop*>& loops) {
+    const std::vector<kir::ForLoop*>& loops,
+    const std::unordered_map<IterDomain*, Val*>& override_index) {
   FUSER_PERF_SCOPE("GpuLower::Lower::getGlobalConsumerIndex");
 
   auto index_from_id_graph = getTensorIndexFromIdGraph(loops, consumer_tv);
   auto consumer_indexing = index_from_id_graph.index;
   auto strides = getStrides(consumer_tv);
-  auto root_inds = getRootIndices(consumer_tv, loops, index_from_id_graph);
+  auto root_inds = getRootIndices(
+      consumer_tv, loops, index_from_id_graph, override_index.size() > 0);
+  auto root_dom = consumer_tv->getMaybeRFactorDomain();
 
   // Global striding
   auto vectorize_shift =
@@ -1923,6 +1932,10 @@ std::vector<Val*> Index::getGlobalConsumerStridedIndices(
   std::vector<Val*> strided_inds(
       root_inds.size(), GpuLower::current()->kernel()->zeroVal());
   for (const auto i : c10::irange(root_inds.size())) {
+    auto override_it = override_index.find(root_dom[i]);
+    if (override_it != override_index.end()) {
+      root_inds[i] = override_it->second;
+    }
     if (root_inds[i]->isZeroInt()) {
       continue;
     } else {
@@ -1946,9 +1959,12 @@ std::vector<Val*> Index::getGlobalConsumerStridedIndices(
 // Consumer index for either shared or local memory
 std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
     const TensorView* consumer_tv,
-    const std::vector<kir::ForLoop*>& loops) {
+    const std::vector<kir::ForLoop*>& loops,
+    const std::unordered_map<IterDomain*, Val*>& override_index) {
   const auto gpu_lower = GpuLower::current();
-
+  // At now, only ScatterOp set override_index, and the output of ScatterOp
+  // is on global memory, so in this method, the override_index must be empty.
+  TORCH_INTERNAL_ASSERT(override_index.size() == 0);
   auto consumer_indexing_from_idgraph = getTensorIndexFromIdGraph(
       loops,
       consumer_tv,
@@ -2142,7 +2158,8 @@ kir::TensorIndex* Index::getProducerIndex(
 Val* Index::getConsumerStridedIndices(
     TensorView* consumer,
     const std::vector<kir::ForLoop*>& loops,
-    bool cvta_smem_address) {
+    bool cvta_smem_address,
+    const std::unordered_map<IterDomain*, Val*>& override_index) {
   FUSER_PERF_SCOPE("GpuLower::Lower::Index::getConsumerStridedIndices");
   if (consumer->domain()->noReductions().size() == 0) {
     return GpuLower::current()->kernel()->zeroVal();
@@ -2170,7 +2187,8 @@ Val* Index::getConsumerStridedIndices(
 kir::TensorIndex* Index::getConsumerIndex(
     TensorView* consumer,
     const std::vector<kir::ForLoop*>& loops,
-    bool cvta_smem_address) {
+    bool cvta_smem_address,
+    const std::unordered_map<IterDomain*, Val*>& override_index) {
   auto index = getConsumerStridedIndices(consumer, loops, cvta_smem_address);
   index = GpuLower::current()->commonScalarMap().hoistScalar(index, loops);
   return SimplifyingIrBuilder::create<kir::TensorIndex>(consumer, index);

--- a/third_party/nvfuser/csrc/index_compute.h
+++ b/third_party/nvfuser/csrc/index_compute.h
@@ -315,7 +315,8 @@ class Index {
   // Consumer indexing if it's in shared or local memory
   static std::vector<Val*> getNonGlobalConsumerStridedIndices(
       const TensorView* consumer,
-      const std::vector<kir::ForLoop*>& loops);
+      const std::vector<kir::ForLoop*>& loops,
+      const std::unordered_map<IterDomain*, Val*>& override_index = {});
 
   // get the strides of a tensor used for the index lowering
   static std::vector<Val*> getStrides(const TensorView* tv);
@@ -324,7 +325,8 @@ class Index {
   static std::vector<Val*> getRootIndices(
       const TensorView* tv,
       const std::vector<kir::ForLoop*>& loops,
-      const IndexFromIdGraph& index_from_id_graph);
+      const IndexFromIdGraph& index_from_id_graph,
+      bool from_concrete = false);
 
  public:
   // Producer if it's in global memory
@@ -337,7 +339,8 @@ class Index {
   // Consumer indexing if it's in global memory
   static std::vector<Val*> getGlobalConsumerStridedIndices(
       const TensorView* consumer,
-      const std::vector<kir::ForLoop*>& loops);
+      const std::vector<kir::ForLoop*>& loops,
+      const std::unordered_map<IterDomain*, Val*>& override_index = {});
 
   // Indexing functions
   // Consumer = Producer
@@ -359,7 +362,8 @@ class Index {
   static kir::TensorIndex* getConsumerIndex(
       TensorView* consumer,
       const std::vector<kir::ForLoop*>& loops,
-      bool cvta_smem_address = false);
+      bool cvta_smem_address = false,
+      const std::unordered_map<IterDomain*, Val*>& override_index = {});
 
   //! Returns a vector of strided indices mapped onto the (rfactor)
   //! root domain of a producer tensor. The size of the returned
@@ -379,7 +383,8 @@ class Index {
   static Val* getConsumerStridedIndices(
       TensorView* consumer,
       const std::vector<kir::ForLoop*>& loops,
-      bool cvta_smem_address = false);
+      bool cvta_smem_address = false,
+      const std::unordered_map<IterDomain*, Val*>& override_index = {});
 
   //! Returns the logical index linearized from a multi-dimension address into a
   //! linear memory address a consumer tensor. The returned index is intended to

--- a/third_party/nvfuser/csrc/index_compute.h
+++ b/third_party/nvfuser/csrc/index_compute.h
@@ -362,8 +362,8 @@ class Index {
   static kir::TensorIndex* getConsumerIndex(
       TensorView* consumer,
       const std::vector<kir::ForLoop*>& loops,
-      bool cvta_smem_address = false,
-      const std::unordered_map<IterDomain*, Val*>& override_index = {});
+      const std::unordered_map<IterDomain*, Val*>& override_index = {},
+      bool cvta_smem_address = false);
 
   //! Returns a vector of strided indices mapped onto the (rfactor)
   //! root domain of a producer tensor. The size of the returned
@@ -383,8 +383,8 @@ class Index {
   static Val* getConsumerStridedIndices(
       TensorView* consumer,
       const std::vector<kir::ForLoop*>& loops,
-      bool cvta_smem_address = false,
-      const std::unordered_map<IterDomain*, Val*>& override_index = {});
+      const std::unordered_map<IterDomain*, Val*>& override_index = {},
+      bool cvta_smem_address = false);
 
   //! Returns the logical index linearized from a multi-dimension address into a
   //! linear memory address a consumer tensor. The returned index is intended to

--- a/third_party/nvfuser/csrc/lower_index.cpp
+++ b/third_party/nvfuser/csrc/lower_index.cpp
@@ -33,8 +33,8 @@ Val* IndexLowering::lowerSrcIndex(
 
 Val* IndexLowering::lowerDstIndex(
     Val* dst,
-    bool cvta_smem_address,
-    const std::unordered_map<IterDomain*, Val*>& override_index) const {
+    const std::unordered_map<IterDomain*, Val*>& override_index,
+    bool cvta_smem_address) const {
   if (auto tv = dynamic_cast<TensorView*>(dst)) {
     return Index::getConsumerIndex(
         tv, for_loops_, override_index, cvta_smem_address);
@@ -1167,7 +1167,7 @@ void IndexLowering::handleGroupedGridWelford(
 
 void IndexLowering::handle(const LoadStoreOp* ldst) {
   const auto in = lowerSrcIndex(ldst->in(), ldst->out(), {}, true);
-  const auto out = lowerDstIndex(ldst->out(), true);
+  const auto out = lowerDstIndex(ldst->out(), {}, true);
   auto new_ldst = IrBuilder::create<LoadStoreOp>(ldst->opType(), out, in)
                       ->withPredicate(ldst->predicate());
   pushBack(new_ldst);

--- a/third_party/nvfuser/csrc/lower_index.cpp
+++ b/third_party/nvfuser/csrc/lower_index.cpp
@@ -37,7 +37,7 @@ Val* IndexLowering::lowerDstIndex(
     const std::unordered_map<IterDomain*, Val*>& override_index) const {
   if (auto tv = dynamic_cast<TensorView*>(dst)) {
     return Index::getConsumerIndex(
-        tv, for_loops_, cvta_smem_address, override_index);
+        tv, for_loops_, override_index, cvta_smem_address);
   } else {
     return dst;
   }

--- a/third_party/nvfuser/csrc/lower_index.cpp
+++ b/third_party/nvfuser/csrc/lower_index.cpp
@@ -31,9 +31,13 @@ Val* IndexLowering::lowerSrcIndex(
   }
 }
 
-Val* IndexLowering::lowerDstIndex(Val* dst, bool cvta_smem_address) const {
+Val* IndexLowering::lowerDstIndex(
+    Val* dst,
+    bool cvta_smem_address,
+    const std::unordered_map<IterDomain*, Val*>& override_index) const {
   if (auto tv = dynamic_cast<TensorView*>(dst)) {
-    return Index::getConsumerIndex(tv, for_loops_, cvta_smem_address);
+    return Index::getConsumerIndex(
+        tv, for_loops_, cvta_smem_address, override_index);
   } else {
     return dst;
   }

--- a/third_party/nvfuser/csrc/lower_index.h
+++ b/third_party/nvfuser/csrc/lower_index.h
@@ -86,8 +86,8 @@ class TORCH_CUDA_CU_API IndexLowering : private OptOutConstDispatch {
 
   Val* lowerDstIndex(
       Val* dst,
-      bool cvta_smem_address = false,
-      const std::unordered_map<IterDomain*, Val*>& override_index = {}) const;
+      const std::unordered_map<IterDomain*, Val*>& override_index = {},
+      bool cvta_smem_address = false) const;
 
   void handleBlockReduction(const ReductionOp* rop, Val* out, Val* in);
   void handleGridReduction(const ReductionOp* rop, Val* out, Val* in);

--- a/third_party/nvfuser/csrc/lower_index.h
+++ b/third_party/nvfuser/csrc/lower_index.h
@@ -84,7 +84,10 @@ class TORCH_CUDA_CU_API IndexLowering : private OptOutConstDispatch {
       const std::unordered_map<IterDomain*, Val*>& override_index = {},
       bool cvta_smem_address = false) const;
 
-  Val* lowerDstIndex(Val* dst, bool cvta_smem_address = false) const;
+  Val* lowerDstIndex(
+      Val* dst,
+      bool cvta_smem_address = false,
+      const std::unordered_map<IterDomain*, Val*>& override_index = {}) const;
 
   void handleBlockReduction(const ReductionOp* rop, Val* out, Val* in);
   void handleGridReduction(const ReductionOp* rop, Val* out, Val* in);


### PR DESCRIPTION
This is the first PR of the `scatter/scatter_add` operator. In order to support these ops, we need a more flexible method to compute index for consumer.  This PR adds the `override_index`.