### PR TITLE
[Do not merge] Matmul crash

### DIFF
--- a/third_party/nvfuser/test/test_gpu_tensorcore.cpp
+++ b/third_party/nvfuser/test/test_gpu_tensorcore.cpp
@@ -765,12 +765,12 @@ TEST_F(NVFuserTest, FusionAmpereMatmul_CUDA) {
 // Matmul test for Ampere MMA: with pipelined gmem load
 TEST_F(NVFuserTest, FusionAmpereMatmulPipelineGmem_CUDA) {
   // Keep multiples of 8 to keep vectorizable.
-  int M = 504, N = 136, K = 248;
+  int M = 128, N = 13824, K = 32;
   REQUIRE_DEVICE_SMEM_SIZE(70 << 10, 0);
 
   // Gmem pipeline stage
-  for (auto stage : {3, 4}) {
-    for (auto layout : kAllSupportedLayout) {
+  for (auto stage : {4}) {
+    for (auto layout : {MatmulLayout::TT}) {
       Fusion fusion;
       FusionGuard fg(&fusion);
       auto tv0 = makeContigTensor(2, DataType::Half);
@@ -804,6 +804,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulPipelineGmem_CUDA) {
       auto inputs = fp16MatmulAtInput(M, N, K, layout);
 
       FusionExecutor fe;
+      fe.setMeasureKernelTimeFlag(true);
       NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
           8,
           0,
@@ -857,7 +858,8 @@ TEST_F(NVFuserTest, FusionAmpereMatmulRegDoubleBuffer_CUDA) {
 
       at::manual_seed(0);
       auto inputs = fp16MatmulAtInput(M, N, K, layout);
-
+       
+     
       FusionExecutor fe;
       NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
           8,


### PR DESCRIPTION
I'm experiencing some random crashes with this specific matmul problem. I had trouble narrowing it down as it sometimes works okay. Here's what I get:


```
Note: Google Test filter = *FusionAmpereMatmulPipelineGmem_CUDA*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from NVFuserTest
[ RUN      ] NVFuserTest.FusionAmpereMatmulPipelineGmem_CUDA
unknown file: Failure
C++ exception with description "CUDA error: an illegal memory access was encountered
CUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.

Exception raised from c10_cuda_check_implementation at ../c10/cuda/CUDAException.cpp:40 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x6c (0x7f737d300a8c in /home/mmigdal/pytorch/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xfa (0x7f737d2c9bce in /home/mmigdal/pytorch/torch/lib/libc10.so)
frame #2: c10::cuda::c10_cuda_check_implementation(char const*, char const*, int, bool) + 0x3c7 (0x7f737d6351d7 in /home/mmigdal/pytorch/torch/lib/libc10_cuda.so)
frame #3: torch::jit::fuser::cuda::FusionExecutor::runFusion(torch::jit::fuser::cuda::KernelArgumentHolder&, torch::jit::fuser::cuda::LaunchParams const&, torch::jit::fuser::cuda::CompileParams, std::vector<at::Tensor, std::allocator<at::Tensor> > const&) + 0x1db9 (0x7f7399a318c9 in /home/mmigdal/pytorch/torch/lib/libnvfuser_codegen.so)
frame #4: <unknown function> + 0x1fa65e (0x5629cc05265e in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #5: <unknown function> + 0x3dcbc0 (0x5629cc234bc0 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #6: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 0x51 (0x5629cc30d201 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #7: <unknown function> + 0x4a6e40 (0x5629cc2fee40 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #8: <unknown function> + 0x4a72d5 (0x5629cc2ff2d5 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #9: <unknown function> + 0x4a7a31 (0x5629cc2ffa31 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #10: testing::internal::UnitTestImpl::RunAllTests() + 0x10e9 (0x5629cc3011b9 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #11: testing::UnitTest::Run() + 0x98 (0x5629cc3016d8 in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #12: <unknown function> + 0x12580c (0x5629cbf7d80c in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
frame #13: __libc_start_main + 0xf3 (0x7f737ce090b3 in /lib/x86_64-linux-gnu/libc.so.6)
frame #14: _start + 0x2e (0x5629cbfb340e in /home/mmigdal/anaconda3/lib/python3.9/site-packages/torch/bin/nvfuser_tests)
" thrown in the test body.
[  FAILED  ] NVFuserTest.FusionAmpereMatmulPipelineGmem_CUDA (2270 ms)
[----------] 1 test from NVFuserTest (2270 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2270 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] NVFuserTest.FusionAmpereMatmulPipelineGmem_CUDA

 1 FAILED TEST
```
