### PR TITLE
Moving predicate to cp.async and optional path for unaligned accesses

### DIFF
--- a/third_party/nvfuser/runtime/array.cu
+++ b/third_party/nvfuser/runtime/array.cu
@@ -100,10 +100,127 @@ __device__ void loadGenericVolatile(
   }
 }
 
+
+template<int size>
+__device__ inline void loadLocalToGlobalAlignedImpl(
+        char *__restrict to,
+        const char *__restrict from);
+
+template<>
+__device__ inline void loadLocalToGlobalAlignedImpl<1>(
+        char *__restrict to,
+        const char *__restrict from) {
+    asm("st.global.cs.u8 [%0], {%1};"::"l"(__builtin_assume_aligned(to, 1)), "r"((unsigned) *from) : "memory");
+}
+
+template<>
+__device__ inline void loadLocalToGlobalAlignedImpl<2>(
+        char *__restrict to,
+        const char *__restrict from) {
+    unsigned short const &data = *reinterpret_cast<const unsigned short *>(from);
+    asm("st.global.cs.u16 [%0], {%1};"::"l"(__builtin_assume_aligned(to, 1)), "r"((unsigned) data) : "memory");
+}
+
+template<>
+__device__ inline void loadLocalToGlobalAlignedImpl<4>(
+        char *__restrict to,
+        const char *__restrict from) {
+    unsigned const &data = *reinterpret_cast<const unsigned *>(from);
+    asm("st.global.cs.u32 [%0], {%1};"::"l"(reinterpret_cast<unsigned *>(__builtin_assume_aligned(to, 4))),
+    "r"(data)
+            : "memory");
+}
+
+template<>
+__device__ inline void loadLocalToGlobalAlignedImpl<8>(
+        char *__restrict to,
+        const char *__restrict from) {
+    uint2 const &data = *reinterpret_cast<const uint2 *>(from);
+    asm("st.global.cs.v2.u32 [%0], {%1,%2};"::"l"(reinterpret_cast<uint2 *>(__builtin_assume_aligned(to, 8))),
+    "r"(data.x),
+    "r"(data.y)
+            : "memory");
+}
+
+template<>
+__device__ inline void loadLocalToGlobalAlignedImpl<16>(
+        char *__restrict to,
+        const char *__restrict from) {
+    uint4 const &data = *reinterpret_cast<const uint4 *>(from);
+    asm("st.global.cs.v4.u32 [%0], {%1,%2,%3,%4};"::"l"(
+    reinterpret_cast<uint4 *>(__builtin_assume_aligned(to, 16))),
+    "r"(data.x),
+    "r"(data.y),
+    "r"(data.z),
+    "r"(data.w)
+            : "memory");
+}
+
+
+constexpr static inline __device__ bool is_power_two(unsigned v, int result = 1) {
+    if (v == 0) return false;
+    if (v == result) return true;
+    else if (result < v) return is_power_two(v, result * 2);
+    else return false;
+}
+
+
+constexpr static inline __device__ unsigned prev_or_equal_power_two(unsigned v, unsigned result = 1) {
+    if (v == 0) return 0;
+    if (result <= v && 2 * result > v) return result;
+    else return prev_or_equal_power_two(v, result * 2);
+}
+
+/**
+ * 
+ * @tparam T 
+ * @tparam count 
+ * @param to 
+ * @param from 
+ */
+template<typename T, int count>
+__device__ inline void loadLocalToGlobalUnaligned(
+        T *__restrict to,
+        const T *__restrict from) {
+
+    if constexpr (count == 0) return;
+    static_assert(is_power_two(sizeof(T)));
+    constexpr unsigned byte_size = sizeof(T) * count;
+    constexpr unsigned min_alignment = sizeof(T) < 16 ? sizeof(T) : 16;
+    constexpr unsigned upper_alignment = prev_or_equal_power_two(byte_size) < 16 ? prev_or_equal_power_two(byte_size) : 16;
+    static_assert(byte_size % min_alignment == 0);
+
+    const auto ptr_low = static_cast<unsigned> (reinterpret_cast<size_t>(to) & 0xFFFFFFFF); //Should be std::intptr_t
+
+    if (ptr_low % upper_alignment == 0) {
+        char *__restrict dst = reinterpret_cast< char *>(__builtin_assume_aligned(to, upper_alignment));
+        const char *__restrict src = reinterpret_cast<const char *>(from);
+        unsigned i = 0;
+#pragma unroll
+        for (; i + upper_alignment <= byte_size; i += upper_alignment) {
+            loadLocalToGlobalAlignedImpl<upper_alignment>(dst + i, src + i);
+        }
+
+#pragma unroll
+        for (; i < byte_size; i += min_alignment) {
+            loadLocalToGlobalAlignedImpl<min_alignment>(dst + i, src + i);
+        }
+    } else {
+        char *__restrict dst = reinterpret_cast< char *>(__builtin_assume_aligned(to, min_alignment));
+        const char *__restrict src = reinterpret_cast<const char *>(from);
+#pragma unroll
+        for (unsigned i = 0; i < byte_size; i += min_alignment) {
+            loadLocalToGlobalAlignedImpl<min_alignment>(dst + i, src + i);
+        }
+    }
+}
+
 template <typename scalar_t, int vec_size, bool is_volatile>
 __device__ void loadLocalToGlobal(
     typename MaybeVolatile<scalar_t, is_volatile>::type* to,
     scalar_t* from) {
+  return loadLocalToGlobalUnaligned<scalar_t, vec_size>(to, from);
+
   switch (sizeof(scalar_t) * vec_size) {
     case 1:
     case 2:

--- a/third_party/nvfuser/runtime/memory.cu
+++ b/third_party/nvfuser/runtime/memory.cu
@@ -114,58 +114,128 @@ DEVICE_INLINE void ldMatrixT(Array<__half, 8, 8>& out, unsigned addr) {
 
 namespace Ampere {
 
+
 // MMA instruction wrappers (sm_80+):
+template<int count, typename word_type>
+__device__ __noinline__ static void cpGlobalToShared(
+        unsigned smem_addr,
+        const void *gmem_ptr,
+        bool predicate) {
+    constexpr int word_size = sizeof(word_type);
+    const auto *__restrict src = reinterpret_cast<const word_type *>(__builtin_assume_aligned(gmem_ptr, word_size));
+    auto *__restrict dst = reinterpret_cast<word_type *>(__builtin_assume_aligned(__cvta_shared_to_generic(smem_addr), word_size));
+    // these allow to generate ld.global.u8 and st.shared.u8 properly.
+    bool s = __isShared(dst);
+    __builtin_assume(s);
+    bool g = __isGlobal(src);
+    __builtin_assume(g);
 
-// Global to SMEM load that is asynchronous,
-// not guaranteed to be completed until cpAsyncBarrier() is called.
-// if predicate is set to false, then gmem_ptr won't be read and smem_addr will be zero-initialized
-// gmem_ptr must be `sizeof(dtype) * len` aligned
-template <typename dtype, int len>
+#pragma unroll
+    for (int i = 0; i < count; ++i) {
+        dst[i] = predicate ? src[i] : word_type{0};
+    }
+}
+
+template<int byte_size>
+DEVICE_INLINE void cpAsyncCaAligned(
+        unsigned smem_addr,
+        const void *gmem_ptr,
+        bool predicate) {
+    static_assert(byte_size == 4 || byte_size == 8 || byte_size == 16, "cp_async : unsupported byte size");
+    asm volatile(
+            "{\n"
+            "  .reg .pred p;\n"
+            "  setp.eq.b32 p, %3, 0;\n"
+            "cp.async.ca.shared.global [%0], [%1], %2, p;\n"
+            "}\n"::"r"(smem_addr),
+    "l"(__builtin_assume_aligned(gmem_ptr, byte_size)),
+    "n"(byte_size),
+    "r"((int) predicate));
+}
+
+/**
+ * Async load from gmem to smem. 
+ * @tparam T elt type
+ * @tparam count elt count
+ * @tparam assume_aligned_data Assumes that gmem is aligned on sizeof(T) * count
+ * @param smem_addr 
+ * @param gmem_ptr must be at least aligned on sizeof(T)
+ * @param predicate if predicate is false, zeroes are written to smem and gmem is not accessed
+ */
+template<typename T, int count, bool assume_aligned_data = true>
 DEVICE_INLINE void cpAsyncCa(
-    unsigned smem_addr,
-    void const* gmem_ptr,
-    bool predicate) {
-  constexpr int byte_size = sizeof(dtype) * len;
+        unsigned smem_addr,
+        const void *gmem_ptr,
+        bool predicate) {
 
-  static_assert(
-      byte_size == 4 || byte_size == 8 || byte_size == 16,
-      "cp_async : unsupported byte size");
+    constexpr unsigned byte_size = sizeof(T) * count;
+    static_assert(byte_size == 4 || byte_size == 8 || byte_size == 16, "cp_async : unsupported byte size");
 
-  asm volatile(
-      "{\n"
-      "  .reg .pred p;\n"
-      "  setp.eq.b32 p, %3, 0;\n"
-      "  cp.async.ca.shared.global [%0], [%1], %2, p;\n"
-      "}\n" ::"r"(smem_addr),
-      "l"(gmem_ptr),
-      "n"(byte_size),
-      "r"((int)predicate));
+    if constexpr (assume_aligned_data || sizeof(T) == byte_size) {
+        const char *__restrict src = reinterpret_cast< const char *>(__builtin_assume_aligned(gmem_ptr, byte_size));
+        cpAsyncCaAligned<byte_size>(smem_addr, src, predicate);
+    } else {
+        const auto ptr_low = static_cast<unsigned> (reinterpret_cast<size_t>(gmem_ptr) & 0xFFFFFFFF); //Should be std::intptr_t
+        if (ptr_low % byte_size == 0) {
+            const char *__restrict src = reinterpret_cast< const char *>(__builtin_assume_aligned(gmem_ptr, byte_size));
+            cpAsyncCaAligned<byte_size>(smem_addr, src, predicate);
+        } else { // Unaligned case, fallback on min_alignment
+            constexpr unsigned min_alignment = sizeof(T); // min alignment guaranteed for the type
+            static_assert(byte_size % min_alignment == 0);
+            if constexpr (min_alignment == 1) {
+                const char *__restrict src = reinterpret_cast< const char *>(__builtin_assume_aligned(gmem_ptr, 1));
+                cpGlobalToShared<byte_size, unsigned char>(smem_addr, src, predicate);
+            } else if constexpr (min_alignment == 2) {
+                const char *__restrict src = reinterpret_cast< const char *>(__builtin_assume_aligned(gmem_ptr, 2));
+                cpGlobalToShared<byte_size / 2, unsigned short>(smem_addr, src, predicate);
+            } else {
+                const char *__restrict src = reinterpret_cast< const char *>(__builtin_assume_aligned(gmem_ptr, min_alignment));
+#pragma unroll
+                for (unsigned i = 0; i < byte_size; i += min_alignment) {
+                    cpAsyncCaAligned<min_alignment>(smem_addr + i, src + i, predicate);
+                }
+            }
+        }
+    }
+}
+
+
+DEVICE_INLINE void cpAsyncCgAligned(
+        unsigned smem_addr,
+        void const *__restrict gmem_ptr,
+        bool predicate) {
+    asm volatile(
+            "{\n"
+            "  .reg .pred p;\n"
+            "  setp.eq.b32 p, %2, 0;\n"
+            "cp.async.cg.shared.global [%0], [%1], 16, p;\n"
+            "}\n"::"r"(smem_addr),
+    "l"(__builtin_assume_aligned(gmem_ptr, 16)),
+    "r"((int) predicate));
 }
 
 // Global to SMEM load that is asynchronous,
-//  The cache global variant, i.e. skip L1 caching.
-// more details see:
-// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#cache-operators
 // not guaranteed to be completed until cpAsyncBarrier() is called.
-// if predicate is set to false, then gmem_ptr won't be read and smem_addr will be zero-initialized
-// gmem_ptr must be 16B aligned
-template <typename dtype, int len>
+template<typename T, int len, bool assume_aligned_data = false>
 DEVICE_INLINE void cpAsyncCg(
-    unsigned smem_addr,
-    void const* gmem_ptr,
-    bool predicate) {
-  constexpr int byte_size = sizeof(dtype) * len;
+        unsigned smem_addr,
+        const void *gmem_ptr,
+        bool predicate) {
+    constexpr int byte_size = sizeof(T) * len;
+    static_assert(byte_size == 16, "cp_async : unsupported byte size");
 
-  static_assert(byte_size == 16, "cp_async : unsupported byte size");
-
-  asm volatile(
-      "{\n"
-      "  .reg .pred p;\n"
-      "  setp.eq.b32 p, %2, 0;\n"
-      "  cp.async.cg.shared.global [%0], [%1], 16, p;\n"
-      "}\n" ::"r"(smem_addr),
-      "l"(gmem_ptr),
-      "r"((int)predicate));
+    if constexpr (assume_aligned_data || sizeof(T) == 16) {
+        cpAsyncCgAligned(smem_addr, gmem_ptr, predicate);
+    } else {
+        const auto ptr_low = static_cast<unsigned> (reinterpret_cast<size_t>(gmem_ptr) & 0xFFFFFFFF); //Should be std::intptr_t
+        unsigned misalignment = ptr_low % byte_size;
+        __builtin_assume(misalignment < byte_size);
+        if (misalignment == 0) {
+            cpAsyncCgAligned(smem_addr, gmem_ptr, predicate);
+        } else {
+            cpAsyncCa<T, len, assume_aligned_data>(smem_addr, gmem_ptr, predicate);
+        }
+    }
 }
 
 // TODO: Might have a different category of sync if we want to build out this:


### PR DESCRIPTION
## Predicate 
- Moving the predicate `p` to `cp.async.` args seems to increase performance. I'm running more tests. 


## Misaligned Accesses 
- `cp.async.cg` works only on 16 byte sizes and 16 byte aligned data. `cp.async.ca` work only on 4, 8, and 16 byte sizes with same matching alignments 
- When `assume_aligned_data` is `false`, we generate another codepath that allows to process unaligned data. This is disabled by default as this gets inlined in the innermost loops, bloats the SASS and has a perf impact (10% in some tests) when the code unaligned path is not required. 
- Maybe we could move the alignment checks to the epilogue and generate several MMAs loops depending on alignment? Or check sizes+padding at runtime and generate a kernel for the specific alignment?
- We could handle any unaligned case, including align 1 and 2 with a single `cp.async.ca` instructions, but it would require a lot of changes outside of these functions 


