### PR TITLE
Add support for aten::index operator

### DIFF
--- a/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
+++ b/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
@@ -1347,6 +1347,26 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("dim"),
       py::return_value_policy::reference);
   nvf_ops.def(
+      "index",
+      [](nvfuser::FusionDefinition::Operators& self,
+         nvfuser::Tensor arg,
+         nvfuser::Tensor index) -> nvfuser::Tensor {
+        FUSER_PERF_SCOPE("Operators.index");
+        nvfuser::FusionDefinition* fd = self.fusion_definition;
+        nvfuser::Tensor output = fd->defineTensor(arg.dims);
+        fd->defineRecord(new nvfuser::IndexSelectOpRecord(
+            {
+                fd->recordingState(arg()),
+                fd->recordingState(index()),
+            },
+            {fd->recordingState(output())},
+            0));
+        return output;
+      },
+      py::arg("arg"),
+      py::arg("index"),
+      py::return_value_policy::reference);
+  nvf_ops.def(
       "gather",
       [](nvfuser::FusionDefinition::Operators& self,
          nvfuser::Tensor arg1,

--- a/third_party/nvfuser/csrc/type_inference.cpp
+++ b/third_party/nvfuser/csrc/type_inference.cpp
@@ -459,6 +459,7 @@ class NaiveTypePropagator {
       case aten::transpose_copy:
       case aten::unsqueeze_copy:
       case aten::index_select:
+      case aten::index:
       case aten::gather:
       case aten::view_copy: {
         auto out_type = node->input(0)->type()->cast<TensorType>();


### PR DESCRIPTION
There are many Tensor indexing API in PyTorch. We already support the `index_select` operator, but we doesn't support `index` operator, which is supported by `Inductor + Triton` and widely used in GNN. So we need to add this operator. 

Although we can share most of logic with index_select, there are some difficulties. The `index` signature is `aten::index.Tensor(Tensor self, Tensor?[] indices)` which use `List` data type. But nvfuser doesn't support it. So the TorchScript test will raise an error until we support `List[T]`.   

- [ ] Support List[T] type in nvfuser.