### PR TITLE
Drop contiguity info for size 1 dimensions for Python's define_tensor(sizes=..., strides=...)

### DIFF
--- a/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
+++ b/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
@@ -25,7 +25,7 @@ std::vector<bool> computeContiguity(
   TORCH_CHECK(
       sizes.size() == strides.size(),
       "compute_contiguity: Sizes and strides must have the same number of dimensions");
-  auto not_broadcast = [&](auto i) { return strides[i] != 0 && sizes[i] != 1; };
+  auto not_broadcast = [&](auto i) { return (sizes[i] != 1) || (strides[i] != 0 && sizes[i] != 1); };
   auto irange = c10::irange(sizes.size());
   auto no_b_size = std::count_if(irange.begin(), irange.end(), not_broadcast);
   std::vector<bool> contiguity(no_b_size);
@@ -291,7 +291,6 @@ void initNvFuserPythonBindings(PyObject* module) {
             // identified by -1, and size == 0 is not supported.
 
             // Translate to TensorViewBuilder's view of the world.
-            std::vector<bool> contiguity = computeContiguity(sizes, strides);
             std::vector<int64_t> maybe_symbolic_sizes;
             maybe_symbolic_sizes.reserve(sizes.size());
             for (const auto i : c10::irange(sizes.size())) {
@@ -302,7 +301,6 @@ void initNvFuserPythonBindings(PyObject* module) {
                   " is not supported in nvFuser. Expected size > 0.");
               if (sizes[i] == 1) {
                 maybe_symbolic_sizes.push_back(1);
-                contiguity.erase(contiguity.begin() + i);
               } else {
                 maybe_symbolic_sizes.push_back(-1);
               }
@@ -312,7 +310,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             self.defineRecord(new TensorRecord(
                 {self.recordingState(out())},
                 std::move(maybe_symbolic_sizes),
-                std::move(contiguity),
+                computeContiguity(sizes, strides),
                 dtype,
                 is_cpu));
 

--- a/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
+++ b/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
@@ -291,6 +291,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             // identified by -1, and size == 0 is not supported.
 
             // Translate to TensorViewBuilder's view of the world.
+            std::vector<bool> contiguity = computeContiguity(sizes, strides);
             std::vector<int64_t> maybe_symbolic_sizes;
             maybe_symbolic_sizes.reserve(sizes.size());
             for (const auto i : c10::irange(sizes.size())) {
@@ -301,6 +302,7 @@ void initNvFuserPythonBindings(PyObject* module) {
                   " is not supported in nvFuser. Expected size > 0.");
               if (sizes[i] == 1) {
                 maybe_symbolic_sizes.push_back(1);
+                contiguity.erase(contiguity.begin() + i);
               } else {
                 maybe_symbolic_sizes.push_back(-1);
               }
@@ -310,7 +312,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             self.defineRecord(new TensorRecord(
                 {self.recordingState(out())},
                 std::move(maybe_symbolic_sizes),
-                computeContiguity(sizes, strides),
+                std::move(contiguity),
                 dtype,
                 is_cpu));
 

--- a/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
+++ b/third_party/nvfuser/csrc/python_frontend/python_bindings.cpp
@@ -25,7 +25,9 @@ std::vector<bool> computeContiguity(
   TORCH_CHECK(
       sizes.size() == strides.size(),
       "compute_contiguity: Sizes and strides must have the same number of dimensions");
-  auto not_broadcast = [&](auto i) { return (sizes[i] != 1) || (strides[i] != 0 && sizes[i] != 1); };
+  auto not_broadcast = [&](auto i) {
+    return (sizes[i] != 1) || (strides[i] != 0 && sizes[i] != 1);
+  };
   auto irange = c10::irange(sizes.size());
   auto no_b_size = std::count_if(irange.begin(), irange.end(), not_broadcast);
   std::vector<bool> contiguity(no_b_size);

--- a/third_party/nvfuser/python_tests/test_python_frontend.py
+++ b/third_party/nvfuser/python_tests/test_python_frontend.py
@@ -1115,7 +1115,7 @@ class TestNvFuserFrontend(TestCase):
 
         self.assertEqual(at_rfloat, rfloat)
         self.assertEqual(at_rdouble, rdouble)
-        
+
     def test_reduction_complex_number(self) :
         def test_dtype(torch_dtype):
             inputs = [torch.randn(2, 32, device='cuda', dtype=torch_dtype)]
@@ -1330,6 +1330,23 @@ class TestNvFuserFrontend(TestCase):
         strides = [800, 300, 300, 456456465465, 0, 60, 10]
         contiguity = [False, True, True, False]
         self.assertEqual(compute_contiguity(sizes, strides), contiguity)
+
+    def test_fix_2549(self):
+        a = torch.ones(4, 1, dtype=torch.double, device='cuda')
+        b = torch.ones(4, 4, dtype=torch.double, device='cuda')
+
+        def nvfuser_fusion_id(fd : FusionDefinition) -> None :
+            T0 = fd.define_tensor(sizes=a.shape, strides=a.stride(), dtype=DataType.Double, is_cpu=False)
+            T1 = fd.define_tensor(sizes=b.shape, strides=b.stride(), dtype=DataType.Double, is_cpu=False)
+            T2 = fd.ops.broadcast_in_dim(T0, output_shape=[4, 4], broadcast_dims=[0, 1])
+            T3 = fd.ops.div(T1, T2)
+            fd.add_output(T3)
+
+        with FusionDefinition() as fd:
+            nvfuser_fusion_id(fd)
+
+        out = fd.execute([a, b])
+        self.assertEqual(out[0], b / a)
 
     def test_prod(self) :
         inputs = [


### PR DESCRIPTION
Fixes https://github.com/csarofeen/pytorch/issues/2549.