### PR TITLE
[Scatter 2] Add ScatterOp IR data structure

### DIFF
--- a/third_party/nvfuser/csrc/arith.cpp
+++ b/third_party/nvfuser/csrc/arith.cpp
@@ -596,6 +596,62 @@ TensorView* torch_gather(TensorView* inp, int dim, TensorView* index) {
   return out_tensor->as<TensorView>();
 }
 
+// torch.scatter torch.scatter_add
+TensorView* scatterOp(
+    ScatterOpType type,
+    TensorView* self,
+    int dim,
+    TensorView* index,
+    TensorView* src) {
+  auto self_dom = TensorDomain::noReductions(self->getMaybeRFactorDomain());
+  auto idx_dom = TensorDomain::noReductions(index->getMaybeRFactorDomain());
+  auto src_dom = TensorDomain::noReductions(src->getMaybeRFactorDomain());
+
+  TORCH_CHECK(self_dom.size() > 0, "scatter can not be applied to 0d tensor.");
+  TORCH_CHECK(
+      self_dom.size() == idx_dom.size() && self_dom.size() == src_dom.size(),
+      "self, index and src tensor should all have the same number of dimensions in scatter like ops.");
+  if (dim < 0) {
+    dim += self_dom.size();
+  }
+  TORCH_CHECK(
+      dim >= 0 && dim < (int)self_dom.size(),
+      "Scatter on invalid axis, received: ",
+      dim,
+      " however tensor view only has ",
+      self_dom.size(),
+      " non-reduction dims.");
+
+  // The shape of output tensor is same as input tensor.
+  std::vector<IterDomain*> out_domain;
+  for (const auto i : c10::irange(self_dom.size())) {
+    out_domain.push_back(
+        IterDomainBuilder(self_dom[i])
+            .iter_type(
+                self_dom[i]->getIterType() == IterType::Iteration
+                    ? IterType::GatherScatter
+                    : self_dom[i]->getIterType())
+            .build());
+  }
+
+  TensorView* out_tensor = IrBuilder::create<TensorView>(
+      IrBuilder::create<TensorDomain>(
+          out_domain, TensorDomain::getContiguousContiguity(out_domain)),
+      self->getDataType().value());
+
+  IrBuilder::create<ScatterOp>(
+      type, out_tensor, self, dim, index, src, out_domain[dim]);
+  return out_tensor->as<TensorView>();
+}
+
+TensorView* scatter(
+    TensorView* self,
+    int dim,
+    TensorView* index,
+    TensorView* src) {
+  return scatterOp(ScatterOpType::Set, self, dim, index, src);
+}
+
 // TENSOR FACTORIES
 TensorView* rand(const std::vector<Val*>& shape, DataType dtype) {
   auto n = shape.size();

--- a/third_party/nvfuser/csrc/arith.cpp
+++ b/third_party/nvfuser/csrc/arith.cpp
@@ -622,7 +622,7 @@ TensorView* scatterOp(
       self_dom.size(),
       " non-reduction dims.");
 
-  // The shape of output tensor is same as input tensor.
+  // The shape of output tensor is same as self tensor.
   std::vector<IterDomain*> out_domain;
   for (const auto i : c10::irange(self_dom.size())) {
     out_domain.push_back(

--- a/third_party/nvfuser/csrc/arith.h
+++ b/third_party/nvfuser/csrc/arith.h
@@ -563,6 +563,18 @@ TORCH_CUDA_CU_API TensorView* torch_gather(
     TensorView* input,
     int dim,
     TensorView* index);
+// torch.scatter
+TORCH_CUDA_CU_API TensorView* scatterOp(
+    ScatterOpType type,
+    TensorView* self,
+    int dim,
+    TensorView* index,
+    TensorView* src);
+TORCH_CUDA_CU_API TensorView* scatter(
+    TensorView* self,
+    int dim,
+    TensorView* index,
+    TensorView* src);
 
 // addcmul
 TORCH_CUDA_CU_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);

--- a/third_party/nvfuser/csrc/codegen.cpp
+++ b/third_party/nvfuser/csrc/codegen.cpp
@@ -1007,6 +1007,17 @@ class CudaKernelGenerator : private OptOutConstDispatch {
     code_ << gen(sop->input(0)) << ";\n";
   }
 
+  void handle(const ScatterOp* sop) final {
+    // generate code like T_output[... T_index[...]] = op(T_src[...]);
+    if (sop->getScatterOpType() == ScatterOpType::Set) {
+      // When value of index_tv are not unique, the behavior of Set is
+      // non-deterministic
+      indent() << gen(sop->output(0)) << " = " << gen(sop->srcTv()) << ";\n";
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "unkown scatterOp");
+    }
+  }
+
   std::string genArchString(MmaOptions::MacroType macro) {
     std::stringstream ss;
     if (isVolta(macro)) {

--- a/third_party/nvfuser/csrc/dispatch.cpp
+++ b/third_party/nvfuser/csrc/dispatch.cpp
@@ -135,6 +135,10 @@ void Expr::dispatch(T handler, Expr* expr) {
     ptr(handler)->handle(expr->as<TorchGatherOp>());
     return;
   }
+  if (expr->isStrictlyA<ScatterOp>()) {
+    ptr(handler)->handle(expr->as<ScatterOp>());
+    return;
+  }
   if (expr->isStrictlyA<RNGOp>()) {
     ptr(handler)->handle(expr->as<RNGOp>());
     return;
@@ -385,6 +389,10 @@ void Expr::constDispatch(T handler, const Expr* expr) {
   }
   if (expr->isStrictlyA<TorchGatherOp>()) {
     ptr(handler)->handle(expr->as<TorchGatherOp>());
+    return;
+  }
+  if (expr->isStrictlyA<ScatterOp>()) {
+    ptr(handler)->handle(expr->as<ScatterOp>());
     return;
   }
   if (expr->isStrictlyA<RNGOp>()) {
@@ -774,6 +782,9 @@ void OptOutConstDispatch::handle(const IndexSelectOp* stmt) {
 void OptOutConstDispatch::handle(const TorchGatherOp* stmt) {
   unhandled(stmt);
 }
+void OptOutConstDispatch::handle(const ScatterOp* stmt) {
+  unhandled(stmt);
+}
 void OptOutConstDispatch::handle(const RNGOp* stmt) {
   unhandled(stmt);
 }
@@ -943,6 +954,9 @@ void OptOutDispatch::handle(IndexSelectOp* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(TorchGatherOp* stmt) {
+  unhandled(stmt);
+}
+void OptOutDispatch::handle(ScatterOp* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(RNGOp* stmt) {

--- a/third_party/nvfuser/csrc/dispatch.h
+++ b/third_party/nvfuser/csrc/dispatch.h
@@ -80,6 +80,7 @@ class TernaryOp;
 class SelectOp;
 class IndexSelectOp;
 class TorchGatherOp;
+class ScatterOp;
 class RNGOp;
 class ReductionOp;
 class GroupedReductionOp;
@@ -160,6 +161,7 @@ class TORCH_CUDA_CU_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const SelectOp* stmt);
   virtual void handle(const IndexSelectOp* stmt);
   virtual void handle(const TorchGatherOp* stmt);
+  virtual void handle(const ScatterOp* stmt);
   virtual void handle(const RNGOp* stmt);
   virtual void handle(const ReductionOp* stmt);
   virtual void handle(const GroupedReductionOp* stmt);
@@ -232,6 +234,7 @@ class TORCH_CUDA_CU_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(SelectOp* stmt);
   virtual void handle(IndexSelectOp* stmt);
   virtual void handle(TorchGatherOp* stmt);
+  virtual void handle(ScatterOp* stmt);
   virtual void handle(RNGOp* stmt);
   virtual void handle(ReductionOp* stmt);
   virtual void handle(GroupedReductionOp* stmt);

--- a/third_party/nvfuser/csrc/ir_internal_nodes.h
+++ b/third_party/nvfuser/csrc/ir_internal_nodes.h
@@ -145,6 +145,53 @@ class TORCH_CUDA_CU_API TorchGatherOp : public Expr {
   }
 };
 
+class TORCH_CUDA_CU_API ScatterOp : public Expr {
+ public:
+  using Expr::Expr;
+  ScatterOp(
+      IrBuilderPasskey,
+      ScatterOpType type,
+      Val* out,
+      Val* self,
+      int dim,
+      Val* index,
+      Val* src,
+      IterDomain* select_out_id);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  virtual const char* getOpString() const override {
+    return "ScatterOp";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+
+  TensorView* selfTv() const {
+    return input(0)->as<TensorView>();
+  }
+
+  TensorView* indexTv() const {
+    return input(1)->as<TensorView>();
+  }
+
+  TensorView* srcTv() const {
+    return input(2)->as<TensorView>();
+  }
+
+  int dim() const {
+    return attribute(1)->as<Attribute<int>>()->value;
+  }
+
+  IterDomain* getOutputSelectAxis() const {
+    return attribute(0)->as<IterDomain>();
+  }
+
+  ScatterOpType getScatterOpType() const {
+    return attribute(2)->as<Attribute<ScatterOpType>>()->value;
+  }
+};
+
 class TORCH_CUDA_CU_API ARangeOp : public Expr {
  public:
   using Expr::Expr;

--- a/third_party/nvfuser/csrc/lower_expr_sort.cpp
+++ b/third_party/nvfuser/csrc/lower_expr_sort.cpp
@@ -1046,8 +1046,7 @@ void ExprSegmentationSorter::initializeForLoopDependencies() {
       }
 
       // Loops after tv_id are dependent on tv_id
-      dependencies.emplace(GpuLower::current()->caMap()->getConcreteMappedID(
-          tv_id, IdMappingMode::LOOP));
+      dependencies.emplace(concrete_id);
     }
   }
 

--- a/third_party/nvfuser/csrc/lower_expr_sort.cpp
+++ b/third_party/nvfuser/csrc/lower_expr_sort.cpp
@@ -1046,7 +1046,8 @@ void ExprSegmentationSorter::initializeForLoopDependencies() {
       }
 
       // Loops after tv_id are dependent on tv_id
-      dependencies.emplace(concrete_id);
+      dependencies.emplace(GpuLower::current()->caMap()->getConcreteMappedID(
+          tv_id, IdMappingMode::LOOP));
     }
   }
 

--- a/third_party/nvfuser/csrc/type.cpp
+++ b/third_party/nvfuser/csrc/type.cpp
@@ -1016,11 +1016,14 @@ std::ostream& operator<<(std::ostream& out, const UnaryOpType uotype) {
 std::ostream& operator<<(std::ostream& out, const BinaryOpType botype) {
   return out << binary_op_type2string(botype);
 }
+
 std::ostream& operator<<(std::ostream& out, const ScatterOpType sotype) {
-  if (sotype == ScatterOpType::Set)
+  if (sotype == ScatterOpType::Set) {
     return out << "scatter";
+  }
   TORCH_INTERNAL_ASSERT(false, "No scatterOp type found for scatterOp.");
 }
+
 std::ostream& operator<<(std::ostream& out, const TernaryOpType totype) {
   return out << ternary_op_type2string(totype);
 }

--- a/third_party/nvfuser/csrc/type.cpp
+++ b/third_party/nvfuser/csrc/type.cpp
@@ -1016,7 +1016,11 @@ std::ostream& operator<<(std::ostream& out, const UnaryOpType uotype) {
 std::ostream& operator<<(std::ostream& out, const BinaryOpType botype) {
   return out << binary_op_type2string(botype);
 }
-
+std::ostream& operator<<(std::ostream& out, const ScatterOpType sotype) {
+  if (sotype == ScatterOpType::Set)
+    return out << "scatter";
+  TORCH_INTERNAL_ASSERT(false, "No scatterOp type found for scatterOp.");
+}
 std::ostream& operator<<(std::ostream& out, const TernaryOpType totype) {
   return out << ternary_op_type2string(totype);
 }

--- a/third_party/nvfuser/csrc/type.h
+++ b/third_party/nvfuser/csrc/type.h
@@ -238,6 +238,8 @@ enum class BinaryOpType {
   Xor
 };
 
+enum class ScatterOpType { Set };
+
 enum class RNGOpType {
   Uniform, // Uniform in [0, 1)
   UniformRange, // Uniform in [low, high]
@@ -369,6 +371,7 @@ TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const DataType);
 TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const UnaryOpType);
 TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const BinaryOpType);
 TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const TernaryOpType);
+TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const ScatterOpType);
 TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const RNGOpType);
 TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const ParallelType);
 TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const MemoryType);


### PR DESCRIPTION
This is the second PR for the scatter/scatter_add operator. This PR add the basic IR data structure for scatter op. This PR does not include how to lower the index and how to do schedule, which will be in subsequent PRs.