### PR TITLE
[NO NOT MERGE] Disabling reducePredicateRegisterUsage

### DIFF
--- a/third_party/nvfuser/csrc/expr_simplifier.cpp
+++ b/third_party/nvfuser/csrc/expr_simplifier.cpp
@@ -1697,8 +1697,8 @@ Val* simplifyExpr(Val* value, const std::list<VarInfo>& variables) {
     RUN_PASS(distributeDivisibleDivMod);
     PASS_BARRIER;
     RUN_PASS(distributeMul);
-    PASS_BARRIER;
-    RUN_PASS(reducePredicateRegisterUsage);
+    //PASS_BARRIER;
+    //RUN_PASS(reducePredicateRegisterUsage);
   }
 
   auto unflattened = assoc_comm::unflatten(simplified, variables);


### PR DESCRIPTION
Hello, 

The PR https://github.com/csarofeen/pytorch/pull/2268 added an optimization pass `reducePredicateRegisterUsage`. 
It happens to negatively impact performance on A100, in matmuls for tile sizes 64x64x32 or 256x256x32.

Here are some impacted problems:
```
MNK(1024 1024 8192) layout(TT) stages(3) cta(64 64 32) warp(64 64 32) tile(16 8 16) prev: 0.184203 new: 0.228496 speedup -24.05 %
MNK(8192 8192 1024) layout(NT) stages(3) cta(256 256 32) warp(64 64 32) tile(16 8 16) prev: 8.618862 new: 10.260005 speedup -19.04 %
MNK(8192 8192 4096) layout(NT) stages(3) cta(256 256 32) warp(64 64 32) tile(16 8 16) prev: 34.333916 new: 40.569051 speedup -18.16 %
```

For the last problem, I attached two CUDA kernels that I got from the commit d6d258dfa325d6a359971285b50af647c84ba164 (tracking-matmul), with and without this pass. 
[Archive.zip](https://github.com/csarofeen/pytorch/files/10697046/Archive.zip)


